### PR TITLE
Add json-schema (PHP) to list of who uses the test suite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This suite is being used by:
   * [jsonschema (javascript)](https://github.com/tdegrunt/jsonschema)
   * [JaySchema (javascript)](https://github.com/natesilva/jayschema)
   * [jesse (Erlang)](https://github.com/klarna/jesse)
+  * [json-schema (PHP)](https://github.com/justinrainbow/json-schema)
 
 If you use it as well, please fork and send a pull request adding yourself to
 the list :).


### PR DESCRIPTION
I added [json-schema (PHP)](https://github.com/justinrainbow/json-schema) to the list of who uses this test suite in the README.md file. I thought that adding a composer.json file would help PHP projects include this project as a repository dependency for Composer to resolve, but I later found out that it wasn't necessary so I deleted it. Please ignore the two commits that add and then delete composer.json. Thanks!
