### PR TITLE
add 'forbidden property' test (not with blank schema)

### DIFF
--- a/tests/draft4/not.json
+++ b/tests/draft4/not.json
@@ -69,5 +69,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
     }
+
 ]


### PR DESCRIPTION
As discussed in the [json schema google group](https://groups.google.com/forum/#!topic/json-schema/upaYd1Sq_ds). I wouldn't imagine validators would have trouble with this one, but it does seem like a useful edge case to cover.
