### PR TITLE
Add string length tests for supplementary Unicode code points

### DIFF
--- a/tests/draft3/maxLength.json
+++ b/tests/draft3/maxLength.json
@@ -22,6 +22,11 @@
                 "description": "ignores non-strings",
                 "data": 10,
                 "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points (here, U+1F4A9) is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
             }
         ]
     }

--- a/tests/draft3/minLength.json
+++ b/tests/draft3/minLength.json
@@ -22,6 +22,11 @@
                 "description": "ignores non-strings",
                 "data": 1,
                 "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point (here, U+1F4A9) is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/maxLength.json
+++ b/tests/draft4/maxLength.json
@@ -22,6 +22,11 @@
                 "description": "ignores non-strings",
                 "data": 10,
                 "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points (here, U+1F4A9) is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/minLength.json
+++ b/tests/draft4/minLength.json
@@ -22,6 +22,11 @@
                 "description": "ignores non-strings",
                 "data": 1,
                 "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point (here, U+1F4A9) is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
That is, code points outside the Basic Multilingual Plane (U+0000 to U+FFFF).

This will test that validators correctly account for the number of _code points_
inside strings, as required by RFC 7159, section 1:

   A string is a sequence of zero or more Unicode characters [UNICODE].
   Note that this citation references the latest version of Unicode
   rather than a specific release.  It is not expected that future
   changes in the UNICODE specification will impact the syntax of JSON.

In order to keep it "easy" for storage, the UTF-16 escape sequence (as defined
by RFC 7159, section 7) is used to represent these characters. The chosen code
point is U+1F4A9 (yes, Unicode defines that):

http://www.fileformat.info/info/unicode/char/1F4A9/index.htm
