### PR TITLE
[Issue 62] Test change of scope during ref resolution

### DIFF
--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -77,7 +77,10 @@
             "definitions": {
                 "schema1": {
                     "id": "http://localhost:1234/subSchemas.json",
-                    "a": {"$ref": "#/integer"}
+                    "a": {"$ref": "#/integer"},
+                    "integer": {
+                        "type": "integer"
+                    }
                 }
             },
             "integer": {

--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -70,5 +70,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Change of scope during ref resolution",
+        "schema": {
+            "definitions": {
+                "id": "http://localhost:1234/subSchemas.json",
+                "a": {"$ref": "#/integer"}
+            },
+            "integer": {
+                "type": "string"
+            },
+            "$ref": "#/definitions/a"
+        },
+        "tests": [
+            {
+                "description": "Integer valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "String invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -75,13 +75,15 @@
         "description": "Change of scope during ref resolution",
         "schema": {
             "definitions": {
-                "id": "http://localhost:1234/subSchemas.json",
-                "a": {"$ref": "#/integer"}
+                "schema1": {
+                    "id": "http://localhost:1234/subSchemas.json",
+                    "a": {"$ref": "#/integer"}
+                }
             },
             "integer": {
                 "type": "string"
             },
-            "$ref": "#/definitions/a"
+            "$ref": "#/definitions/schema1/a"
         },
         "tests": [
             {


### PR DESCRIPTION
The closest parent "id" must be used to resolve refs.
