### PR TITLE
Made sure the data for ip formats are strings, not floats

### DIFF
--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -78,7 +78,7 @@
             },
             {
                 "description": "an IP address without 4 components",
-                "data": "127.0",
+                "data": "127.0.0",
                 "valid": false
             },
             {


### PR DESCRIPTION
In the tests for the ip format, all of the data values should be strings (because the format attribute is only for string values). However, one of the data values is a float, not a string: "127.0" (there's no way for a json parser to know that this is a string, and not a float, so most parsers I've tried load this value as a float).

I've corrected the data for this test so that it has an extra decimal point. This should make it unambiguous and all json parsers should load it as a string.
