### PR TITLE
moved remote $ref test

### DIFF
--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -139,21 +139,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "remote ref, containing refs itself",
-        "schema": {"$ref": "http://json-schema.org/draft-03/schema#"},
-        "tests": [
-            {
-                "description": "remote ref valid",
-                "data": {"items": {"type": "integer"}},
-                "valid": true
-            },
-            {
-                "description": "remote ref invalid",
-                "data": {"items": {"type": 1}},
-                "valid": false
-            }
-        ]
     }
 ]

--- a/tests/draft3/refRemote.json
+++ b/tests/draft3/refRemote.json
@@ -1,5 +1,21 @@
 [
     {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-03/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"items": {"type": "integer"}},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"items": {"type": 1}},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "remote ref",
         "schema": {"$ref": "http://localhost:1234/integer.json"},
         "tests": [


### PR DESCRIPTION
I implemented local $refs for jesse, and I would like to use the local ref test file, without having to implement the support for remote refs.
