### PR TITLE
Test required ignores non objects

### DIFF
--- a/tests/draft4/required.json
+++ b/tests/draft4/required.json
@@ -18,6 +18,11 @@
                 "description": "non-present required property is invalid",
                 "data": {"bar": 1},
                 "valid": false
+            },
+            {
+                "description": "ignores non-objects",
+                "data": 12,
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
This PR adds a test to make sure non objects are ignored by required like the rest of the object constraints.