### PR TITLE
Test change resolution scope with absolute reference

### DIFF
--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -70,5 +70,27 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "change resolution scope with absolute reference",
+        "schema": {
+            "id": "http://localhost:1234/",
+            "items": {
+                "id": "http://localhost:1234/folder/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "changed scope ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "changed scope ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Hello,

This PR adds a test for a scenario outlined in [7.2.2](http://json-schema.org/latest/json-schema-core.html#anchor29) of the specification.

``` json

{
    "id": "http://x.y.z/rootschema.json#",
    "schema1": {
        "id": "#foo"
    },
    "schema2": {
        "id": "otherschema.json",
        "nested": {
            "id": "#bar"
        },
        "alsonested": {
            "id": "t/inner.json#a"
        }
    },
    "schema3": {
        "id": "some://where.else/completely#"
    }
}
```

> Subschemas at the following URI-encoded JSON Pointer [json‑pointer]s (starting from the root schema) define the following resolution scopes:

```
#/schema3
some://where.else/completely#
```

With the current test suite, it's possible to write a validator that does not check if the reference is absolute and always appends.  This test should ensure that you try to resolve:

```
http://localhost:1234/folder/folderInteger.json
```

...instead of :

```
http://localhost:1234/http://localhost:1234/folder/folderInteger.json
```
