### PR TITLE
Test relative reference resolution when ID is not present

### DIFF
--- a/remotes/subSchemas.json
+++ b/remotes/subSchemas.json
@@ -1,8 +1,11 @@
 {
     "integer": {
         "type": "integer"
-    }, 
+    },
     "refToInteger": {
         "$ref": "#/integer"
+    },
+    "relativeRefToInteger": {
+        "$ref": "integer.json"
     }
 }

--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -50,6 +50,24 @@
         ]
     },
     {
+        "description": "relative remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/relativeRefToInteger"
+        },
+        "tests": [
+            {
+                "description": "relative ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "relative ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "change resolution scope",
         "schema": {
             "id": "http://localhost:1234/",


### PR DESCRIPTION
This PR adds a test to ensure that relative references are resolved against the URI of the current schema, as outlined in section [7.1](http://json-schema.org/latest/json-schema-core.html#anchor26) of the specification and section 4 of the [JSON Reference specification](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03).

> The initial resolution scope of a schema is the URI of the schema itself, if any, or the empty URI if the schema was not loaded from a URI.
> 
> If the URI contained in the JSON Reference value is a relative URI,
>    then the base URI resolution MUST be calculated according to
>    [RFC3986], section 5.2.  Resolution is performed relative to the
>    referring document.

We currently have the "change resolution scope" test which uses a relative reference, but because the schema has an ID it does not prove that an implementation uses the current schema's URI as the initial resolution scope.
