### PR TITLE
Add test for properties named $ref

### DIFF
--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -155,5 +155,25 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The JSON Reference spec states:

> A JSON Reference is a JSON object, which contains a member named
   "$ref", which has a JSON string value.  Example:

>  { "$ref": "http://example.com/example.json#/foo/bar" }

  > If a JSON value does not have these characteristics, then it SHOULD
   NOT be interpreted as a JSON Reference.

[The swagger schema](https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v2.0/schema.json) declares a property named `$ref` that is not actually a reference, like this:

```json
"properties": {
        "$ref": {
          "type": "string"
        }
      }
```

Since the value is not a string, it's not considered a reference and should not be dereferenced.

This test ensures that a validator will not attempt to dereference a property named `$ref` when the value is not a string.