### PR TITLE
Added tests for items when data contains more or less types than the schema

### DIFF
--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -40,6 +40,21 @@
                 "description": "wrong types",
                 "data": [ "foo", 1 ],
                 "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
What happens if you specify items as an array of types, but you don't include a value for every type? Right now we have no tests for that. We also don't have a test for when there are more values than defined item types.

I've assumed that if the data has fewer values than there are types in the schema, we validate the values that we have. If there are more values than types, we don't validate values that we haven't got schema items for. This might be wrong, but I'd like to open up the discussion (the RFC isn't very clear on how array items should be validated)
