### PR TITLE
Added test cases from Foundations of JSON Schema research paper

### DIFF
--- a/tests/draft-next/dependentSchemas.json
+++ b/tests/draft-next/dependentSchemas.json
@@ -128,5 +128,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft-next/uniqueItems.json
+++ b/tests/draft-next/uniqueItems.json
@@ -57,6 +57,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},

--- a/tests/draft2019-09/dependentSchemas.json
+++ b/tests/draft2019-09/dependentSchemas.json
@@ -128,5 +128,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -57,6 +57,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},

--- a/tests/draft2020-12/dependentSchemas.json
+++ b/tests/draft2020-12/dependentSchemas.json
@@ -128,5 +128,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/uniqueItems.json
+++ b/tests/draft2020-12/uniqueItems.json
@@ -57,6 +57,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},

--- a/tests/draft4/dependencies.json
+++ b/tests/draft4/dependencies.json
@@ -190,5 +190,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependencies": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -54,6 +54,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},

--- a/tests/draft6/dependencies.json
+++ b/tests/draft6/dependencies.json
@@ -244,5 +244,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependencies": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -54,6 +54,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},

--- a/tests/draft7/dependencies.json
+++ b/tests/draft7/dependencies.json
@@ -244,5 +244,43 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "dependent subschema incompatible with root",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "dependencies": {
+                "foo": {
+                    "properties": {
+                        "bar": {}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches root",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "matches dependency",
+                "data": {"bar": 1},
+                "valid": true
+            },
+            {
+                "description": "matches both",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "no dependency",
+                "data": {"baz": 1},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -54,6 +54,11 @@
                 "valid": false
             },
             {
+                "description": "property order of array of objects is ignored",
+                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "valid": false
+            },
+            {
                 "description": "unique array of nested objects is valid",
                 "data": [
                     {"foo": {"bar" : {"baz" : true}}},


### PR DESCRIPTION
In the 25th internationl world wide web conference there was a paper
 named "Foundations of JSON Schema", presented by:
- Felipe Pezoa (fipezoa@uc.cl)
- Juan L. Reutter (jreutter@ing.puc.cl)
- Fernando Suarez (fsuarez1@ing.puc.cl)
- Martín Ugarte (martin.ugarte@ulb.ac.be)
- Domagoj Vrgo (dvrgoc@ing.puc.cl)

See:

http://www2016.net/proceedings/proceedings/p263.pdf

This paper compared a number of json schema implementations, using a set
of 5 tests which highlighted inconsistencies between the
implementations. I have reproduced those tests here. All credit should
go to the authors of the paper for highlighting these inconsistencies
and publishing the details of them online.
