### PR TITLE
Made sure all $ref objects contain only a $ref property

### DIFF
--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -125,17 +125,21 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/c"
+                }
+            }
         },
         "tests": [
             {
                 "description": "nested ref valid",
-                "data": 5,
+                "data": {"foo": 5},
                 "valid": true
             },
             {
                 "description": "nested ref invalid",
-                "data": "a",
+                "data": {"foo": "a"},
                 "valid": false
             }
         ]

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -125,17 +125,21 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/c"
+                }
+            }
         },
         "tests": [
             {
                 "description": "nested ref valid",
-                "data": 5,
+                "data": {"foo": 5},
                 "valid": true
             },
             {
                 "description": "nested ref invalid",
-                "data": "a",
+                "data": {"foo": "a"},
                 "valid": false
             }
         ]


### PR DESCRIPTION
The IETF JSON Reference spec, section 3 (syntax) says the following:

```
Any members other than "$ref" in a JSON Reference object SHALL be
ignored.
```

We have two groups of tests that have a $ref at the root level of the
schema, referring to a definition that is also at the root
level. According to the spec, a $ref object should not have any sibling
properties.

To make those JSON references valid, I've refactored those test cases to
use a $ref object as a json schema property definition instead, which
is valid.
