### PR TITLE
Add optional check for non-ECMA 262 regular expressions

### DIFF
--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "ECMA 262 regex non-compliance",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "ECMA 262 has no support for \\Z anchor from .NET",
+                "data": "^\\S(|(.|\\n)*\\S)\\Z",
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
See #119.
The `.NET` documentation is [here](https://msdn.microsoft.com/en-us/library/az24scfc(v=vs.110).aspx#atomic_zerowidth_assertions)