### PR TITLE
Add test-case for default. default should obviate require

### DIFF
--- a/tests/draft3/default.json
+++ b/tests/draft3/default.json
@@ -45,5 +45,23 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "default value obviates require",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "default": "something"
+                }
+            },
+            "required": [ "bar" ]
+        },
+        "tests": [
+            {
+                "description": "valid with missing property",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/default.json
+++ b/tests/draft4/default.json
@@ -45,5 +45,23 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "default value obviates require",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "default": "something"
+                }
+            },
+            "required": [ "bar" ]
+        },
+        "tests": [
+            {
+                "description": "valid with missing property",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The tests for `default` are incorrect.

The specification [Section 6.2](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2) states:

> There are no restrictions placed on the value of this keyword.
> This keyword can be used to supply a default JSON value associated with a particular schema. It is RECOMMENDED that a default value be valid against the associated schema.
> This keyword MAY be used in root schemas, and in any subschemas.

While this means that are no limits on the value of `default`, the presence of this keyword has other implications. One of them is the fulfilment of the `required` keyword.

If the schema as presented in this pull-request is not valid, then there is no purpose for the `default`. Whether this is implemented by modifying the original document (which would go against the intent of pure validation) or by simply modifying the validation can be up to the implementation. However this schema as presented should be valid by any compliant implementation