### PR TITLE
"items" with an object value is always valid

### DIFF
--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -11,9 +11,9 @@
                 "valid": true
             },
             {
-                "description": "wrong type of items",
+                "description": "wrong type of items is valid",
                 "data": [1, "x"],
-                "valid": false
+                "valid": true
             },
             {
                 "description": "ignores non-arrays",


### PR DESCRIPTION
## What
Allow the `"type"` test for an array item to pass, even though the type is incorrect.

## Why
The draft-04 spec [says](https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.1.2) (also [draft-05](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.9)):

> if "items" is not present, **or its value is an object**, validation of the instance always succeeds, regardless of the value of "additionalItems";

The draft-04 testsuite [contradicts this](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/master/tests/draft4/items.json#L16), and expects a failure for an invalid type, even though the value of `"items"` [is an object](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/master/tests/draft4/items.json#L5).