### PR TITLE
Update erlang URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This suite is being used by:
 
 ### Erlang ###
 
-* [jesse](https://github.com/klarna/jesse)
+* [jesse](https://github.com/for-GET/jesse)
 
 ### Go ###
 


### PR DESCRIPTION
Per https://github.com/klarna/jesse:

> This repository is no longer actively maintained, please see https://github.com/for-GET/jesse