### PR TITLE
Add name.json to the CLI tool's remotes.

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -38,17 +38,24 @@ else:
     )
 
 
-ROOT_DIR = os.path.join(
-    os.path.dirname(__file__), os.pardir).rstrip("__pycache__")
+ROOT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir).rstrip("__pycache__"),
+)
 SUITE_ROOT_DIR = os.path.join(ROOT_DIR, "tests")
 
 REMOTES = {
-    "integer.json": {"type": "integer"},
-    "subSchemas.json": {
-        "integer": {"type": "integer"},
-        "refToInteger": {"$ref": "#/integer"},
+    "integer.json": {u"type": u"integer"},
+    "name.json": {
+        u"type": "string",
+        u"definitions": {
+            u"orNull": {u"anyOf": [{u"type": u"null"}, {u"$ref": u"#"}]},
+        },
     },
-    "folder/folderInteger.json": {"type": "integer"}
+    "subSchemas.json": {
+        u"integer": {u"type": u"integer"},
+        u"refToInteger": {u"$ref": u"#/integer"},
+    },
+    "folder/folderInteger.json": {u"type": u"integer"}
 }
 REMOTES_DIR = os.path.join(ROOT_DIR, "remotes")
 
@@ -139,10 +146,19 @@ class SanityTests(unittest.TestCase):
                 self.fail(str(error))
 
     def test_remote_schemas_are_updated(self):
-        for url, schema in REMOTES.items():
-            filepath = os.path.join(REMOTES_DIR, url)
-            with open(filepath) as schema_file:
-                self.assertEqual(json.load(schema_file), schema)
+        files = {}
+        for parent, _, paths in os.walk(REMOTES_DIR):
+            for path in paths:
+                absolute_path = os.path.join(parent, path)
+                with open(absolute_path) as schema_file:
+                    files[absolute_path] = json.load(schema_file)
+
+        self.assertEqual(
+            files, {
+                os.path.join(REMOTES_DIR, path): contents
+                for path, contents in REMOTES.iteritems()
+            },
+        )
 
 
 def main(arguments):


### PR DESCRIPTION
Also fix the test that was trying to ensure that this wouldn't happen
(it was only checking that no new ones were added in-line that didn't
live on the filesystem, so now check in both directions).

Right now, remotes are maintained in both of these places, which is a
bit non-ideal, but that's the status quo. The right actual fix here is
probably to remove the in-memory schemas and serve off the filesystem
for the `remotes` command (and use shutil.copytree for dumping).

Given that this was broken and no one complained, I assume people must be directly poking at the `remotes` directory in order to serve up schemas, rather than using the CLI tool, which is kind of unintended, but I suppose not the worst thing in the world.