### PR TITLE
Flesh out some more ignore cases for object validators.

### DIFF
--- a/tests/draft3/additionalProperties.json
+++ b/tests/draft3/additionalProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             },
             {

--- a/tests/draft3/dependencies.json
+++ b/tests/draft3/dependencies.json
@@ -26,8 +26,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
-                "data": "foo",
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft3/patternProperties.json
+++ b/tests/draft3/patternProperties.json
@@ -29,7 +29,12 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
             }

--- a/tests/draft3/properties.json
+++ b/tests/draft3/properties.json
@@ -29,8 +29,13 @@
                 "valid": true
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft4/additionalProperties.json
+++ b/tests/draft4/additionalProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             },
             {

--- a/tests/draft4/dependencies.json
+++ b/tests/draft4/dependencies.json
@@ -26,8 +26,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
-                "data": "foo",
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft4/maxProperties.json
+++ b/tests/draft4/maxProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
                 "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft4/minProperties.json
+++ b/tests/draft4/minProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
                 "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft4/patternProperties.json
+++ b/tests/draft4/patternProperties.json
@@ -29,7 +29,17 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
             }

--- a/tests/draft4/properties.json
+++ b/tests/draft4/properties.json
@@ -29,8 +29,13 @@
                 "valid": true
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft4/required.json
+++ b/tests/draft4/required.json
@@ -20,7 +20,17 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
             }

--- a/tests/draft6/additionalProperties.json
+++ b/tests/draft6/additionalProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             },
             {

--- a/tests/draft6/dependencies.json
+++ b/tests/draft6/dependencies.json
@@ -26,8 +26,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
-                "data": "foo",
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft6/maxProperties.json
+++ b/tests/draft6/maxProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
                 "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft6/minProperties.json
+++ b/tests/draft6/minProperties.json
@@ -19,8 +19,18 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
                 "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft6/patternProperties.json
+++ b/tests/draft6/patternProperties.json
@@ -29,7 +29,17 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
             }

--- a/tests/draft6/properties.json
+++ b/tests/draft6/properties.json
@@ -29,8 +29,13 @@
                 "valid": true
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
                 "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft6/propertyNames.json
+++ b/tests/draft6/propertyNames.json
@@ -27,8 +27,18 @@
                 "valid": true
             },
             {
-                "description": "non-object is valid",
-                "data": [],
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
                 "valid": true
             }
         ]

--- a/tests/draft6/required.json
+++ b/tests/draft6/required.json
@@ -20,7 +20,17 @@
                 "valid": false
             },
             {
-                "description": "ignores non-objects",
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
             }


### PR DESCRIPTION
Some languages have sequence types covering hash maps,
arrays, and strings. Make sure those languages properly
notice to ignore these validators on non-objects.

Closes #187 

@epoberezkin if you have a second?