### PR TITLE
multipleOf - IEEE-754 floating point rounding error

### DIFF
--- a/tests/draft4/multipleOf.json
+++ b/tests/draft4/multipleOf.json
@@ -56,5 +56,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by 0.1 (IEEE-754 floating point rounding error)",
+        "schema": {"multipleOf": 0.1},
+        "tests": [
+            {
+                "description": "2.5 is multiple of 0.1",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "2.4 is multiple of 0.1",
+                "data": 2.4,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/multipleOf.json
+++ b/tests/draft6/multipleOf.json
@@ -56,5 +56,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by 0.1 (IEEE-754 floating point rounding error)",
+        "schema": {"multipleOf": 0.1},
+        "tests": [
+            {
+                "description": "2.5 is multiple of 0.1",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "2.4 is multiple of 0.1",
+                "data": 2.4,
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Add tests for multipleOf 0.1, to cover IEEE-754 floating point rounding error.
0.1 cannot be exactly represented in binary.
http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
This can cause JSON Schema implementations to assert that, e.g. 2.4 is not a multiple of 0.1.

For example, in a browser console, try evaluating `2.4 / 0.1` compared to `2.5 / 0.1`

Testing for multiples of 0.1 is a reasonable enough requirement, IMHO, for example validating user-entered percentages with this precision.

This PR breaks your tests too - sorry! You use Ajv, which has not fixed this issue. 