### PR TITLE
No other keywords allowed beside "$ref"

### DIFF
--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -125,7 +125,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{"$ref": "#/definitions/c"}]
         },
         "tests": [
             {

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -125,7 +125,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{"$ref": "#/definitions/c"}]
         },
         "tests": [
             {

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -125,7 +125,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{"$ref": "#/definitions/c"}]
         },
         "tests": [
             {
@@ -212,7 +212,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{"$ref": "#/definitions/bool"}],
             "definitions": {
                 "bool": true
             }
@@ -228,7 +228,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{"$ref": "#/definitions/bool"}],
             "definitions": {
                 "bool": false
             }


### PR DESCRIPTION
The spec for $ref, whether in its own JSON Reference spec
or as part of the JSON Schema Core spec, states that keywords
adjacent to "$ref" MUST be ignored.  Therefore these tests were
invalid, even though the intent was clear to most readers.

The correct way to combine "$ref"s is with "allOf".

This addresses #113.