### PR TITLE
feat: test draft-7 with Ajv

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,43 @@
 'use strict';
 
-var Ajv = require('ajv');
-var jsonSchemaTest = require('json-schema-test');
-var assert = require('assert');
+const Ajv = require('ajv');
+const jsonSchemaTest = require('json-schema-test');
+const assert = require('assert');
 
-var refs = {
+const refs = {
   'http://localhost:1234/integer.json': require('./remotes/integer.json'),
   'http://localhost:1234/subSchemas.json': require('./remotes/subSchemas.json'),
   'http://localhost:1234/folder/folderInteger.json': require('./remotes/folder/folderInteger.json'),
   'http://localhost:1234/name.json': require('./remotes/name.json')
 };
 
-runTest(4);
-runTest(6);
+const SKIP = {
+  4: ['optional/zeroTerminatedFloats'],
+  7: ['optional/content', 'optional/format']
+};
 
-function runTest(draft) {
-  var opts = {
+[4, 6, 7].forEach((draft) => {
+  let opts = {
     format: 'full',
-    formats: {'json-pointer': /^(?:\/(?:[^~\/]|~0|~1)*)*$/}
+    unknownFormats: ['iri', 'iri-reference', 'idn-hostname', 'idn-email']
   };
-  if (draft == 4) opts.meta = false;
-  var ajv = new Ajv(opts);
-  ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-  if (draft == 4) ajv._opts.defaultMeta = 'http://json-schema.org/draft-04/schema#';
-  for (var uri in refs) ajv.addSchema(refs[uri], uri);
+
+  let ajv;
+  if (draft == 7) {
+    ajv = new Ajv(opts);
+  } else {
+    opts.meta = false;
+    ajv = new Ajv(opts);
+    ajv.addMetaSchema(require(`ajv/lib/refs/json-schema-draft-0${draft}.json`));
+    ajv._opts.defaultMeta = `http://json-schema.org/draft-0${draft}/schema#`;
+  }
+  for (const uri in refs) ajv.addSchema(refs[uri], uri);
 
   jsonSchemaTest(ajv, {
-    description: 'Test suite draft-0' + draft,
-    suites: {tests: './tests/draft' + draft + '/{**/,}*.json'},
-    skip: draft == 4 ? ['optional/zeroTerminatedFloats'] : [],
+    description: `Test suite draft-0${draft}`,
+    suites: {tests: `./tests/draft${draft}/{**/,}*.json`},
+    skip: SKIP[draft],
     cwd: __dirname,
     hideFolder: 'tests/'
   });
-}
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/json-schema-org/JSON-Schema-Test-Suite#readme",
   "devDependencies": {
-    "ajv": "^5.0.4-beta.1",
+    "ajv": "^6.0.0-rc.0",
     "json-schema-test": "^1.3.0",
     "mocha": "^3.2.0"
   }

--- a/tests/draft7/definitions.json
+++ b/tests/draft7/definitions.json
@@ -1,7 +1,7 @@
 [
     {
         "description": "valid definition",
-        "schema": {"$ref": "http://json-schema.org/draft-06/schema#"},
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
         "tests": [
             {
                 "description": "valid definition schema",
@@ -16,7 +16,7 @@
     },
     {
         "description": "invalid definition",
-        "schema": {"$ref": "http://json-schema.org/draft-06/schema#"},
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
         "tests": [
             {
                 "description": "invalid definition schema",

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -175,7 +175,7 @@
     },
     {
         "description": "remote ref, containing refs itself",
-        "schema": {"$ref": "http://json-schema.org/draft-06/schema#"},
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
         "tests": [
             {
                 "description": "remote ref valid",


### PR DESCRIPTION
I've skipped tests optional/content and optional/format (content keywords and new international formats aren't part of ajv, I hope I or somebody else will make plugins to support them, then I can add them back).
Could we maybe split formats to multiple files as we've discussed (or at least two files)? It would be possible to exclude only those unsupported at the moment.