### PR TITLE
Fix invalid IPv6 IRI

### DIFF
--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -25,8 +25,13 @@
             },
             {
                 "description": "a valid IRI based on IPv6",
-                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
                 "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
             },
             {
                 "description": "an invalid relative IRI Reference",


### PR DESCRIPTION
IPv6 URIs (and IRIs) require square brackets around the IP address.

https://tools.ietf.org/html/rfc3986#section-3.2.2

> A host identified by an Internet Protocol literal address, version 6
> [RFC3513] or later, is distinguished by enclosing the IP literal
> within square brackets ("[" and "]").  This is the only place where
> square bracket characters are allowed in the URI syntax.