### PR TITLE
test false-exclusivity for max/min numbers

### DIFF
--- a/tests/draft4/maximum.json
+++ b/tests/draft4/maximum.json
@@ -26,6 +26,32 @@
         ]
     },
     {
+        "description": "maximum validation (explicit false exclusivity)",
+        "schema": {"maximum": 3.0, "exclusiveMaximum": false},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "exclusiveMaximum validation",
         "schema": {
             "maximum": 3.0,

--- a/tests/draft4/minimum.json
+++ b/tests/draft4/minimum.json
@@ -26,6 +26,32 @@
         ]
     },
     {
+        "description": "minimum validation (explicit false exclusivity)",
+        "schema": {"minimum": 1.1, "exclusiveMinimum": false},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "exclusiveMinimum validation",
         "schema": {
             "minimum": 1.1,


### PR DESCRIPTION
My C++ schema validator was not working correctly when `exclusiveMinimum` or `exclusiveMinimum` was set to false. Adding a test for explicit false-testing.