### PR TITLE
Add tests for date-strings

### DIFF
--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -9,6 +9,31 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a invalid day in date-time string",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:60-24:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false
@@ -78,6 +103,11 @@
                 "description": "a valid mailto URI",
                 "data": "mailto:John.Doe@example.com",
                 "valid": true
+            },
+            {
+                "description": "an invalid mailto URI",
+                "data": "mailto:John.Doe-example.com",
+                "valid": false
             },
             {
                 "description": "a valid newsgroup URI",

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -105,11 +105,6 @@
                 "valid": true
             },
             {
-                "description": "an invalid mailto URI",
-                "data": "mailto:John.Doe-example.com",
-                "valid": false
-            },
-            {
                 "description": "a valid newsgroup URI",
                 "data": "news:comp.infosystems.www.servers.unix",
                 "valid": true

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -20,7 +20,7 @@
             },
             {
                 "description": "a valid date-time string with minus offset",
-                "data": "1990-12-31T15:59:60.123-08:00",
+                "data": "1990-12-31T15:59:50.123-08:00",
                 "valid": true
             },
             {

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -9,6 +9,31 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a invalid day in date-time string",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:60-24:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -20,7 +20,7 @@
             },
             {
                 "description": "a valid date-time string with minus offset",
-                "data": "1990-12-31T15:59:60.123-08:00",
+                "data": "1990-12-31T15:59:50.123-08:00",
                 "valid": true
             },
             {

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -9,6 +9,31 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a invalid day in date-time string",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:60-24:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -9,6 +9,31 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a invalid day in date-time string",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:60-24:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963",
                 "valid": false

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -20,7 +20,7 @@
             },
             {
                 "description": "a valid date-time string with minus offset",
-                "data": "1990-12-31T15:59:60.123-08:00",
+                "data": "1990-12-31T15:59:50.123-08:00",
                 "valid": true
             },
             {

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -9,31 +9,6 @@
                 "valid": true
             },
             {
-                "description": "a valid date-time string without second fraction",
-                "data": "1963-06-19T08:30:06Z",
-                "valid": true
-            },
-            {
-                "description": "a valid date-time string with plus offset",
-                "data": "1937-01-01T12:00:27.87+00:20",
-                "valid": true
-            },
-            {
-                "description": "a valid date-time string with minus offset",
-                "data": "1990-12-31T15:59:50.123-08:00",
-                "valid": true
-            },
-            {
-                "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
-                "valid": false
-            },
-            {
-                "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
-                "valid": false
-            },
-            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963",
                 "valid": false


### PR DESCRIPTION
Just some more tests for `"format": "date-time"`.  