### PR TITLE
Testing closing Z after time-zone offset for date-time

### DIFF
--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -34,6 +34,11 @@
                 "valid": false
             },
             {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },            
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false


### PR DESCRIPTION
Added a test for an invalid closing Z after time-zone offset for date-time format.