### PR TITLE
Add tests for missing cases for `properties`, `additionalProperties` and `patternProperties`

### DIFF
--- a/tests/draft7/properties.json
+++ b/tests/draft7/properties.json
@@ -116,6 +116,24 @@
         ]
     },
     {
+        "description": "additionalProperties on its own",
+        "schema": {
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "any property always invalid",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "properties with boolean schema",
         "schema": {
             "properties": {

--- a/tests/draft7/properties.json
+++ b/tests/draft7/properties.json
@@ -95,6 +95,27 @@
         ]
     },
     {
+        "description": "patternProperties without properties",
+        "schema": {
+            "patternProperties": {
+                "f.o": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "patternProperty covers all keys",
+                "data": {"fxo": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty always invalid",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "properties with boolean schema",
         "schema": {
             "properties": {


### PR DESCRIPTION
The test suite needs to make sure that `additionalProperties` and `patternProperties` work correctly when not used with a `properties` assertion.

