### PR TITLE
Enforce ECMA 262 regular expression definition of $

### DIFF
--- a/tests/draft3/pattern.json
+++ b/tests/draft3/pattern.json
@@ -14,6 +14,11 @@
                 "valid": false
             },
             {
+                "description": "the $ character should match the end of the string",
+                "data": "a\n",
+                "valid": false
+            },
+            {
                 "description": "ignores non-strings",
                 "data": true,
                 "valid": true

--- a/tests/draft4/pattern.json
+++ b/tests/draft4/pattern.json
@@ -14,6 +14,11 @@
                 "valid": false
             },
             {
+                "description": "the $ character should match the end of the string",
+                "data": "a\n",
+                "valid": false
+            },
+            {
                 "description": "ignores non-strings",
                 "data": true,
                 "valid": true

--- a/tests/draft6/pattern.json
+++ b/tests/draft6/pattern.json
@@ -14,6 +14,11 @@
                 "valid": false
             },
             {
+                "description": "the $ character should match the end of the string",
+                "data": "a\n",
+                "valid": false
+            },
+            {
                 "description": "ignores non-strings",
                 "data": true,
                 "valid": true

--- a/tests/draft7/pattern.json
+++ b/tests/draft7/pattern.json
@@ -14,6 +14,11 @@
                 "valid": false
             },
             {
+                "description": "the $ character should match the end of the string",
+                "data": "a\n",
+                "valid": false
+            },
+            {
                 "description": "ignores non-strings",
                 "data": true,
                 "valid": true


### PR DESCRIPTION
The regular expression specification in different languages varies.

The json schema draft 3 states:

"Regular expressions SHOULD follow the regular expression specification from ECMA 262/Perl 5"
https://tools.ietf.org/html/draft-zyp-json-schema-03

In that regular expression definition:

If multiline is FALSE, $ must match the end of the string.
If multiline is TRUE, $ may match \n.

https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.2.6

We should test this since Python for instance will match \n if it is the
final character even if multiline is FALSE (with \Z acting as end of
string only).

## Worries

This could be a rabbit hole, since if we accept this shouldn't we eventually enforce all of the syntax on https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions
So please let me know if you think this is a good idea or not.

## Why I made this MR

It is standard to define a fully matching `pattern` as e.g. `"^a+$"` to match `a` and `aaa` but it would be surprising for most that it in fact also matches `aa\n` in the python libraries. This change will make at least the 2 python libraries alter their `pattern` implementations.