### PR TITLE
Added test for additionalProperties

### DIFF
--- a/tests/draft3/additionalProperties.json
+++ b/tests/draft3/additionalProperties.json
@@ -113,5 +113,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "additionalProperties should not look in applicators",
+        "schema": {
+            "extends": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in extends are not allowed",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/additionalProperties.json
+++ b/tests/draft4/additionalProperties.json
@@ -113,5 +113,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "additionalProperties should not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not allowed",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/additionalProperties.json
+++ b/tests/draft6/additionalProperties.json
@@ -113,5 +113,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "additionalProperties should not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not allowed",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/additionalProperties.json
+++ b/tests/draft7/additionalProperties.json
@@ -113,5 +113,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "additionalProperties should not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not allowed",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
`additionalProperties` should not be able to recognize properties that are defined within applicator keywords (`allOf`, etc.).  This was the main point of contention that led to the creation of `unevaluatedProperties` which behaves similarly, but _can_ look inside applicators.

This change adds tests to ensure that `additionalProperties` behaves properly in this regard.

Not sure if it should also go in draft-03 tests...