### PR TITLE
Make sure to have an idn-email case that's email-ish.

### DIFF
--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -9,6 +9,11 @@
                 "valid": true
             },
             {
+                "description": "valid IDN, but not a valid email",
+                "data": "실례@실례.테스트",
+                "valid": false
+            },
+            {
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -9,7 +9,12 @@
                 "valid": true
             },
             {
-                "description": "an invalid idn e-mail address",
+                "description": "an invalid idn email that is not valid IDN",
+                "data": "-foo@example.com",
+                "valid": false
+            },
+            {
+                "description": "a completely invalid e-mail address",
                 "data": "2962",
                 "valid": false
             }


### PR DESCRIPTION
This example looks close enough to an email, but is
designed to force validators to invoke IDN validation
on the email.

IDN disallows a hyphen at the (beginning or) end.

@epoberezkin / @handrews either of you care to review?