### PR TITLE
Add more tests for valid emails

### DIFF
--- a/tests/draft3/optional/format.json
+++ b/tests/draft3/optional/format.json
@@ -177,11 +177,6 @@
                 "valid": true
             },
             {
-                "description": "a valid host name starting with a number",
-                "data": "123.24-7-examples.com",
-                "valid": true
-            },
-            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false

--- a/tests/draft3/optional/format.json
+++ b/tests/draft3/optional/format.json
@@ -124,17 +124,17 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with numbers and hyphens in the domain",
+                "description": "a valid e-mail address with a complex domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
                 "valid": true
             },
             {
-                "description": "a valid email address with an IP address as the destination",
+                "description": "a valid email address with an IP address",
                 "data": "email@123.123.123.123",
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "description": "a valid e-mail address with a bracketed IP address",
                 "data": "email@[123.123.123.123]",
                 "valid": true
             },

--- a/tests/draft3/optional/format.json
+++ b/tests/draft3/optional/format.json
@@ -109,8 +109,33 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a numeric hostname",
+                "description": "a valid email address with numbers in the local part",
+                "data": "1234567890@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with symbols in the local part",
+                "data": "!#$%'*+-/=?^_`{|}~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with a quoted local part",
+                "data": "\"(unusual)\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with numbers and hyphens in the domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with an IP address as the destination",
+                "data": "email@123.123.123.123",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "data": "email@[123.123.123.123]",
                 "valid": true
             },
             {

--- a/tests/draft3/optional/format.json
+++ b/tests/draft3/optional/format.json
@@ -109,6 +109,11 @@
                 "valid": true
             },
             {
+                "description": "a valid e-mail address with a numeric hostname",
+                "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
@@ -169,6 +174,11 @@
             {
                 "description": "a valid host name",
                 "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid host name starting with a number",
+                "data": "123.24-7-examples.com",
                 "valid": true
             },
             {

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -176,17 +176,17 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with numbers and hyphens in the domain",
+                "description": "a valid e-mail address with a complex domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
                 "valid": true
             },
             {
-                "description": "a valid email address with an IP address as the destination",
+                "description": "a valid email address with an IP address",
                 "data": "email@123.123.123.123",
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "description": "a valid e-mail address with a bracketed IP address",
                 "data": "email@[123.123.123.123]",
                 "valid": true
             },

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -161,6 +161,11 @@
                 "valid": true
             },
             {
+                "description": "a valid e-mail address with a numeric hostname",
+                "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
@@ -231,6 +236,11 @@
             {
                 "description": "a valid host name",
                 "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid hostname starting with a number",
+                "data": "123.24-7-examples.com",
                 "valid": true
             },
             {

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -161,8 +161,33 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a numeric hostname",
+                "description": "a valid email address with numbers in the local part",
+                "data": "1234567890@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with symbols in the local part",
+                "data": "!#$%'*+-/=?^_`{|}~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with a quoted local part",
+                "data": "\"(unusual)\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with numbers and hyphens in the domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with an IP address as the destination",
+                "data": "email@123.123.123.123",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "data": "email@[123.123.123.123]",
                 "valid": true
             },
             {

--- a/tests/draft4/optional/format.json
+++ b/tests/draft4/optional/format.json
@@ -239,11 +239,6 @@
                 "valid": true
             },
             {
-                "description": "a valid hostname starting with a number",
-                "data": "123.24-7-examples.com",
-                "valid": true
-            },
-            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -250,17 +250,17 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with numbers and hyphens in the domain",
+                "description": "a valid e-mail address with a complex domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
                 "valid": true
             },
             {
-                "description": "a valid email address with an IP address as the destination",
+                "description": "a valid email address with an IP address",
                 "data": "email@123.123.123.123",
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "description": "a valid e-mail address with a bracketed IP address",
                 "data": "email@[123.123.123.123]",
                 "valid": true
             },

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -313,11 +313,6 @@
                 "valid": true
             },
             {
-                "description": "a valid hostname starting with a number",
-                "data": "123.24-7-examples.com",
-                "valid": true
-            },
-            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -235,8 +235,33 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a numeric hostname",
+                "description": "a valid email address with numbers in the local part",
+                "data": "1234567890@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with symbols in the local part",
+                "data": "!#$%'*+-/=?^_`{|}~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with a quoted local part",
+                "data": "\"(unusual)\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with numbers and hyphens in the domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with an IP address as the destination",
+                "data": "email@123.123.123.123",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "data": "email@[123.123.123.123]",
                 "valid": true
             },
             {

--- a/tests/draft6/optional/format.json
+++ b/tests/draft6/optional/format.json
@@ -235,6 +235,11 @@
                 "valid": true
             },
             {
+                "description": "a valid e-mail address with a numeric hostname",
+                "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
@@ -305,6 +310,11 @@
             {
                 "description": "a valid host name",
                 "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid hostname starting with a number",
+                "data": "123.24-7-examples.com",
                 "valid": true
             },
             {

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -9,8 +9,33 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a numeric hostname",
+                "description": "a valid email address with numbers in the local part",
+                "data": "1234567890@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with symbols in the local part",
+                "data": "!#$%'*+-/=?^_`{|}~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with a quoted local part",
+                "data": "\"(unusual)\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with numbers and hyphens in the domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
+                "description": "a valid email address with an IP address as the destination",
+                "data": "email@123.123.123.123",
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "data": "email@[123.123.123.123]",
                 "valid": true
             },
             {

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -9,6 +9,11 @@
                 "valid": true
             },
             {
+                "description": "a valid e-mail address with a numeric hostname",
+                "data": "joe.bloggs@123.24-7-examples.com",
+                "valid": true
+            },
+            {
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -24,17 +24,17 @@
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with numbers and hyphens in the domain",
+                "description": "a valid e-mail address with a complex domain",
                 "data": "joe.bloggs@123.24-7-examples.com",
                 "valid": true
             },
             {
-                "description": "a valid email address with an IP address as the destination",
+                "description": "a valid email address with an IP address",
                 "data": "email@123.123.123.123",
                 "valid": true
             },
             {
-                "description": "a valid e-mail address with a bracketed IP address as the destination",
+                "description": "a valid e-mail address with a bracketed IP address",
                 "data": "email@[123.123.123.123]",
                 "valid": true
             },

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "a valid hostname starting with a number",
+                "data": "123.24-7-examples.com",
+                "valid": true
+            },
+            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -14,11 +14,6 @@
                 "valid": true
             },
             {
-                "description": "a valid hostname starting with a number",
-                "data": "123.24-7-examples.com",
-                "valid": true
-            },
-            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false


### PR DESCRIPTION
Per [RFC 1123](https://tools.ietf.org/html/rfc1123#page-13), hostname labels are allowed to start with either a letter or a digit. The [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1) email spec specifies that the domain part of an email is subject to the modifications in RFC 1123. However, the tests for hostnames and emails do not include any examples of hostname labels beginning with a digit.

This PR adds cases to the hostname and email tests for all draft versions.

