### PR TITLE
Additional keyword tests

### DIFF
--- a/tests/draft4/allOf.json
+++ b/tests/draft4/allOf.json
@@ -108,5 +108,78 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/anyOf.json
+++ b/tests/draft4/anyOf.json
@@ -105,5 +105,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -74,5 +74,122 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/oneOf.json
+++ b/tests/draft4/oneOf.json
@@ -105,5 +105,58 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/type.json
+++ b/tests/draft4/type.json
@@ -116,6 +116,11 @@
                 "valid": true
             },
             {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "an object is not a string",
                 "data": {},
                 "valid": false
@@ -229,6 +234,11 @@
                 "valid": false
             },
             {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a float is not a boolean",
                 "data": 1.1,
                 "valid": false
@@ -236,6 +246,11 @@
             {
                 "description": "a string is not a boolean",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
                 "valid": false
             },
             {
@@ -249,8 +264,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is a boolean",
+                "description": "true is a boolean",
                 "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
                 "valid": true
             },
             {
@@ -275,8 +295,18 @@
                 "valid": false
             },
             {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a string is not null",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
                 "valid": false
             },
             {
@@ -290,8 +320,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is not null",
+                "description": "true is not null",
                 "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
                 "valid": false
             },
             {
@@ -338,6 +373,90 @@
             {
                 "description": "null is invalid",
                 "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
                 "valid": false
             }
         ]

--- a/tests/draft6/allOf.json
+++ b/tests/draft6/allOf.json
@@ -141,5 +141,78 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/anyOf.json
+++ b/tests/draft6/anyOf.json
@@ -138,5 +138,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/dependencies.json
+++ b/tests/draft6/dependencies.json
@@ -168,5 +168,30 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "empty array of dependencies",
+        "schema": {
+            "dependencies": {
+                "foo": []
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property is valid",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/items.json
+++ b/tests/draft6/items.json
@@ -129,5 +129,122 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/oneOf.json
+++ b/tests/draft6/oneOf.json
@@ -149,5 +149,58 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/type.json
+++ b/tests/draft6/type.json
@@ -116,6 +116,11 @@
                 "valid": true
             },
             {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "an object is not a string",
                 "data": {},
                 "valid": false
@@ -229,6 +234,11 @@
                 "valid": false
             },
             {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a float is not a boolean",
                 "data": 1.1,
                 "valid": false
@@ -236,6 +246,11 @@
             {
                 "description": "a string is not a boolean",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
                 "valid": false
             },
             {
@@ -249,8 +264,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is a boolean",
+                "description": "true is a boolean",
                 "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
                 "valid": true
             },
             {
@@ -275,8 +295,18 @@
                 "valid": false
             },
             {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a string is not null",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
                 "valid": false
             },
             {
@@ -290,8 +320,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is not null",
+                "description": "true is not null",
                 "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
                 "valid": false
             },
             {
@@ -338,6 +373,90 @@
             {
                 "description": "null is invalid",
                 "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
                 "valid": false
             }
         ]

--- a/tests/draft7/allOf.json
+++ b/tests/draft7/allOf.json
@@ -141,5 +141,78 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/anyOf.json
+++ b/tests/draft7/anyOf.json
@@ -138,5 +138,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/dependencies.json
+++ b/tests/draft7/dependencies.json
@@ -168,5 +168,30 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "empty array of dependencies",
+        "schema": {
+            "dependencies": {
+                "foo": []
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property is valid",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/items.json
+++ b/tests/draft7/items.json
@@ -129,5 +129,122 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/oneOf.json
+++ b/tests/draft7/oneOf.json
@@ -149,5 +149,58 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/type.json
+++ b/tests/draft7/type.json
@@ -116,6 +116,11 @@
                 "valid": true
             },
             {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "an object is not a string",
                 "data": {},
                 "valid": false
@@ -229,6 +234,11 @@
                 "valid": false
             },
             {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a float is not a boolean",
                 "data": 1.1,
                 "valid": false
@@ -236,6 +246,11 @@
             {
                 "description": "a string is not a boolean",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
                 "valid": false
             },
             {
@@ -249,8 +264,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is a boolean",
+                "description": "true is a boolean",
                 "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
                 "valid": true
             },
             {
@@ -275,8 +295,18 @@
                 "valid": false
             },
             {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
                 "description": "a string is not null",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
                 "valid": false
             },
             {
@@ -290,8 +320,13 @@
                 "valid": false
             },
             {
-                "description": "a boolean is not null",
+                "description": "true is not null",
                 "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
                 "valid": false
             },
             {
@@ -338,6 +373,90 @@
             {
                 "description": "null is invalid",
                 "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
                 "valid": false
             }
         ]


### PR DESCRIPTION
@Julian as discussed in https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/253#issuecomment-473467955, I've added several tests for keywords. There are more tests for $ref and some other special cases that are not limited to ajv (I will make separate PRs).

What I meant by implementation specific tests, see these two for example:
- https://github.com/epoberezkin/ajv/blob/master/spec/tests/rules/oneOf.json#L51
- https://github.com/epoberezkin/ajv/blob/master/spec/tests/rules/uniqueItems.json

Ajv has performance optimisation that these tests invoke. They are not in this PR - I don't think they should be here, but let me know what you think.