### PR TITLE
Fix $ref value as properly percent-encoded.

### DIFF
--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -301,7 +301,7 @@
         "description": "refs with quote",
         "schema": {
             "properties": {
-                "foo\"bar": {"$ref": "#/definitions/foo\"bar"}
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
             },
             "definitions": {
                 "foo\"bar": {"type": "number"}

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -333,7 +333,7 @@
         "description": "refs with quote",
         "schema": {
             "properties": {
-                "foo\"bar": {"$ref": "#/definitions/foo\"bar"}
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
             },
             "definitions": {
                 "foo\"bar": {"type": "number"}

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -333,7 +333,7 @@
         "description": "refs with quote",
         "schema": {
             "properties": {
-                "foo\"bar": {"$ref": "#/definitions/foo\"bar"}
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
             },
             "definitions": {
                 "foo\"bar": {"type": "number"}


### PR DESCRIPTION
Hello everyone.
This PR is for fixing the issue #261 .
All test schemas for Draft-07, -06, and -04 after the modification, are tested by the validator of [Justify](https://github.com/leadpony/justify) with the schema validation against metaschema enabled.
Thank you.   