### PR TITLE
Initial run at draft/2019-04 tests, complete with output

### DIFF
--- a/tests/draft2019-04/additionalItems.json
+++ b/tests/draft2019-04/additionalItems.json
@@ -1,0 +1,533 @@
+[
+  {
+    "description": "additionalItems as schema",
+    "schema": {"items": [{}], "additionalItems": {"type": "integer"}},
+    "tests": [
+      {
+        "description": "additional items match schema",
+        "data": [null, 2, 3, 4],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/2",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "additional items do not match schema",
+        "data": [null, 2, 3, "foo"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems/type",
+            "instanceLocation": "#/2",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems/type",
+            "instanceLocation": "#/2",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems",
+                "error": "Items not covered by `items` failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/additionalItems",
+                    "instanceLocation": "#/2",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/additionalItems/type",
+                        "instanceLocation": "#/2",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "items is schema, no additionalItems",
+    "schema": {"items": {}, "additionalItems": false},
+    "tests": [
+      {
+        "description": "all items match schema",
+        "data": [1, 2, 3, 4, 5],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/2"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/3"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/4"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "array of items with no additionalItems",
+    "schema": {"items": [{}, {}, {}], "additionalItems": false},
+    "tests": [
+      {
+        "description": "fewer number of items present",
+        "data": [1, 2],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "equal number of items present",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2",
+                    "instanceLocation": "#/2"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "additional items are not permitted",
+        "data": [1, 2, 3, 4],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems",
+            "instanceLocation": "#",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems",
+            "instanceLocation": "#",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2",
+                    "instanceLocation": "#/2"
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems",
+                "error": "Items not covered by `items` are not allowed."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalItems as false without items",
+    "schema": {"additionalItems": false},
+    "tests": [
+      {
+        "description": "items defaults to empty schema so everything is valid",
+        "data": [1, 2, 3, 4, 5],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": {"foo": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalItems are allowed by default",
+    "schema": {"items": [{"type": "integer"}]},
+    "tests": [
+      {
+        "description": "only the first item is validated",
+        "data": [1, "foo", false],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/additionalProperties.json
+++ b/tests/draft2019-04/additionalProperties.json
@@ -1,0 +1,827 @@
+[
+  {
+    "description": "additionalProperties being false does not allow other properties",
+    "schema": {
+      "properties": {"foo": {}, "bar": {}},
+      "patternProperties": {"^v": {}},
+      "additionalProperties": false
+    },
+    "tests": [
+      {
+        "description": "no additional properties is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an additional property is invalid",
+        "data": {"foo": 1, "bar": 2, "quux": "boom"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "foobarbaz",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "patternProperties are not additional properties",
+        "data": {"foo": 1, "vroom": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/^v",
+                    "instanceLocation": "#/vroom"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "non-ASCII pattern with additionalProperties",
+    "schema": {"patternProperties": {"^á": {}}, "additionalProperties": false},
+    "tests": [
+      {
+        "description": "matching the pattern is valid",
+        "data": {"ármányos": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/^á",
+                    "instanceLocation": "#/ármányos"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "not matching the pattern is invalid",
+        "data": {"élmény": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalProperties allows a schema which should validate",
+    "schema": {
+      "properties": {"foo": {}, "bar": {}},
+      "additionalProperties": {"type": "boolean"}
+    },
+    "tests": [
+      {
+        "description": "no additional properties is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an additional valid property is valid",
+        "data": {"foo": 1, "bar": 2, "quux": true},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/quux",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/quux",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an additional invalid property is invalid",
+        "data": {"foo": 1, "bar": 2, "quux": 12},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/quux",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/quux",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar"
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Any properties not covered by `properties` and `patternProperties` failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/quux",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/quux",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalProperties can exist by itself",
+    "schema": {"additionalProperties": {"type": "boolean"}},
+    "tests": [
+      {
+        "description": "an additional valid property is valid",
+        "data": {"foo": true},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an additional invalid property is invalid",
+        "data": {"foo": 1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Any properties not covered by `properties` and `patternProperties` failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalProperties are allowed by default",
+    "schema": {"properties": {"foo": {}, "bar": {}}},
+    "tests": [
+      {
+        "description": "additional properties are allowed",
+        "data": {"foo": 1, "bar": 2, "quux": true},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "additionalProperties should not look in applicators",
+    "schema": {
+      "allOf": [{"properties": {"foo": {}}}],
+      "additionalProperties": {"type": "boolean"}
+    },
+    "tests": [
+      {
+        "description": "properties defined in allOf are not allowed",
+        "data": {"foo": 1, "bar": true},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/foo",
+                            "instanceLocation": "#/foo"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Any properties not covered by `properties` and `patternProperties` failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/allOf.json
+++ b/tests/draft2019-04/allOf.json
@@ -1,0 +1,1663 @@
+[
+  {
+    "description": "allOf",
+    "schema": {
+      "allOf": [
+        {"properties": {"bar": {"type": "integer"}}, "required": ["bar"]},
+        {"properties": {"foo": {"type": "string"}}, "required": ["foo"]}
+      ]
+    },
+    "tests": [
+      {
+        "description": "allOf",
+        "data": {"foo": "baz", "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch second",
+        "data": {"foo": "baz"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"bar\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch first",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong type",
+        "data": {"foo": "baz", "bar": "quux"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "error": "At least one subschema failed validation.",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/allOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/allOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type",
+                                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with base schema",
+    "schema": {
+      "properties": {"bar": {"type": "integer"}},
+      "required": ["bar"],
+      "allOf": [
+        {"properties": {"foo": {"type": "string"}}, "required": ["foo"]},
+        {"properties": {"baz": {"type": "null"}}, "required": ["baz"]}
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {"foo": "quux", "bar": 2, "baz": null},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/0/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/baz",
+                            "instanceLocation": "#/baz",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/baz/type",
+                                "instanceLocation": "#/baz",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch base schema",
+        "data": {"foo": "quux", "baz": null},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"bar\"] are required."
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/0/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/baz",
+                            "instanceLocation": "#/baz",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/baz/type",
+                                "instanceLocation": "#/baz",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch first allOf",
+        "data": {"bar": 2, "baz": null},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/1/properties/baz",
+                            "instanceLocation": "#/baz",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/1/properties/baz/type",
+                                "instanceLocation": "#/baz",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch second allOf",
+        "data": {"foo": "quux", "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"baz\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"baz\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/allOf/0/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/allOf/0/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"baz\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch both",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "2 of 2 subschemas failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/0/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\"] are required."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/1/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"baz\"] are required."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf",
+            "instanceLocation": "#",
+            "keyword": "allOf",
+            "error": "2 of 2 subschemas failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/0/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\"] are required."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/1/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"baz\"] are required."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "2 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"baz\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf simple types",
+    "schema": {"allOf": [{"maximum": 30}, {"minimum": 20}]},
+    "tests": [
+      {
+        "description": "valid",
+        "data": 25,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/maximum",
+                        "instanceLocation": "#",
+                        "keyword": "maximum"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch one",
+        "data": 35,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/maximum",
+            "instanceLocation": "#",
+            "keyword": "maximum",
+            "error": "The value 35 should be at most 30."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/maximum",
+            "instanceLocation": "#",
+            "keyword": "maximum",
+            "error": "The value 35 should be at most 30."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/maximum",
+                        "instanceLocation": "#",
+                        "keyword": "maximum",
+                        "error": "The value 35 should be at most 30."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with boolean schemas, all true",
+    "schema": {"allOf": [true, true]},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with boolean schemas, some false",
+    "schema": {"allOf": [true, false]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with boolean schemas, all false",
+    "schema": {"allOf": [false, false]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "2 of 2 subschemas failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf",
+            "instanceLocation": "#",
+            "keyword": "allOf",
+            "error": "2 of 2 subschemas failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "2 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with one empty schema",
+    "schema": {"allOf": [{}]},
+    "tests": [
+      {
+        "description": "any data is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with two empty schemas",
+    "schema": {"allOf": [{}, {}]},
+    "tests": [
+      {
+        "description": "any data is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with the first empty schema",
+    "schema": {"allOf": [{}, {"type": "number"}]},
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/1/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/1/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/1/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "allOf with the last empty schema",
+    "schema": {"allOf": [{"type": "number"}, {}]},
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/allOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/allOf/0/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "error": "1 of 2 subschemas failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/allOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/anyOf.json
+++ b/tests/draft2019-04/anyOf.json
@@ -1,0 +1,1235 @@
+[
+  {
+    "description": "anyOf",
+    "schema": {"anyOf": [{"type": "integer"}, {"minimum": 2}]},
+    "tests": [
+      {
+        "description": "first anyOf valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value 1 should be at least 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "second anyOf valid",
+        "data": 2.5,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both anyOf valid",
+        "data": 3,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "neither anyOf valid",
+        "data": 1.5,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value 1.5 should be at least 2."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/anyOf",
+            "instanceLocation": "#",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value 1.5 should be at least 2."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value 1.5 should be at least 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf with base schema",
+    "schema": {"type": "string", "anyOf": [{"maxLength": 2}, {"minLength": 4}]},
+    "tests": [
+      {
+        "description": "mismatch base schema",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "one anyOf valid",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength",
+                        "error": "The string should be at most 2 characters long, but was 6."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both anyOf invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength",
+                "error": "The string should be at most 2 characters long, but was 3."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength",
+                "error": "The string should be at least 4 characters long, but was 3."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/anyOf",
+            "instanceLocation": "#",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength",
+                "error": "The string should be at most 2 characters long, but was 3."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength",
+                "error": "The string should be at least 4 characters long, but was 3."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength",
+                        "error": "The string should be at most 2 characters long, but was 3."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/1/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength",
+                        "error": "The string should be at least 4 characters long, but was 3."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf with boolean schemas, all true",
+    "schema": {"anyOf": [true, true]},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf with boolean schemas, some true",
+    "schema": {"anyOf": [true, false]},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf with boolean schemas, all false",
+    "schema": {"anyOf": [false, false]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/anyOf",
+            "instanceLocation": "#",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf complex types",
+    "schema": {
+      "anyOf": [
+        {"properties": {"bar": {"type": "integer"}}, "required": ["bar"]},
+        {"properties": {"foo": {"type": "string"}}, "required": ["foo"]}
+      ]
+    },
+    "tests": [
+      {
+        "description": "first anyOf valid (complex)",
+        "data": {"bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/anyOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/anyOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "second anyOf valid (complex)",
+        "data": {"foo": "baz"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"bar\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/anyOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/anyOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both anyOf valid (complex)",
+        "data": {"foo": "baz", "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/anyOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/anyOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/anyOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/anyOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "neither anyOf valid (complex)",
+        "data": {"foo": 2, "bar": "quux"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/anyOf",
+            "instanceLocation": "#",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/0/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf/1/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "error": "At least one subschema failed validation.",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/anyOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/anyOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type",
+                                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "error": "At least one subschema failed validation.",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/anyOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/anyOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type",
+                                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "anyOf with one empty schema",
+    "schema": {"anyOf": [{"type": "number"}, {}]},
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "number is valid",
+        "data": 123,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/anyOf",
+                "instanceLocation": "#",
+                "keyword": "anyOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/anyOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/anyOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/boolean_schema.json
+++ b/tests/draft2019-04/boolean_schema.json
@@ -1,0 +1,437 @@
+[
+  {
+    "description": "boolean schema 'true'",
+    "schema": true,
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "boolean true is valid",
+        "data": true,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "boolean false is valid",
+        "data": false,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "null is valid",
+        "data": null,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "object is valid",
+        "data": {"foo": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "array is valid",
+        "data": ["foo"],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "empty array is valid",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "boolean schema 'false'",
+    "schema": false,
+    "tests": [
+      {
+        "description": "number is invalid",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "boolean true is invalid",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "boolean false is invalid",
+        "data": false,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "null is invalid",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "object is invalid",
+        "data": {"foo": "bar"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "empty object is invalid",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "array is invalid",
+        "data": ["foo"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      },
+      {
+        "description": "empty array is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/const.json
+++ b/tests/draft2019-04/const.json
@@ -1,0 +1,421 @@
+[
+  {
+    "description": "const validation",
+    "schema": {"const": 2},
+    "tests": [
+      {
+        "description": "same value is valid",
+        "data": 2,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another value is invalid",
+        "data": 5,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value 5 does not match the expected 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value 5 does not match the expected 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value 5 does not match the expected 2."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another type is invalid",
+        "data": "a",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value \"a\" does not match the expected 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value \"a\" does not match the expected 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value \"a\" does not match the expected 2."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "const with object",
+    "schema": {"const": {"foo": "bar", "baz": "bax"}},
+    "tests": [
+      {
+        "description": "same object is valid",
+        "data": {"foo": "bar", "baz": "bax"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "same object with different property order is valid",
+        "data": {"baz": "bax", "foo": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another object is invalid",
+        "data": {"foo": "bar"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value {\"foo\":\"bar\"} does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value {\"foo\":\"bar\"} does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value {\"foo\":\"bar\"} does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another type is invalid",
+        "data": [1, 2],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [1,2] does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [1,2] does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value [1,2] does not match the expected {\"foo\":\"bar\",\"baz\":\"bax\"}."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "const with array",
+    "schema": {"const": [{"foo": "bar"}]},
+    "tests": [
+      {
+        "description": "same array is valid",
+        "data": [{"foo": "bar"}],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another array item is invalid",
+        "data": [2],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [2] does not match the expected [{\"foo\":\"bar\"}]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [2] does not match the expected [{\"foo\":\"bar\"}]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value [2] does not match the expected [{\"foo\":\"bar\"}]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with additional items is invalid",
+        "data": [1, 2, 3],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [1,2,3] does not match the expected [{\"foo\":\"bar\"}]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value [1,2,3] does not match the expected [{\"foo\":\"bar\"}]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value [1,2,3] does not match the expected [{\"foo\":\"bar\"}]."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "const with null",
+    "schema": {"const": null},
+    "tests": [
+      {
+        "description": "null is valid",
+        "data": null,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "not null is invalid",
+        "data": 0,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value 0 does not match the expected null."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/const",
+            "instanceLocation": "#",
+            "keyword": "const",
+            "error": "The value 0 does not match the expected null."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/const",
+                "instanceLocation": "#",
+                "keyword": "const",
+                "error": "The value 0 does not match the expected null."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/contains.json
+++ b/tests/draft2019-04/contains.json
@@ -1,0 +1,914 @@
+[
+  {
+    "description": "contains keyword validation",
+    "schema": {"contains": {"minimum": 5}},
+    "tests": [
+      {
+        "description": "array with item matching schema (5) is valid",
+        "data": [3, 4, 5],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/0",
+                        "keyword": "minimum",
+                        "error": "The value 3 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/1",
+                        "keyword": "minimum",
+                        "error": "The value 4 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/2",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with item matching schema (6) is valid",
+        "data": [3, 4, 6],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/0",
+                        "keyword": "minimum",
+                        "error": "The value 3 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/1",
+                        "keyword": "minimum",
+                        "error": "The value 4 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/2",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with two items matching schema (5, 6) is valid",
+        "data": [3, 4, 5, 6],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/0",
+                        "keyword": "minimum",
+                        "error": "The value 3 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/1",
+                        "keyword": "minimum",
+                        "error": "The value 4 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/2",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/3",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/3",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array without items matching schema is invalid",
+        "data": [2, 3, 4],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/0",
+                "keyword": "minimum",
+                "error": "The value 2 should be at least 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/1",
+                "keyword": "minimum",
+                "error": "The value 3 should be at least 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/2",
+                "keyword": "minimum",
+                "error": "The value 4 should be at least 5."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/0",
+                "keyword": "minimum",
+                "error": "The value 2 should be at least 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/1",
+                "keyword": "minimum",
+                "error": "The value 3 should be at least 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/minimum",
+                "instanceLocation": "#/2",
+                "keyword": "minimum",
+                "error": "The value 4 should be at least 5."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/0",
+                        "keyword": "minimum",
+                        "error": "The value 2 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/1",
+                        "keyword": "minimum",
+                        "error": "The value 3 should be at least 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/minimum",
+                        "instanceLocation": "#/2",
+                        "keyword": "minimum",
+                        "error": "The value 4 should be at least 5."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "not array is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "contains keyword with const keyword",
+    "schema": {"contains": {"const": 5}},
+    "tests": [
+      {
+        "description": "array with item 5 is valid",
+        "data": [3, 4, 5],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/0",
+                        "keyword": "const",
+                        "error": "The value 3 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/1",
+                        "keyword": "const",
+                        "error": "The value 4 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/2",
+                        "keyword": "const"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with two items 5 is valid",
+        "data": [3, 4, 5, 5],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/0",
+                        "keyword": "const",
+                        "error": "The value 3 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/1",
+                        "keyword": "const",
+                        "error": "The value 4 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/2",
+                        "keyword": "const"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/3",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/3",
+                        "keyword": "const"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array without item 5 is invalid",
+        "data": [1, 2, 3, 4],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/0",
+                "keyword": "const",
+                "error": "The value 1 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/1",
+                "keyword": "const",
+                "error": "The value 2 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/2",
+                "keyword": "const",
+                "error": "The value 3 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/3",
+                "keyword": "const",
+                "error": "The value 4 does not match the expected 5."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/0",
+                "keyword": "const",
+                "error": "The value 1 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/1",
+                "keyword": "const",
+                "error": "The value 2 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/2",
+                "keyword": "const",
+                "error": "The value 3 does not match the expected 5."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/contains/const",
+                "instanceLocation": "#/3",
+                "keyword": "const",
+                "error": "The value 4 does not match the expected 5."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/0",
+                        "keyword": "const",
+                        "error": "The value 1 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/1",
+                        "keyword": "const",
+                        "error": "The value 2 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/2",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/2",
+                        "keyword": "const",
+                        "error": "The value 3 does not match the expected 5."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/3",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/contains/const",
+                        "instanceLocation": "#/3",
+                        "keyword": "const",
+                        "error": "The value 4 does not match the expected 5."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "contains keyword with boolean schema true",
+    "schema": {"contains": true},
+    "tests": [
+      {
+        "description": "any non-empty array is valid",
+        "data": ["foo"],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "contains keyword with boolean schema false",
+    "schema": {"contains": false},
+    "tests": [
+      {
+        "description": "any non-empty array is invalid",
+        "data": ["foo"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#/0",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#/0",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/contains",
+                    "instanceLocation": "#/0",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/contains",
+            "instanceLocation": "#",
+            "keyword": "contains",
+            "error": "Expected an item that matched the given schema but no such items were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/contains",
+                "instanceLocation": "#",
+                "keyword": "contains",
+                "error": "Expected an item that matched the given schema but no such items were found."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/default.json
+++ b/tests/draft2019-04/default.json
@@ -1,0 +1,191 @@
+[
+  {
+    "description": "invalid type for default",
+    "schema": {"properties": {"foo": {"type": "integer", "default": []}}},
+    "tests": [
+      {
+        "description": "valid when property is specified",
+        "data": {"foo": 13},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/default",
+                        "instanceLocation": "#/foo",
+                        "keyword": "default"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "still valid when the invalid default is used",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "invalid string value for default",
+    "schema": {
+      "properties": {
+        "bar": {"type": "string", "minLength": 4, "default": "bad"}
+      }
+    },
+    "tests": [
+      {
+        "description": "valid when property is specified",
+        "data": {"bar": "good"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/properties/bar/default",
+            "instanceLocation": "#/bar",
+            "keyword": "default",
+            "annotation": "bad"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/properties/bar/default",
+            "instanceLocation": "#/bar",
+            "keyword": "default",
+            "annotation": "bad"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/minLength",
+                        "instanceLocation": "#/bar",
+                        "keyword": "minLength"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/default",
+                        "instanceLocation": "#/bar",
+                        "keyword": "default",
+                        "annotation": "bad"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "still valid when the invalid default is used",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/definitions.json
+++ b/tests/draft2019-04/definitions.json
@@ -1,0 +1,575 @@
+[
+  {
+    "description": "valid definition",
+    "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+    "tests": [
+      {
+        "description": "valid definition schema",
+        "data": {"definitions": {"foo": {"type": "integer"}}},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                "instanceLocation": "#"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/title",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                "instanceLocation": "#",
+                "keyword": "title",
+                "annotation": "Core schema meta-schema"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/title",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                "instanceLocation": "#/definitions/foo",
+                "keyword": "title",
+                "annotation": "Core schema meta-schema"
+              }
+            ]
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/title",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                "instanceLocation": "#",
+                "keyword": "title",
+                "annotation": "Core schema meta-schema"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/title",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                "instanceLocation": "#/definitions/foo",
+                "keyword": "title",
+                "annotation": "Core schema meta-schema"
+              }
+            ]
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                "instanceLocation": "#",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/title",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                    "instanceLocation": "#",
+                    "keyword": "title",
+                    "annotation": "Core schema meta-schema"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/definitions",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                    "instanceLocation": "#",
+                    "keyword": "definitions"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/properties",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                    "instanceLocation": "#",
+                    "keyword": "properties",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/$ref/properties/definitions",
+                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions",
+                        "instanceLocation": "#/definitions",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/definitions/type",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/type",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/definitions/default",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/default",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "default"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/additionalProperties",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "additionalProperties",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref",
+                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/additionalProperties/$ref",
+                                "instanceLocation": "#/definitions/foo",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                                    "instanceLocation": "#/definitions/foo",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/title",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "title",
+                                        "annotation": "Core schema meta-schema"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/definitions",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "definitions"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/type",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "properties",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type",
+                                            "instanceLocation": "#/definitions/foo/type",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf",
+                                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf",
+                                                "instanceLocation": "#/definitions/foo/type",
+                                                "keyword": "anyOf",
+                                                "annotations": [
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref",
+                                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/0/$ref",
+                                                    "instanceLocation": "#/definitions/foo/type",
+                                                    "keyword": "$ref",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "annotations": [
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref/enum",
+                                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes/enum",
+                                                            "instanceLocation": "#/definitions/foo/type",
+                                                            "keyword": "enum"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": false,
+                                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1",
+                                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1",
+                                                    "instanceLocation": "#/definitions/foo/type",
+                                                    "errors": [
+                                                      {
+                                                        "valid": false,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/type",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/type",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "type",
+                                                        "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/items",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/items",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "items"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/minItems",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/minItems",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "minItems"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/uniqueItems",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/uniqueItems",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "uniqueItems"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/default",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "default"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/default",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                    "instanceLocation": "#",
+                    "keyword": "default"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "invalid definition",
+    "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+    "tests": [
+      {
+        "description": "invalid definition schema",
+        "data": {"definitions": {"foo": {"type": 1}}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf",
+                "instanceLocation": "#/definitions/foo/type",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref/enum",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes/enum",
+                "instanceLocation": "#/definitions/foo/type",
+                "keyword": "enum",
+                "error": "1 does not match any of the required values."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/type",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/type",
+                "instanceLocation": "#/definitions/foo/type",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf",
+            "instanceLocation": "#/definitions/foo/type",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref/enum",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes/enum",
+                "instanceLocation": "#/definitions/foo/type",
+                "keyword": "enum",
+                "error": "1 does not match any of the required values."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/type",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/type",
+                "instanceLocation": "#/definitions/foo/type",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                "instanceLocation": "#",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/title",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                    "instanceLocation": "#",
+                    "keyword": "title",
+                    "annotation": "Core schema meta-schema"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/definitions",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                    "instanceLocation": "#",
+                    "keyword": "definitions"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/properties",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                    "instanceLocation": "#",
+                    "keyword": "properties",
+                    "error": "At least one subschema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/$ref/properties/definitions",
+                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions",
+                        "instanceLocation": "#/definitions",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/definitions/type",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/type",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/definitions/default",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/default",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "default",
+                            "annotation": {}
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/additionalProperties",
+                            "instanceLocation": "#/definitions",
+                            "keyword": "additionalProperties",
+                            "error": "Any properties not covered by `properties` and `patternProperties` failed validation.",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref",
+                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/definitions/additionalProperties/$ref",
+                                "instanceLocation": "#/definitions/foo",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                                    "instanceLocation": "#/definitions/foo",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/title",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "title",
+                                        "annotation": "Core schema meta-schema"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/definitions",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "definitions"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/type",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "properties",
+                                        "error": "At least one subschema failed validation.",
+                                        "errors": [
+                                          {
+                                            "valid": false,
+                                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type",
+                                            "instanceLocation": "#/definitions/foo/type",
+                                            "errors": [
+                                              {
+                                                "valid": false,
+                                                "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf",
+                                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf",
+                                                "instanceLocation": "#/definitions/foo/type",
+                                                "keyword": "anyOf",
+                                                "errors": [
+                                                  {
+                                                    "valid": false,
+                                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref",
+                                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/0/$ref",
+                                                    "instanceLocation": "#/definitions/foo/type",
+                                                    "keyword": "$ref",
+                                                    "errors": [
+                                                      {
+                                                        "valid": false,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "errors": [
+                                                          {
+                                                            "valid": false,
+                                                            "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/0/$ref/enum",
+                                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes/enum",
+                                                            "instanceLocation": "#/definitions/foo/type",
+                                                            "keyword": "enum",
+                                                            "error": "1 does not match any of the required values."
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": false,
+                                                    "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1",
+                                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1",
+                                                    "instanceLocation": "#/definitions/foo/type",
+                                                    "errors": [
+                                                      {
+                                                        "valid": false,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/type",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/type",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "type",
+                                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/items",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/items",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "items"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/minItems",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/minItems",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "minItems"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/properties/type/anyOf/1/uniqueItems",
+                                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/uniqueItems",
+                                                        "instanceLocation": "#/definitions/foo/type",
+                                                        "keyword": "uniqueItems"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/definitions/additionalProperties/$ref/default",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                                        "instanceLocation": "#/definitions/foo",
+                                        "keyword": "default",
+                                        "annotation": true
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/default",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                    "instanceLocation": "#",
+                    "keyword": "default",
+                    "annotation": true
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/dependencies.json
+++ b/tests/draft2019-04/dependencies.json
@@ -1,0 +1,1792 @@
+[
+  {
+    "description": "dependencies",
+    "schema": {"dependencies": {"bar": ["foo"]}},
+    "tests": [
+      {
+        "description": "neither",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "nondependant",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "with dependency",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing dependency",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/bar",
+            "error": "Properties [\"foo\"] are required when \"bar\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/bar",
+            "error": "Properties [\"foo\"] are required when \"bar\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/bar",
+                    "error": "Properties [\"foo\"] are required when \"bar\" is present."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": ["bar"],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "dependencies with empty array",
+    "schema": {"dependencies": {"bar": []}},
+    "tests": [
+      {
+        "description": "empty object",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with one property",
+        "data": {"bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "multiple dependencies",
+    "schema": {"dependencies": {"quux": ["foo", "bar"]}},
+    "tests": [
+      {
+        "description": "neither",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "quux"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "nondependants",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "quux"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "with dependencies",
+        "data": {"foo": 1, "bar": 2, "quux": 3},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "quux"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing dependency",
+        "data": {"foo": 1, "quux": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"bar\"] are required when \"quux\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"bar\"] are required when \"quux\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/quux",
+                    "error": "Properties [\"bar\"] are required when \"quux\" is present."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing other dependency",
+        "data": {"bar": 1, "quux": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"foo\"] are required when \"quux\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"foo\"] are required when \"quux\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/quux",
+                    "error": "Properties [\"foo\"] are required when \"quux\" is present."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing both dependencies",
+        "data": {"quux": 1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"foo\",\"bar\"] are required when \"quux\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/quux",
+            "instanceLocation": "#",
+            "keyword": "dependencies/quux",
+            "error": "Properties [\"foo\",\"bar\"] are required when \"quux\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/quux",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/quux",
+                    "error": "Properties [\"foo\",\"bar\"] are required when \"quux\" is present."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "multiple dependencies subschema",
+    "schema": {
+      "dependencies": {
+        "bar": {
+          "properties": {"foo": {"type": "integer"}, "bar": {"type": "integer"}}
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "no dependency",
+        "data": {"foo": "quux"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong type",
+        "data": {"foo": "quux", "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar/properties/foo/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar/properties/foo/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/bar",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/dependencies/bar/properties",
+                            "instanceLocation": "#",
+                            "keyword": "properties",
+                            "error": "At least one subschema failed validation.",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/dependencies/bar/properties/foo",
+                                "instanceLocation": "#/foo",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/dependencies/bar/properties/foo/type",
+                                    "instanceLocation": "#/foo",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/dependencies/bar/properties/bar",
+                                "instanceLocation": "#/bar",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/dependencies/bar/properties/bar/type",
+                                    "instanceLocation": "#/bar",
+                                    "keyword": "type"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong type other",
+        "data": {"foo": 2, "bar": "quux"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/bar",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/dependencies/bar/properties",
+                            "instanceLocation": "#",
+                            "keyword": "properties",
+                            "error": "At least one subschema failed validation.",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/dependencies/bar/properties/foo",
+                                "instanceLocation": "#/foo",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/dependencies/bar/properties/foo/type",
+                                    "instanceLocation": "#/foo",
+                                    "keyword": "type"
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/dependencies/bar/properties/bar",
+                                "instanceLocation": "#/bar",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/dependencies/bar/properties/bar/type",
+                                    "instanceLocation": "#/bar",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong type both",
+        "data": {"foo": "quux", "bar": "quux"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies/bar/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies/bar/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies/bar/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar/properties",
+            "instanceLocation": "#",
+            "keyword": "properties",
+            "error": "At least one subschema failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies/bar/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies/bar/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 1 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/bar",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/dependencies/bar/properties",
+                            "instanceLocation": "#",
+                            "keyword": "properties",
+                            "error": "At least one subschema failed validation.",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/dependencies/bar/properties/foo",
+                                "instanceLocation": "#/foo",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/dependencies/bar/properties/foo/type",
+                                    "instanceLocation": "#/foo",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/dependencies/bar/properties/bar",
+                                "instanceLocation": "#/bar",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/dependencies/bar/properties/bar/type",
+                                    "instanceLocation": "#/bar",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "dependencies with boolean subschemas",
+    "schema": {"dependencies": {"foo": true, "bar": false}},
+    "tests": [
+      {
+        "description": "object with property having schema true is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with property having schema false is invalid",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 2 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/bar",
+                        "instanceLocation": "#",
+                        "error": "No value is valid against the false schema."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with both properties is invalid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/bar",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 2 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/bar",
+                        "instanceLocation": "#",
+                        "error": "No value is valid against the false schema."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/bar",
+                    "instanceLocation": "#",
+                    "keyword": "bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "empty array of dependencies",
+    "schema": {"dependencies": {"foo": []}},
+    "tests": [
+      {
+        "description": "object with property is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-object is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo",
+                    "instanceLocation": "#",
+                    "keyword": "foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "dependencies with escaped characters",
+    "schema": {
+      "dependencies": {
+        "foo\nbar": ["foo\rbar"],
+        "foo\tbar": {"minProperties": 4},
+        "foo'bar": {"required": ["foo\"bar"]},
+        "foo\"bar": ["foo'bar"]
+      }
+    },
+    "tests": [
+      {
+        "description": "valid object 1",
+        "data": {"foo\nbar": 1, "foo\rbar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid object 2",
+        "data": {"foo\tbar": 1, "a": 2, "b": 3, "c": 4},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid object 3",
+        "data": {"foo'bar": 1, "foo\"bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid object 1",
+        "data": {"foo\nbar": 1, "foo": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\nbar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/foo\nbar",
+            "error": "Properties [\"foo\rbar\"] are required when \"foo\nbar\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\nbar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/foo\nbar",
+            "error": "Properties [\"foo\rbar\"] are required when \"foo\nbar\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 4 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/foo\nbar",
+                    "error": "Properties [\"foo\rbar\"] are required when \"foo\nbar\" is present."
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid object 2",
+        "data": {"foo\tbar": 1, "a": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\tbar/minProperties",
+            "instanceLocation": "#",
+            "keyword": "minProperties",
+            "error": "The array should contain at least 4 properties, but 2 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\tbar/minProperties",
+            "instanceLocation": "#",
+            "keyword": "minProperties",
+            "error": "The array should contain at least 4 properties, but 2 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 4 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.foo\tbar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/foo\tbar",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/dependencies/foo\tbar/minProperties",
+                            "instanceLocation": "#",
+                            "keyword": "minProperties",
+                            "error": "The array should contain at least 4 properties, but 2 were found."
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid object 3",
+        "data": {"foo'bar": 1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo'bar/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\\\"bar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo'bar/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\\\"bar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 4 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies.foo'bar",
+                    "error": "The schema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/dependencies/foo'bar",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/dependencies/foo'bar/required",
+                            "instanceLocation": "#",
+                            "keyword": "required",
+                            "error": "The properties [\"foo\\\"bar\"] are required."
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\"bar"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid object 4",
+        "data": {"foo\"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\"bar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/foo\"bar",
+            "error": "Properties [\"foo'bar\"] are required when \"foo\\\"bar\" is present."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/dependencies/foo\"bar",
+            "instanceLocation": "#",
+            "keyword": "dependencies/foo\"bar",
+            "error": "Properties [\"foo'bar\"] are required when \"foo\\\"bar\" is present."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/dependencies",
+                "instanceLocation": "#",
+                "keyword": "dependencies",
+                "error": "1 of 4 dependencies failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\nbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\nbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo\tbar",
+                    "instanceLocation": "#",
+                    "keyword": "foo\tbar"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/dependencies/foo'bar",
+                    "instanceLocation": "#",
+                    "keyword": "foo'bar"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/dependencies/foo\"bar",
+                    "instanceLocation": "#",
+                    "keyword": "dependencies/foo\"bar",
+                    "error": "Properties [\"foo'bar\"] are required when \"foo\\\"bar\" is present."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/enum.json
+++ b/tests/draft2019-04/enum.json
@@ -1,0 +1,526 @@
+[
+  {
+    "description": "simple enum validation",
+    "schema": {"enum": [1, 2, 3]},
+    "tests": [
+      {
+        "description": "one of the enum is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "something else is invalid",
+        "data": 4,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "4 does not match any of the required values."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "4 does not match any of the required values."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum",
+                "error": "4 does not match any of the required values."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "heterogeneous enum validation",
+    "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+    "tests": [
+      {
+        "description": "one of the enum is valid",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "something else is invalid",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "null does not match any of the required values."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "null does not match any of the required values."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum",
+                "error": "null does not match any of the required values."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "objects are deep compared",
+        "data": {"foo": false},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "{\"foo\":false} does not match any of the required values."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "{\"foo\":false} does not match any of the required values."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum",
+                "error": "{\"foo\":false} does not match any of the required values."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "enums in properties",
+    "schema": {
+      "type": "object",
+      "properties": {"foo": {"enum": ["foo"]}, "bar": {"enum": ["bar"]}},
+      "required": ["bar"]
+    },
+    "tests": [
+      {
+        "description": "both properties are valid",
+        "data": {"foo": "foo", "bar": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/enum",
+                        "instanceLocation": "#/foo",
+                        "keyword": "enum"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/enum",
+                        "instanceLocation": "#/bar",
+                        "keyword": "enum"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing optional property is valid",
+        "data": {"bar": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/enum",
+                        "instanceLocation": "#/bar",
+                        "keyword": "enum"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing required property is invalid",
+        "data": {"foo": "foo"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/enum",
+                        "instanceLocation": "#/foo",
+                        "keyword": "enum"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"bar\"] are required."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "missing all properties is invalid",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"bar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"bar\"] are required."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "enum with escaped characters",
+    "schema": {"enum": ["foo\nbar", "foo\rbar"]},
+    "tests": [
+      {
+        "description": "member 1 is valid",
+        "data": "foo\nbar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "member 2 is valid",
+        "data": "foo\rbar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "another string is invalid",
+        "data": "abc",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "\"abc\" does not match any of the required values."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/enum",
+            "instanceLocation": "#",
+            "keyword": "enum",
+            "error": "\"abc\" does not match any of the required values."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/enum",
+                "instanceLocation": "#",
+                "keyword": "enum",
+                "error": "\"abc\" does not match any of the required values."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/exclusiveMaximum.json
+++ b/tests/draft2019-04/exclusiveMaximum.json
@@ -1,0 +1,132 @@
+[
+  {
+    "description": "exclusiveMaximum validation",
+    "schema": {"exclusiveMaximum": 3},
+    "tests": [
+      {
+        "description": "below the exclusiveMaximum is valid",
+        "data": 2.2,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/exclusiveMaximum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMaximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "boundary point is invalid",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMaximum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMaximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "above the exclusiveMaximum is invalid",
+        "data": 3.5,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMaximum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMaximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "x",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/exclusiveMaximum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMaximum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/exclusiveMinimum.json
+++ b/tests/draft2019-04/exclusiveMinimum.json
@@ -1,0 +1,132 @@
+[
+  {
+    "description": "exclusiveMinimum validation",
+    "schema": {"exclusiveMinimum": 1.1},
+    "tests": [
+      {
+        "description": "above the exclusiveMinimum is valid",
+        "data": 1.2,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/exclusiveMinimum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMinimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "boundary point is invalid",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMinimum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMinimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "below the exclusiveMinimum is invalid",
+        "data": 0.6,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMinimum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMinimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "x",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/exclusiveMinimum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMinimum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/if-then-else.json
+++ b/tests/draft2019-04/if-then-else.json
@@ -1,0 +1,648 @@
+[
+  {
+    "description": "ignore if without then or else",
+    "schema": {"if": {"const": 0}},
+    "tests": [
+      {
+        "description": "valid when valid against lone if",
+        "data": 0,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "valid when invalid against lone if",
+        "data": "hello",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "ignore then without if",
+    "schema": {"then": {"const": 0}},
+    "tests": [
+      {
+        "description": "valid when valid against lone then",
+        "data": 0,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "valid when invalid against lone then",
+        "data": "hello",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "ignore else without if",
+    "schema": {"else": {"const": 0}},
+    "tests": [
+      {
+        "description": "valid when valid against lone else",
+        "data": 0,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "valid when invalid against lone else",
+        "data": "hello",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "if and then without else",
+    "schema": {"if": {"exclusiveMaximum": 0}, "then": {"minimum": -10}},
+    "tests": [
+      {
+        "description": "valid through then",
+        "data": -1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "if"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid through then",
+        "data": -100,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/then/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -100 should be at least -10."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/then/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -100 should be at least -10."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "then",
+                "error": "Validation of `if` succeeded, but validation of `then` failed",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/then",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/then/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value -100 should be at least -10."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid when if test fails",
+        "data": 3,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "if and else without then",
+    "schema": {"if": {"exclusiveMaximum": 0}, "else": {"multipleOf": 2}},
+    "tests": [
+      {
+        "description": "valid when if test passes",
+        "data": -1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          }
+        }
+      },
+      {
+        "description": "valid through else",
+        "data": 4,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "if"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid through else",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/else/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/else/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "else",
+                "error": "Validation of `if` failed, but validation of `else` also failed",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/else",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/else/multipleOf",
+                        "instanceLocation": "#",
+                        "keyword": "multipleOf",
+                        "error": "1 should be a multiple of 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "validate against correct branch, then vs else",
+    "schema": {
+      "if": {"exclusiveMaximum": 0},
+      "then": {"minimum": -10},
+      "else": {"multipleOf": 2}
+    },
+    "tests": [
+      {
+        "description": "valid through then",
+        "data": -1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "if"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid through then",
+        "data": -100,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/then/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -100 should be at least -10."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/then/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -100 should be at least -10."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "then",
+                "error": "Validation of `if` succeeded, but validation of `then` failed",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/then",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/then/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value -100 should be at least -10."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid through else",
+        "data": 4,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "if"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid through else",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/else/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/else/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/if",
+                "instanceLocation": "#",
+                "keyword": "else",
+                "error": "Validation of `if` failed, but validation of `else` also failed",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/else",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/else/multipleOf",
+                        "instanceLocation": "#",
+                        "keyword": "multipleOf",
+                        "error": "1 should be a multiple of 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "non-interference across combined schemas",
+    "schema": {
+      "allOf": [
+        {"if": {"exclusiveMaximum": 0}},
+        {"then": {"minimum": -10}},
+        {"else": {"multipleOf": 2}}
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid, but woud have been invalid through then",
+        "data": -100,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/2",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid, but would have been invalid through else",
+        "data": 3,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/allOf",
+                "instanceLocation": "#",
+                "keyword": "allOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/1",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/allOf/2",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/items.json
+++ b/tests/draft2019-04/items.json
@@ -1,0 +1,3834 @@
+[
+  {
+    "description": "a schema given for items",
+    "schema": {"items": {"type": "integer"}},
+    "tests": [
+      {
+        "description": "valid items",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/2",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/2",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong type of items",
+        "data": [1, "x"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/type",
+            "instanceLocation": "#/1",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/type",
+            "instanceLocation": "#/1",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": {"foo": "bar"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "JavaScript pseudo-array is valid",
+        "data": {"0": "invalid", "length": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "an array of schemas for items",
+    "schema": {"items": [{"type": "integer"}, {"type": "string"}]},
+    "tests": [
+      {
+        "description": "correct types",
+        "data": [1, "foo"],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong types",
+        "data": ["foo", 1],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/0/type",
+                "instanceLocation": "#/0",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/1/type",
+                "instanceLocation": "#/1",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items",
+            "instanceLocation": "#",
+            "keyword": "items",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items/0/type",
+                "instanceLocation": "#/0",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/1/type",
+                "instanceLocation": "#/1",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/1/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "incomplete array of items",
+        "data": [1],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with additional items",
+        "data": [1, "foo", true],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "JavaScript pseudo-array is valid",
+        "data": {"0": "invalid", "1": "valid", "length": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "items with boolean schema (true)",
+    "schema": {"items": true},
+    "tests": [
+      {
+        "description": "any array is valid",
+        "data": [1, "foo", true],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is valid",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "items with boolean schema (false)",
+    "schema": {"items": false},
+    "tests": [
+      {
+        "description": "any non-empty array is invalid",
+        "data": [1, "foo", true],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/0",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/1",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/2",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items",
+            "instanceLocation": "#",
+            "keyword": "items",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/0",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/1",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#/2",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/2",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is valid",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "items with boolean schemas",
+    "schema": {"items": [true, false]},
+    "tests": [
+      {
+        "description": "array with one item is valid",
+        "data": [1],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "array with two items is invalid",
+        "data": [1, "foo"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/1",
+            "instanceLocation": "#/1",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/1",
+            "instanceLocation": "#/1",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/1",
+                    "instanceLocation": "#/1",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty array is valid",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "items and subitems",
+    "schema": {
+      "definitions": {
+        "item": {
+          "type": "array",
+          "additionalItems": false,
+          "items": [
+            {"$ref": "#/definitions/sub-item"},
+            {"$ref": "#/definitions/sub-item"}
+          ]
+        },
+        "sub-item": {"type": "object", "required": ["foo"]}
+      },
+      "type": "array",
+      "additionalItems": false,
+      "items": [
+        {"$ref": "#/definitions/item"},
+        {"$ref": "#/definitions/item"},
+        {"$ref": "#/definitions/item"}
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid items",
+        "data": [
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}]
+        ],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                    "instanceLocation": "#/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                    "instanceLocation": "#/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                    "instanceLocation": "#/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2/$ref",
+                    "instanceLocation": "#/2",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/2/$ref",
+                        "instanceLocation": "#/2",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/type",
+                            "instanceLocation": "#/2",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/items",
+                            "instanceLocation": "#/2",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                "instanceLocation": "#/2/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                    "instanceLocation": "#/2/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                "instanceLocation": "#/2/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                    "instanceLocation": "#/2/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/additionalItems",
+                            "instanceLocation": "#/2",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too many items",
+        "data": [
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}]
+        ],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems",
+            "instanceLocation": "#",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalItems",
+            "instanceLocation": "#",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                    "instanceLocation": "#/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                    "instanceLocation": "#/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                    "instanceLocation": "#/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2/$ref",
+                    "instanceLocation": "#/2",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/2/$ref",
+                        "instanceLocation": "#/2",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/type",
+                            "instanceLocation": "#/2",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/items",
+                            "instanceLocation": "#/2",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                "instanceLocation": "#/2/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                    "instanceLocation": "#/2/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                "instanceLocation": "#/2/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                    "instanceLocation": "#/2/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/additionalItems",
+                            "instanceLocation": "#/2",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems",
+                "error": "Items not covered by `items` are not allowed."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too many sub-items",
+        "data": [
+          [{"foo": null}, {"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}]
+        ],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/additionalItems",
+            "instanceLocation": "#/0",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/additionalItems",
+            "instanceLocation": "#/0",
+            "keyword": "additionalItems",
+            "error": "Items not covered by `items` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                    "instanceLocation": "#/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                    "instanceLocation": "#/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems",
+                            "error": "Items not covered by `items` are not allowed."
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                    "instanceLocation": "#/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2/$ref",
+                    "instanceLocation": "#/2",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/2/$ref",
+                        "instanceLocation": "#/2",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/type",
+                            "instanceLocation": "#/2",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/items",
+                            "instanceLocation": "#/2",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                "instanceLocation": "#/2/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                    "instanceLocation": "#/2/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                "instanceLocation": "#/2/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                    "instanceLocation": "#/2/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/additionalItems",
+                            "instanceLocation": "#/2",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong item",
+        "data": [
+          {"foo": null},
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}]
+        ],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/type",
+            "instanceLocation": "#/0",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/type",
+            "instanceLocation": "#/0",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type",
+                            "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                    "instanceLocation": "#/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2/$ref",
+                    "instanceLocation": "#/2",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/2/$ref",
+                        "instanceLocation": "#/2",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/type",
+                            "instanceLocation": "#/2",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/items",
+                            "instanceLocation": "#/2",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                "instanceLocation": "#/2/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                    "instanceLocation": "#/2/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                "instanceLocation": "#/2/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                    "instanceLocation": "#/2/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/additionalItems",
+                            "instanceLocation": "#/2",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "wrong sub-item",
+        "data": [
+          [{}, {"foo": null}],
+          [{"foo": null}, {"foo": null}],
+          [{"foo": null}, {"foo": null}]
+        ],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+            "instanceLocation": "#/0/0",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+            "instanceLocation": "#/0/0",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                    "instanceLocation": "#/0/0",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "required",
+                                        "error": "The properties [\"foo\"] are required."
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/1/$ref",
+                                    "instanceLocation": "#/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/0/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/1/$ref",
+                                    "instanceLocation": "#/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/1/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/2/$ref",
+                    "instanceLocation": "#/2",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/2/$ref",
+                        "instanceLocation": "#/2",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/type",
+                            "instanceLocation": "#/2",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/items",
+                            "instanceLocation": "#/2",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                "instanceLocation": "#/2/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/0/$ref",
+                                    "instanceLocation": "#/2/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/2/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                "instanceLocation": "#/2/1",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/2/$ref/items/1/$ref",
+                                    "instanceLocation": "#/2/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/type",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/2/$ref/items/1/$ref/required",
+                                        "instanceLocation": "#/2/1",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/2/$ref/additionalItems",
+                            "instanceLocation": "#/2",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "fewer items is valid",
+        "data": [[{"foo": null}], [{"foo": null}]],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0/$ref",
+                    "instanceLocation": "#/0",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/$ref",
+                        "instanceLocation": "#/0",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/type",
+                            "instanceLocation": "#/0",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/items",
+                            "instanceLocation": "#/0",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/0/$ref/items/0/$ref",
+                                    "instanceLocation": "#/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/0/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/0/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/0/$ref/additionalItems",
+                            "instanceLocation": "#/0",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/items",
+                            "instanceLocation": "#/1",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/1/$ref/items/0/$ref",
+                                    "instanceLocation": "#/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/type",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/1/$ref/items/0/$ref/required",
+                                        "instanceLocation": "#/1/0",
+                                        "keyword": "required"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/additionalItems",
+                            "instanceLocation": "#/1",
+                            "keyword": "additionalItems"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalItems",
+                "instanceLocation": "#",
+                "keyword": "additionalItems"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "nested items",
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {"type": "array", "items": {"type": "number"}}
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid nested array",
+        "data": [[[[1]], [[2], [3]]], [[[4], [5], [6]]]],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/0",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/0",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "items",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/0/0/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/0/0/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/1",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "items",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/1/0/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/1/0/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/1/1",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/1/1/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/1/1/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/1",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/1/0",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "items",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/0/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/0/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/1",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/1/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/1/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/2",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/2",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/2",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/2/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/2/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "nested array with invalid type",
+        "data": [[[["1"]], [[2], [3]]], [[[4], [5], [6]]]],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/items/items/items/type",
+            "instanceLocation": "#/0/0/0/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/items/items/items/type",
+            "instanceLocation": "#/0/0/0/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/0",
+                        "keyword": "items",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/0",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/0/0",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "items",
+                                        "errors": [
+                                          {
+                                            "valid": false,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/0/0/0",
+                                            "errors": [
+                                              {
+                                                "valid": false,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/0/0/0",
+                                                "keyword": "type",
+                                                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/1",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "items",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/1/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/1/0/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/1/0/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/1/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/1/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/1/1",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/0/1/1/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/0/1/1/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/1",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/1/0",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "items",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/0/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/0/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/1",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/1",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/1",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/1/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/1/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/2",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/2",
+                                        "keyword": "type"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/2",
+                                        "keyword": "items",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/items/items/items/items",
+                                            "instanceLocation": "#/1/0/2/0",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/items/items/items/items/type",
+                                                "instanceLocation": "#/1/0/2/0",
+                                                "keyword": "type"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "not deep enough",
+        "data": [[[1], [2], [3]], [[4], [5], [6]]],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items",
+                "instanceLocation": "#/0",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/0/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/1/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/2/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items",
+                "instanceLocation": "#/1",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/0/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/1/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/2/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/0/0/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/0/1/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/0/2/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/1/0/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/1/1/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items/items/type",
+                "instanceLocation": "#/1/2/0",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items",
+            "instanceLocation": "#",
+            "keyword": "items",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items",
+                "instanceLocation": "#/0",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/0/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/1/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/0/2/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items/items",
+                "instanceLocation": "#/1",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/0/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/1/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/items/items/type",
+                    "instanceLocation": "#/1/2/0",
+                    "keyword": "type",
+                    "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                  }
+                ]
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/0",
+                        "keyword": "items",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/0",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/0",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/0/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/0/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/1",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/1",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/1/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/1/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/0/2",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/0/2",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/0/2",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/0/2/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/0/2/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/0/2/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/1",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/type",
+                        "instanceLocation": "#/1",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/1",
+                        "keyword": "items",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/1/0",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/1/0",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/0/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/0/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/1/1",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/1/1",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/1/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/1/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/1/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items",
+                            "instanceLocation": "#/1/2",
+                            "errors": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/type",
+                                "instanceLocation": "#/1/2",
+                                "keyword": "type"
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/items",
+                                "instanceLocation": "#/1/2",
+                                "keyword": "items",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/items",
+                                    "instanceLocation": "#/1/2/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/items/items/items/type",
+                                        "instanceLocation": "#/1/2/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/items/items/items/items",
+                                        "instanceLocation": "#/1/2/0",
+                                        "keyword": "items"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/maxItems.json
+++ b/tests/draft2019-04/maxItems.json
@@ -1,0 +1,133 @@
+[
+  {
+    "description": "maxItems validation",
+    "schema": {"maxItems": 2},
+    "tests": [
+      {
+        "description": "shorter is valid",
+        "data": [1],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxItems",
+                "instanceLocation": "#",
+                "keyword": "maxItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": [1, 2],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxItems",
+                "instanceLocation": "#",
+                "keyword": "maxItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too long is invalid",
+        "data": [1, 2, 3],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/maxItems",
+            "instanceLocation": "#",
+            "keyword": "maxItems",
+            "error": "The array should contain at most 2 items, but 3 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/maxItems",
+            "instanceLocation": "#",
+            "keyword": "maxItems",
+            "error": "The array should contain at most 2 items, but 3 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/maxItems",
+                "instanceLocation": "#",
+                "keyword": "maxItems",
+                "error": "The array should contain at most 2 items, but 3 were found."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxItems",
+                "instanceLocation": "#",
+                "keyword": "maxItems"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/maxLength.json
+++ b/tests/draft2019-04/maxLength.json
@@ -1,0 +1,163 @@
+[
+  {
+    "description": "maxLength validation",
+    "schema": {"maxLength": 2},
+    "tests": [
+      {
+        "description": "shorter is valid",
+        "data": "f",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": "fo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too long is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/maxLength",
+            "instanceLocation": "#",
+            "keyword": "maxLength",
+            "error": "The string should be at most 2 characters long, but was 3."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/maxLength",
+            "instanceLocation": "#",
+            "keyword": "maxLength",
+            "error": "The string should be at most 2 characters long, but was 3."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength",
+                "error": "The string should be at most 2 characters long, but was 3."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 100,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "two supplementary Unicode code points is long enough",
+        "data": "💩💩",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxLength",
+                "instanceLocation": "#",
+                "keyword": "maxLength"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/maxProperties.json
+++ b/tests/draft2019-04/maxProperties.json
@@ -1,0 +1,193 @@
+[
+  {
+    "description": "maxProperties validation",
+    "schema": {"maxProperties": 2},
+    "tests": [
+      {
+        "description": "shorter is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too long is invalid",
+        "data": {"foo": 1, "bar": 2, "baz": 3},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/maxProperties",
+            "instanceLocation": "#",
+            "keyword": "maxProperties",
+            "error": "The array should contain at most 2 properties, but 3 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/maxProperties",
+            "instanceLocation": "#",
+            "keyword": "maxProperties",
+            "error": "The array should contain at most 2 properties, but 3 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties",
+                "error": "The array should contain at most 2 properties, but 3 were found."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maxProperties",
+                "instanceLocation": "#",
+                "keyword": "maxProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/maximum.json
+++ b/tests/draft2019-04/maximum.json
@@ -1,0 +1,133 @@
+[
+  {
+    "description": "maximum validation",
+    "schema": {"maximum": 3},
+    "tests": [
+      {
+        "description": "below the maximum is valid",
+        "data": 2.6,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maximum",
+                "instanceLocation": "#",
+                "keyword": "maximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "boundary point is valid",
+        "data": 3,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maximum",
+                "instanceLocation": "#",
+                "keyword": "maximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "above the maximum is invalid",
+        "data": 3.5,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/maximum",
+            "instanceLocation": "#",
+            "keyword": "maximum",
+            "error": "The value 3.5 should be at most 3."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/maximum",
+            "instanceLocation": "#",
+            "keyword": "maximum",
+            "error": "The value 3.5 should be at most 3."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/maximum",
+                "instanceLocation": "#",
+                "keyword": "maximum",
+                "error": "The value 3.5 should be at most 3."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "x",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maximum",
+                "instanceLocation": "#",
+                "keyword": "maximum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/minItems.json
+++ b/tests/draft2019-04/minItems.json
@@ -1,0 +1,133 @@
+[
+  {
+    "description": "minItems validation",
+    "schema": {"minItems": 1},
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": [1, 2],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minItems",
+                "instanceLocation": "#",
+                "keyword": "minItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": [1],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minItems",
+                "instanceLocation": "#",
+                "keyword": "minItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too short is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minItems",
+            "instanceLocation": "#",
+            "keyword": "minItems",
+            "error": "The array should contain at least 1 items, but 0 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minItems",
+            "instanceLocation": "#",
+            "keyword": "minItems",
+            "error": "The array should contain at least 1 items, but 0 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minItems",
+                "instanceLocation": "#",
+                "keyword": "minItems",
+                "error": "The array should contain at least 1 items, but 0 were found."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": "",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minItems",
+                "instanceLocation": "#",
+                "keyword": "minItems"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/minLength.json
+++ b/tests/draft2019-04/minLength.json
@@ -1,0 +1,168 @@
+[
+  {
+    "description": "minLength validation",
+    "schema": {"minLength": 2},
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": "fo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too short is invalid",
+        "data": "f",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minLength",
+            "instanceLocation": "#",
+            "keyword": "minLength",
+            "error": "The string should be at least 2 characters long, but was 1."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minLength",
+            "instanceLocation": "#",
+            "keyword": "minLength",
+            "error": "The string should be at least 2 characters long, but was 1."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength",
+                "error": "The string should be at least 2 characters long, but was 1."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "one supplementary Unicode code point is not long enough",
+        "data": "💩",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minLength",
+            "instanceLocation": "#",
+            "keyword": "minLength",
+            "error": "The string should be at least 2 characters long, but was 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minLength",
+            "instanceLocation": "#",
+            "keyword": "minLength",
+            "error": "The string should be at least 2 characters long, but was 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minLength",
+                "instanceLocation": "#",
+                "keyword": "minLength",
+                "error": "The string should be at least 2 characters long, but was 2."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/minProperties.json
+++ b/tests/draft2019-04/minProperties.json
@@ -1,0 +1,193 @@
+[
+  {
+    "description": "minProperties validation",
+    "schema": {"minProperties": 1},
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "exact length is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "too short is invalid",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minProperties",
+            "instanceLocation": "#",
+            "keyword": "minProperties",
+            "error": "The array should contain at least 1 properties, but 0 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minProperties",
+            "instanceLocation": "#",
+            "keyword": "minProperties",
+            "error": "The array should contain at least 1 properties, but 0 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties",
+                "error": "The array should contain at least 1 properties, but 0 were found."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minProperties",
+                "instanceLocation": "#",
+                "keyword": "minProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/minimum.json
+++ b/tests/draft2019-04/minimum.json
@@ -1,0 +1,294 @@
+[
+  {
+    "description": "minimum validation",
+    "schema": {"minimum": 1.1},
+    "tests": [
+      {
+        "description": "above the minimum is valid",
+        "data": 2.6,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "boundary point is valid",
+        "data": 1.1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "below the minimum is invalid",
+        "data": 0.6,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value 0.6 should be at least 1.1."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value 0.6 should be at least 1.1."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value 0.6 should be at least 1.1."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "x",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "minimum validation with signed integer",
+    "schema": {"minimum": -2},
+    "tests": [
+      {
+        "description": "negative above the minimum is valid",
+        "data": -1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "positive above the minimum is valid",
+        "data": 0,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "boundary point is valid",
+        "data": -2,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "below the minimum is invalid",
+        "data": -3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -3 should be at least -2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/minimum",
+            "instanceLocation": "#",
+            "keyword": "minimum",
+            "error": "The value -3 should be at least -2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value -3 should be at least -2."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "x",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/multipleOf.json
+++ b/tests/draft2019-04/multipleOf.json
@@ -1,0 +1,275 @@
+[
+  {
+    "description": "by int",
+    "schema": {"multipleOf": 2},
+    "tests": [
+      {
+        "description": "int by int",
+        "data": 10,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "int by int fail",
+        "data": 7,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "1 should be a multiple of 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf",
+                "error": "1 should be a multiple of 2."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-numbers",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "by number",
+    "schema": {"multipleOf": 1.5},
+    "tests": [
+      {
+        "description": "zero is multiple of anything",
+        "data": 0,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "4.5 is multiple of 1.5",
+        "data": 4.5,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "35 is not multiple of 1.5",
+        "data": 35,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "0.5 should be a multiple of 1.5."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "0.5 should be a multiple of 1.5."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf",
+                "error": "0.5 should be a multiple of 1.5."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "by small number",
+    "schema": {"multipleOf": 0.0001},
+    "tests": [
+      {
+        "description": "0.0075 is multiple of 0.0001",
+        "data": 0.0075,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "0.00751 is not multiple of 0.0001",
+        "data": 0.00751,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "9.99999999999982E-06 should be a multiple of 0.0001."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/multipleOf",
+            "instanceLocation": "#",
+            "keyword": "multipleOf",
+            "error": "9.99999999999982E-06 should be a multiple of 0.0001."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/multipleOf",
+                "instanceLocation": "#",
+                "keyword": "multipleOf",
+                "error": "9.99999999999982E-06 should be a multiple of 0.0001."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/not.json
+++ b/tests/draft2019-04/not.json
@@ -1,0 +1,446 @@
+[
+  {
+    "description": "not",
+    "schema": {"not": {"type": "integer"}},
+    "tests": [
+      {
+        "description": "allowed",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "disallowed",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not",
+                "error": "Value should not validate against the schema."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "not multiple types",
+    "schema": {"not": {"type": ["boolean", "integer"]}},
+    "tests": [
+      {
+        "description": "valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not",
+                "error": "Value should not validate against the schema."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "other mismatch",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not",
+                "error": "Value should not validate against the schema."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "not more complex schema",
+    "schema": {
+      "not": {"type": "object", "properties": {"foo": {"type": "string"}}}
+    },
+    "tests": [
+      {
+        "description": "match",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "other match",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch",
+        "data": {"foo": "bar"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not",
+                "error": "Value should not validate against the schema."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "forbidden property",
+    "schema": {"properties": {"foo": {"not": {}}}},
+    "tests": [
+      {
+        "description": "property present",
+        "data": {"foo": 1, "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/not",
+            "instanceLocation": "#/foo",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/not",
+            "instanceLocation": "#/foo",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo/not",
+                        "instanceLocation": "#/foo",
+                        "keyword": "not",
+                        "error": "Value should not validate against the schema."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "property absent",
+        "data": {"bar": 1, "baz": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "not with boolean schema true",
+    "schema": {"not": true},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/not",
+            "instanceLocation": "#",
+            "keyword": "not",
+            "error": "Value should not validate against the schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not",
+                "error": "Value should not validate against the schema."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "not with boolean schema false",
+    "schema": {"not": false},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/not",
+                "instanceLocation": "#",
+                "keyword": "not"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/oneOf.json
+++ b/tests/draft2019-04/oneOf.json
@@ -1,0 +1,1658 @@
+[
+  {
+    "description": "oneOf",
+    "schema": {"oneOf": [{"type": "integer"}, {"minimum": 2}]},
+    "tests": [
+      {
+        "description": "first oneOf valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value 1 should be at least 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "second oneOf valid",
+        "data": 2.5,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both oneOf valid",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "neither oneOf valid",
+        "data": 1.5,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value 1.5 should be at least 2."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 0.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum",
+                "error": "The value 1.5 should be at least 2."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/minimum",
+                        "instanceLocation": "#",
+                        "keyword": "minimum",
+                        "error": "The value 1.5 should be at least 2."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with base schema",
+    "schema": {"type": "string", "oneOf": [{"minLength": 2}, {"maxLength": 4}]},
+    "tests": [
+      {
+        "description": "mismatch base schema",
+        "data": 3,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {"valid": false, "keywordLocation": "#", "instanceLocation": "#"},
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "one oneOf valid",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength",
+                        "error": "The string should be at most 4 characters long, but was 6."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both oneOf valid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/minLength",
+                        "instanceLocation": "#",
+                        "keyword": "minLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/maxLength",
+                        "instanceLocation": "#",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with boolean schemas, all true",
+    "schema": {"oneOf": [true, true, true]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 3."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 3."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 3.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/2",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with boolean schemas, one true",
+    "schema": {"oneOf": [true, false, false]},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/2",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with boolean schemas, more than one true",
+    "schema": {"oneOf": [true, true, false]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf/2",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf/2",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/2",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with boolean schemas, all false",
+    "schema": {"oneOf": [false, false, false]},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/2",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 0.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/2",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/2",
+                    "instanceLocation": "#",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf complex types",
+    "schema": {
+      "oneOf": [
+        {"properties": {"bar": {"type": "integer"}}, "required": ["bar"]},
+        {"properties": {"foo": {"type": "string"}}, "required": ["foo"]}
+      ]
+    },
+    "tests": [
+      {
+        "description": "first oneOf valid (complex)",
+        "data": {"bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/oneOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/oneOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "second oneOf valid (complex)",
+        "data": {"foo": "baz"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"bar\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/oneOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/oneOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both oneOf valid (complex)",
+        "data": {"foo": "baz", "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/oneOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/oneOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/oneOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/oneOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "neither oneOf valid (complex)",
+        "data": {"foo": 2, "bar": "quux"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 0.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "error": "At least one subschema failed validation.",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/oneOf/0/properties/bar",
+                            "instanceLocation": "#/bar",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/oneOf/0/properties/bar/type",
+                                "instanceLocation": "#/bar",
+                                "keyword": "type",
+                                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/properties",
+                        "instanceLocation": "#",
+                        "keyword": "properties",
+                        "error": "At least one subschema failed validation.",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/oneOf/1/properties/foo",
+                            "instanceLocation": "#/foo",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/oneOf/1/properties/foo/type",
+                                "instanceLocation": "#/foo",
+                                "keyword": "type",
+                                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with empty schema",
+    "schema": {"oneOf": [{"type": "number"}, {}]},
+    "tests": [
+      {
+        "description": "one valid - valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both valid - invalid",
+        "data": 123,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "oneOf with required",
+    "schema": {
+      "type": "object",
+      "oneOf": [{"required": ["foo", "bar"]}, {"required": ["foo", "baz"]}]
+    },
+    "tests": [
+      {
+        "description": "both invalid - invalid",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\"] are required."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\",\"baz\"] are required."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 0.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/0/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\"] are required."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf/1/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\",\"baz\"] are required."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 0.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"foo\",\"baz\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "first valid - valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"baz\"] are required."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "second valid - valid",
+        "data": {"foo": 1, "baz": 3},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "annotations": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required",
+                        "error": "The properties [\"bar\"] are required."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both valid - invalid",
+        "data": {"foo": 1, "bar": 2, "baz": 3},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/oneOf",
+            "instanceLocation": "#",
+            "keyword": "oneOf",
+            "error": "Expected exactly one subschema to pass validation, but found 2."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/oneOf",
+                "instanceLocation": "#",
+                "keyword": "oneOf",
+                "error": "Expected exactly one subschema to pass validation, but found 2.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/0",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/0/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/oneOf/1",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/oneOf/1/required",
+                        "instanceLocation": "#",
+                        "keyword": "required"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/bignum.json
+++ b/tests/draft2019-04/optional/bignum.json
@@ -1,0 +1,317 @@
+[
+  {
+    "description": "integer",
+    "schema": {"type": "integer"},
+    "tests": [
+      {
+        "description": "a bignum is an integer",
+        "data": 1.23456789101112e+52,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a negative bignum is an integer",
+        "data": -1.23456789101112e+52,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "number",
+    "schema": {"type": "number"},
+    "tests": [
+      {
+        "description": "a bignum is a number",
+        "data": 9.82492837492349e+52,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a negative bignum is a number",
+        "data": -9.82492837492349e+52,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "string",
+    "schema": {"type": "string"},
+    "tests": [
+      {
+        "description": "a bignum is not a string",
+        "data": 9.82492837492349e+52,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "integer comparison",
+    "schema": {"maximum": 18446744073709600000},
+    "tests": [
+      {
+        "description": "comparison works for high numbers",
+        "data": 18446744073709600000,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/maximum",
+                "instanceLocation": "#",
+                "keyword": "maximum"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "comparison works for very negative numbers",
+        "data": -18446744073709600000,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/minimum",
+                "instanceLocation": "#",
+                "keyword": "minimum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "float comparison with high precision",
+    "schema": {"exclusiveMaximum": 9.72783798187987e+26},
+    "tests": [
+      {
+        "description": "comparison works for high numbers",
+        "data": 9.72783798187987e+26,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMaximum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMaximum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMaximum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMaximum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "float comparison with high precision on negative numbers",
+    "schema": {"exclusiveMinimum": -9.72783798187987e+26},
+    "tests": [
+      {
+        "description": "comparison works for very negative numbers",
+        "data": -9.72783798187987e+26,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/exclusiveMinimum",
+            "instanceLocation": "#",
+            "keyword": "exclusiveMinimum"
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/exclusiveMinimum",
+                "instanceLocation": "#",
+                "keyword": "exclusiveMinimum"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/content.json
+++ b/tests/draft2019-04/optional/content.json
@@ -1,0 +1,301 @@
+[
+  {
+    "description": "validation of string-encoded content based on media type",
+    "schema": {"contentMediaType": "application/json"},
+    "tests": [
+      {
+        "description": "a valid JSON document",
+        "data": "{\"foo\": \"bar\"}",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/contentMediaType",
+            "instanceLocation": "#",
+            "keyword": "contentMediaType",
+            "annotation": "application/json"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/contentMediaType",
+            "instanceLocation": "#",
+            "keyword": "contentMediaType",
+            "annotation": "application/json"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 100,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/contentMediaType",
+            "instanceLocation": "#",
+            "keyword": "contentMediaType",
+            "annotation": "application/json"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/contentMediaType",
+            "instanceLocation": "#",
+            "keyword": "contentMediaType",
+            "annotation": "application/json"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "validation of binary string-encoding",
+    "schema": {"contentEncoding": "base64"},
+    "tests": [
+      {
+        "description": "a valid base64 string",
+        "data": "eyJmb28iOiAiYmFyIn0K",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/contentEncoding",
+            "instanceLocation": "#",
+            "keyword": "contentEncoding",
+            "annotation": "base64"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/contentEncoding",
+            "instanceLocation": "#",
+            "keyword": "contentEncoding",
+            "annotation": "base64"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 100,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/contentEncoding",
+            "instanceLocation": "#",
+            "keyword": "contentEncoding",
+            "annotation": "base64"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/contentEncoding",
+            "instanceLocation": "#",
+            "keyword": "contentEncoding",
+            "annotation": "base64"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "validation of binary-encoded media type documents",
+    "schema": {
+      "contentMediaType": "application/json",
+      "contentEncoding": "base64"
+    },
+    "tests": [
+      {
+        "description": "a valid base64-encoded JSON document",
+        "data": "eyJmb28iOiAiYmFyIn0K",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "annotations": [
+              {"valid": true, "keywordLocation": "#", "instanceLocation": "#"},
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 100,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "annotations": [
+              {"valid": true, "keywordLocation": "#", "instanceLocation": "#"},
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/contentMediaType",
+                "instanceLocation": "#",
+                "keyword": "contentMediaType",
+                "annotation": "application/json"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/contentEncoding",
+                "instanceLocation": "#",
+                "keyword": "contentEncoding",
+                "annotation": "base64"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/ecmascript-regex.json
+++ b/tests/draft2019-04/optional/ecmascript-regex.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "ECMA 262 regex non-compliance",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "ECMA 262 has no support for \\Z anchor from .NET",
+                "data": "^\\S(|(.|\\n)*\\S)\\Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft2019-04/optional/format/date-time.json
+++ b/tests/draft2019-04/optional/format/date-time.json
@@ -1,0 +1,323 @@
+[
+  {
+    "description": "validation of date-time strings",
+    "schema": {"format": "date-time"},
+    "tests": [
+      {
+        "description": "a valid date-time string",
+        "data": "1963-06-19T08:30:06.283185Z",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date-time"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid date-time string without second fraction",
+        "data": "1963-06-19T08:30:06Z",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date-time"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid date-time string with plus offset",
+        "data": "1937-01-01T12:00:27.87+00:20",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date-time"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid date-time string with minus offset",
+        "data": "1990-12-31T15:59:50.123-08:00",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date-time"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a invalid day in date-time string",
+        "data": "1990-02-31T15:59:60.123-08:00",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1990-02-31T15:59:60.123-08:00\" is not in an acceptable \"date-time\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1990-02-31T15:59:60.123-08:00\" is not in an acceptable \"date-time\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"1990-02-31T15:59:60.123-08:00\" is not in an acceptable \"date-time\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid offset in date-time string",
+        "data": "1990-12-31T15:59:60-24:00",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1990-12-31T15:59:60-24:00\" is not in an acceptable \"date-time\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1990-12-31T15:59:60-24:00\" is not in an acceptable \"date-time\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"1990-12-31T15:59:60-24:00\" is not in an acceptable \"date-time\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid date-time string",
+        "data": "06/19/1963 08:30:06 PST",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"06/19/1963 08:30:06 PST\" is not in an acceptable \"date-time\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"06/19/1963 08:30:06 PST\" is not in an acceptable \"date-time\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"06/19/1963 08:30:06 PST\" is not in an acceptable \"date-time\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "case-insensitive T and Z",
+        "data": "1963-06-19t08:30:06.283185z",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date-time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date-time"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "only RFC3339 not all of ISO 8601 are valid",
+        "data": "2013-350T01:01:01",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"2013-350T01:01:01\" is not in an acceptable \"date-time\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"2013-350T01:01:01\" is not in an acceptable \"date-time\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"2013-350T01:01:01\" is not in an acceptable \"date-time\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/date.json
+++ b/tests/draft2019-04/optional/format/date.json
@@ -1,0 +1,43 @@
+[
+  {
+    "description": "validation of date strings",
+    "schema": {"format": "date"},
+    "tests": [
+      {
+        "description": "a valid date string",
+        "data": "1963-06-19",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "date"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "date"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/email.json
+++ b/tests/draft2019-04/optional/format/email.json
@@ -1,0 +1,78 @@
+[
+  {
+    "description": "validation of e-mail addresses",
+    "schema": {"format": "email"},
+    "tests": [
+      {
+        "description": "a valid e-mail address",
+        "data": "joe.bloggs@example.com",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "email"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "email"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "email"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid e-mail address",
+        "data": "2962",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"2962\" is not in an acceptable \"email\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"2962\" is not in an acceptable \"email\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"2962\" is not in an acceptable \"email\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/hostname.json
+++ b/tests/draft2019-04/optional/format/hostname.json
@@ -1,0 +1,148 @@
+[
+  {
+    "description": "validation of host names",
+    "schema": {"format": "hostname"},
+    "tests": [
+      {
+        "description": "a valid host name",
+        "data": "www.example.com",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "hostname"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "hostname"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "hostname"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid punycoded IDN hostname",
+        "data": "xn--4gbwdl.xn--wgbh1c",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "hostname"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "hostname"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "hostname"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a host name containing illegal characters",
+        "data": "not_a_valid_host_name",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"not_a_valid_host_name\" is not in an acceptable \"hostname\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"not_a_valid_host_name\" is not in an acceptable \"hostname\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"not_a_valid_host_name\" is not in an acceptable \"hostname\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a host name with a component too long",
+        "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component\" is not in an acceptable \"hostname\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component\" is not in an acceptable \"hostname\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component\" is not in an acceptable \"hostname\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/idn-email.json
+++ b/tests/draft2019-04/optional/format/idn-email.json
@@ -1,0 +1,43 @@
+[
+  {
+    "description": "validation of an internationalized e-mail addresses",
+    "schema": {"format": "idn-email"},
+    "tests": [
+      {
+        "description": "a valid idn e-mail (example@example.test in Hangul)",
+        "data": "실례@실례.테스트",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "idn-email"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "idn-email"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "idn-email"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/idn-hostname.json
+++ b/tests/draft2019-04/optional/format/idn-hostname.json
@@ -1,0 +1,43 @@
+[
+  {
+    "description": "validation of internationalized host names",
+    "schema": {"format": "idn-hostname"},
+    "tests": [
+      {
+        "description": "a valid host name (example.test in Hangul)",
+        "data": "실례.테스트",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "idn-hostname"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "idn-hostname"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "idn-hostname"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/ipv4.json
+++ b/tests/draft2019-04/optional/format/ipv4.json
@@ -1,0 +1,183 @@
+[
+  {
+    "description": "validation of IP addresses",
+    "schema": {"format": "ipv4"},
+    "tests": [
+      {
+        "description": "a valid IP address",
+        "data": "192.168.0.1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "ipv4"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "ipv4"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "ipv4"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IP address with too many components",
+        "data": "127.0.0.0.1",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"127.0.0.0.1\" is not in an acceptable \"ipv4\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"127.0.0.0.1\" is not in an acceptable \"ipv4\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"127.0.0.0.1\" is not in an acceptable \"ipv4\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IP address with out-of-range values",
+        "data": "256.256.256.256",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"256.256.256.256\" is not in an acceptable \"ipv4\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"256.256.256.256\" is not in an acceptable \"ipv4\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"256.256.256.256\" is not in an acceptable \"ipv4\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IP address without 4 components",
+        "data": "127.0",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"127.0\" is not in an acceptable \"ipv4\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"127.0\" is not in an acceptable \"ipv4\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"127.0\" is not in an acceptable \"ipv4\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IP address as an integer",
+        "data": "0x7f000001",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"0x7f000001\" is not in an acceptable \"ipv4\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"0x7f000001\" is not in an acceptable \"ipv4\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"0x7f000001\" is not in an acceptable \"ipv4\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/ipv6.json
+++ b/tests/draft2019-04/optional/format/ipv6.json
@@ -1,0 +1,148 @@
+[
+  {
+    "description": "validation of IPv6 addresses",
+    "schema": {"format": "ipv6"},
+    "tests": [
+      {
+        "description": "a valid IPv6 address",
+        "data": "::1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "ipv6"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "ipv6"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "ipv6"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IPv6 address with out-of-range values",
+        "data": "12345::",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"12345::\" is not in an acceptable \"ipv6\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"12345::\" is not in an acceptable \"ipv6\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"12345::\" is not in an acceptable \"ipv6\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IPv6 address with too many components",
+        "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1\" is not in an acceptable \"ipv6\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1\" is not in an acceptable \"ipv6\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1\" is not in an acceptable \"ipv6\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an IPv6 address containing illegal characters",
+        "data": "::laptop",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"::laptop\" is not in an acceptable \"ipv6\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"::laptop\" is not in an acceptable \"ipv6\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"::laptop\" is not in an acceptable \"ipv6\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/iri-reference.json
+++ b/tests/draft2019-04/optional/format/iri-reference.json
@@ -1,0 +1,183 @@
+[
+  {
+    "description": "validation of IRI References",
+    "schema": {"format": "iri-reference"},
+    "tests": [
+      {
+        "description": "a valid IRI",
+        "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid protocol-relative IRI Reference",
+        "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid relative IRI Reference",
+        "data": "/âππ",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI Reference",
+        "data": "âππ",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI fragment",
+        "data": "#ƒrägmênt",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri-reference"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/iri.json
+++ b/tests/draft2019-04/optional/format/iri.json
@@ -1,0 +1,183 @@
+[
+  {
+    "description": "validation of IRIs",
+    "schema": {"format": "iri"},
+    "tests": [
+      {
+        "description": "a valid IRI with anchor tag",
+        "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI with anchor tag and parantheses",
+        "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI with URL-encoded stuff",
+        "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI with many special characters",
+        "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid IRI based on IPv6",
+        "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "iri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "iri"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/json-pointer.json
+++ b/tests/draft2019-04/optional/format/json-pointer.json
@@ -1,0 +1,708 @@
+[
+  {
+    "description": "validation of JSON-pointers (JSON String Representation)",
+    "schema": {"format": "json-pointer"},
+    "tests": [
+      {
+        "description": "a valid JSON-pointer",
+        "data": "/foo/bar~0/baz~1/%a",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer with empty segment",
+        "data": "/foo//bar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer with the last empty segment",
+        "data": "/foo/bar/",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #1",
+        "data": "",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #2",
+        "data": "/foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #3",
+        "data": "/foo/0",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #4",
+        "data": "/",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #5",
+        "data": "/a~1b",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #6",
+        "data": "/c%d",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #7",
+        "data": "/e^f",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #8",
+        "data": "/g|h",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #9",
+        "data": "/i\\j",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #10",
+        "data": "/k\"l",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #11",
+        "data": "/ ",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer as stated in RFC 6901 #12",
+        "data": "/m~0n",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer used adding to the last array position",
+        "data": "/foo/-",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer (- used as object member name)",
+        "data": "/foo/-/bar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer (multiple escaped characters)",
+        "data": "/~1~0~0~1~1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer (escaped with fraction part) #1",
+        "data": "/~1.1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "valid JSON-pointer (escaped with fraction part) #2",
+        "data": "/~0.1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "json-pointer"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/regex.json
+++ b/tests/draft2019-04/optional/format/regex.json
@@ -1,0 +1,43 @@
+[
+  {
+    "description": "validation of regular expressions",
+    "schema": {"format": "regex"},
+    "tests": [
+      {
+        "description": "a valid regular expression",
+        "data": "([abc])+\\s+$",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "regex"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "regex"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "regex"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-04/optional/format/relative-json-pointer.json
@@ -1,0 +1,148 @@
+[
+  {
+    "description": "validation of Relative JSON Pointers (RJP)",
+    "schema": {"format": "relative-json-pointer"},
+    "tests": [
+      {
+        "description": "a valid upwards RJP",
+        "data": "1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "relative-json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid downwards RJP",
+        "data": "0/foo/bar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "relative-json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid up and then down RJP, with array index",
+        "data": "2/0/baz/1/zip",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "relative-json-pointer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid RJP taking the member or index name",
+        "data": "0#",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "relative-json-pointer"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "relative-json-pointer"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/time.json
+++ b/tests/draft2019-04/optional/format/time.json
@@ -1,0 +1,43 @@
+[
+  {
+    "description": "validation of time strings",
+    "schema": {"format": "time"},
+    "tests": [
+      {
+        "description": "a valid time string",
+        "data": "08:30:06.283185Z",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "time"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "time"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "time"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/uri-reference.json
+++ b/tests/draft2019-04/optional/format/uri-reference.json
@@ -1,0 +1,183 @@
+[
+  {
+    "description": "validation of URI References",
+    "schema": {"format": "uri-reference"},
+    "tests": [
+      {
+        "description": "a valid URI",
+        "data": "http://foo.bar/?baz=qux#quux",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid protocol-relative URI Reference",
+        "data": "//foo.bar/?baz=qux#quux",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid relative URI Reference",
+        "data": "/abc",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URI Reference",
+        "data": "abc",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-reference"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URI fragment",
+        "data": "#fragment",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-reference"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-reference"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/uri-template.json
+++ b/tests/draft2019-04/optional/format/uri-template.json
@@ -1,0 +1,113 @@
+[
+  {
+    "description": "format: uri-template",
+    "schema": {"format": "uri-template"},
+    "tests": [
+      {
+        "description": "a valid uri-template",
+        "data": "http://example.com/dictionary/{term:1}/{term}",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-template"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid uri-template without variables",
+        "data": "http://example.com/dictionary",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-template"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid relative uri-template",
+        "data": "dictionary/{term:1}/{term}",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri-template"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri-template"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/format/uri.json
+++ b/tests/draft2019-04/optional/format/uri.json
@@ -1,0 +1,603 @@
+[
+  {
+    "description": "validation of URIs",
+    "schema": {"format": "uri"},
+    "tests": [
+      {
+        "description": "a valid URL with anchor tag",
+        "data": "http://foo.bar/?baz=qux#quux",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL with anchor tag and parantheses",
+        "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL with URL-encoded stuff",
+        "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid puny-coded URL ",
+        "data": "http://xn--nw2a.xn--j6w193g/",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL with many special characters",
+        "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL based on IPv4",
+        "data": "http://223.255.255.254",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL with ftp scheme",
+        "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL for a simple text file",
+        "data": "http://www.ietf.org/rfc/rfc2396.txt",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URL ",
+        "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid mailto URI",
+        "data": "mailto:John.Doe@example.com",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid newsgroup URI",
+        "data": "news:comp.infosystems.www.servers.unix",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid tel URI",
+        "data": "tel:+1-816-555-1212",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a valid URN",
+        "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "annotation": "uri"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "annotation": "uri"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid protocol-relative URI Reference",
+        "data": "//foo.bar/?baz=qux#quux",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"//foo.bar/?baz=qux#quux\" is not in an acceptable \"uri\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"//foo.bar/?baz=qux#quux\" is not in an acceptable \"uri\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"//foo.bar/?baz=qux#quux\" is not in an acceptable \"uri\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid URI",
+        "data": "\\\\WINDOWS\fileshare",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"\\\\\\\\WINDOWS\\\fileshare\" is not in an acceptable \"uri\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"\\\\\\\\WINDOWS\\\fileshare\" is not in an acceptable \"uri\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"\\\\\\\\WINDOWS\\\fileshare\" is not in an acceptable \"uri\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid URI with spaces",
+        "data": "http:// shouldfail.com",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"http:// shouldfail.com\" is not in an acceptable \"uri\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\"http:// shouldfail.com\" is not in an acceptable \"uri\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\"http:// shouldfail.com\" is not in an acceptable \"uri\" format."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid URI with spaces and missing scheme",
+        "data": ":// should fail",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\":// should fail\" is not in an acceptable \"uri\" format."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/format",
+            "instanceLocation": "#",
+            "keyword": "format",
+            "error": "\":// should fail\" is not in an acceptable \"uri\" format."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/format",
+                "instanceLocation": "#",
+                "keyword": "format",
+                "error": "\":// should fail\" is not in an acceptable \"uri\" format."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/optional/zeroTerminatedFloats.json
+++ b/tests/draft2019-04/optional/zeroTerminatedFloats.json
@@ -1,0 +1,38 @@
+[
+  {
+    "description": "some languages do not distinguish between different types of numeric value",
+    "schema": {"type": "integer"},
+    "tests": [
+      {
+        "description": "a float without fractional part is an integer",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/pattern.json
+++ b/tests/draft2019-04/pattern.json
@@ -1,0 +1,139 @@
+[
+  {
+    "description": "pattern validation",
+    "schema": {"pattern": "^a*$"},
+    "tests": [
+      {
+        "description": "a matching pattern is valid",
+        "data": "aaa",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/pattern",
+                "instanceLocation": "#",
+                "keyword": "pattern"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a non-matching pattern is invalid",
+        "data": "abc",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/pattern",
+            "instanceLocation": "#",
+            "keyword": "pattern",
+            "error": "\"abc\" should match the Regular Expression `\"^a*$\"`."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/pattern",
+            "instanceLocation": "#",
+            "keyword": "pattern",
+            "error": "\"abc\" should match the Regular Expression `\"^a*$\"`."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/pattern",
+                "instanceLocation": "#",
+                "keyword": "pattern",
+                "error": "\"abc\" should match the Regular Expression `\"^a*$\"`."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores non-strings",
+        "data": true,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/pattern",
+                "instanceLocation": "#",
+                "keyword": "pattern"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "pattern is not anchored",
+    "schema": {"pattern": "a+"},
+    "tests": [
+      {
+        "description": "matches a substring",
+        "data": "xxaayy",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/pattern",
+                "instanceLocation": "#",
+                "keyword": "pattern"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/patternProperties.json
+++ b/tests/draft2019-04/patternProperties.json
@@ -1,0 +1,1121 @@
+[
+  {
+    "description": "patternProperties validates properties matching a regex",
+    "schema": {"patternProperties": {"f.*o": {"type": "integer"}}},
+    "tests": [
+      {
+        "description": "a single valid match is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "multiple valid matches is valid",
+        "data": {"foo": 1, "foooooo": 2},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foooooo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foooooo",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a single invalid match is invalid",
+        "data": {"foo": "bar", "fooooo": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.*o/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.*o/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/fooooo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/fooooo",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "multiple invalid matches is invalid",
+        "data": {"foo": "bar", "foooooo": "baz"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/f.*o/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/f.*o/type",
+                "instanceLocation": "#/foooooo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties",
+            "instanceLocation": "#",
+            "keyword": "patternProperties",
+            "error": "At least one subschema failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/f.*o/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/f.*o/type",
+                "instanceLocation": "#/foooooo",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/f.*o",
+                    "instanceLocation": "#/foooooo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/f.*o/type",
+                        "instanceLocation": "#/foooooo",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": ["foo"],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "multiple simultaneous patternProperties are validated",
+    "schema": {
+      "patternProperties": {"a*": {"type": "integer"}, "aaa*": {"maximum": 20}}
+    },
+    "tests": [
+      {
+        "description": "a single valid match is valid",
+        "data": {"a": 21},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/a",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/a",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a simultaneous match is valid",
+        "data": {"aaaa": 18},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/aaa*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/aaa*/maximum",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "maximum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "multiple matches is valid",
+        "data": {"a": 21, "aaaa": 18},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/a",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/a",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/aaa*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/aaa*/maximum",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "maximum"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid due to one is invalid",
+        "data": {"a": "bar"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/a*/type",
+            "instanceLocation": "#/a",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/a*/type",
+            "instanceLocation": "#/a",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/a",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/a",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid due to the other is invalid",
+        "data": {"aaaa": 31},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/aaa*/maximum",
+            "instanceLocation": "#/aaaa",
+            "keyword": "maximum",
+            "error": "The value 31 should be at most 20."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/aaa*/maximum",
+            "instanceLocation": "#/aaaa",
+            "keyword": "maximum",
+            "error": "The value 31 should be at most 20."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/aaa*",
+                    "instanceLocation": "#/aaaa",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/aaa*/maximum",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "maximum",
+                        "error": "The value 31 should be at most 20."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an invalid due to both is invalid",
+        "data": {"aaa": "foo", "aaaa": 31},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/a*/type",
+                "instanceLocation": "#/aaa",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/aaa*/maximum",
+                "instanceLocation": "#/aaaa",
+                "keyword": "maximum",
+                "error": "The value 31 should be at most 20."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties",
+            "instanceLocation": "#",
+            "keyword": "patternProperties",
+            "error": "At least one subschema failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/a*/type",
+                "instanceLocation": "#/aaa",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties/aaa*/maximum",
+                "instanceLocation": "#/aaaa",
+                "keyword": "maximum",
+                "error": "The value 31 should be at most 20."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/aaa",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/aaa",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/a*",
+                    "instanceLocation": "#/aaaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/a*/type",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/aaa*",
+                    "instanceLocation": "#/aaa",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/aaa*/maximum",
+                        "instanceLocation": "#/aaa",
+                        "keyword": "maximum"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/aaa*",
+                    "instanceLocation": "#/aaaa",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/aaa*/maximum",
+                        "instanceLocation": "#/aaaa",
+                        "keyword": "maximum",
+                        "error": "The value 31 should be at most 20."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "regexes are not anchored by default and are case sensitive",
+    "schema": {
+      "patternProperties": {
+        "[0-9]{2,}": {"type": "boolean"},
+        "X_": {"type": "string"}
+      }
+    },
+    "tests": [
+      {
+        "description": "non recognized members are ignored",
+        "data": {"answer 1": "42"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "recognized members are accounted for",
+        "data": {"a31b": null},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/[0-9]{2,}/type",
+            "instanceLocation": "#/a31b",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/[0-9]{2,}/type",
+            "instanceLocation": "#/a31b",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/[0-9]{2,}",
+                    "instanceLocation": "#/a31b",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/[0-9]{2,}/type",
+                        "instanceLocation": "#/a31b",
+                        "keyword": "type",
+                        "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "regexes are case sensitive",
+        "data": {"a_x_3": 3},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "regexes are case sensitive, 2",
+        "data": {"a_X_3": 3},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/X_/type",
+            "instanceLocation": "#/a_X_3",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/X_/type",
+            "instanceLocation": "#/a_X_3",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/X_",
+                    "instanceLocation": "#/a_X_3",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/X_/type",
+                        "instanceLocation": "#/a_X_3",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "patternProperties with boolean schemas",
+    "schema": {"patternProperties": {"f.*": true, "b.*": false}},
+    "tests": [
+      {
+        "description": "object with property matching schema true is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with property matching schema false is invalid",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/b.*",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/b.*",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/b.*",
+                    "instanceLocation": "#/bar",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with both properties is invalid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/b.*",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/b.*",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.*",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/b.*",
+                    "instanceLocation": "#/bar",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/properties.json
+++ b/tests/draft2019-04/properties.json
@@ -1,0 +1,1389 @@
+[
+  {
+    "description": "object properties validation",
+    "schema": {
+      "properties": {"foo": {"type": "integer"}, "bar": {"type": "string"}}
+    },
+    "tests": [
+      {
+        "description": "both properties present and valid is valid",
+        "data": {"foo": 1, "bar": "baz"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "one property invalid is invalid",
+        "data": {"foo": 1, "bar": {}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type",
+                        "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both properties invalid is invalid",
+        "data": {"foo": [], "bar": {}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties",
+            "instanceLocation": "#",
+            "keyword": "properties",
+            "error": "At least one subschema failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo/type",
+                "instanceLocation": "#/foo",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/bar/type",
+                "instanceLocation": "#/bar",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type",
+                        "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type",
+                        "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "doesn't invalidate other properties",
+        "data": {"quux": []},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "properties, patternProperties, additionalProperties interaction",
+    "schema": {
+      "properties": {
+        "foo": {"type": "array", "maxItems": 3},
+        "bar": {"type": "array"}
+      },
+      "patternProperties": {"f.o": {"minItems": 2}},
+      "additionalProperties": {"type": "integer"}
+    },
+    "tests": [
+      {
+        "description": "property validates property",
+        "data": {"foo": [1, 2]},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/maxItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "maxItems"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.o",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.o/minItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "minItems"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "property invalidates property",
+        "data": {"foo": [1, 2, 3, 4]},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/maxItems",
+            "instanceLocation": "#/foo",
+            "keyword": "maxItems",
+            "error": "The array should contain at most 3 items, but 4 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/maxItems",
+            "instanceLocation": "#/foo",
+            "keyword": "maxItems",
+            "error": "The array should contain at most 3 items, but 4 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo/maxItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "maxItems",
+                        "error": "The array should contain at most 3 items, but 4 were found."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.o",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.o/minItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "minItems"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "patternProperty invalidates property",
+        "data": {"foo": []},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.o/minItems",
+            "instanceLocation": "#/foo",
+            "keyword": "minItems",
+            "error": "The array should contain at least 2 items, but 0 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.o/minItems",
+            "instanceLocation": "#/foo",
+            "keyword": "minItems",
+            "error": "The array should contain at least 2 items, but 0 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/type",
+                        "instanceLocation": "#/foo",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/maxItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "maxItems"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/f.o",
+                    "instanceLocation": "#/foo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/f.o/minItems",
+                        "instanceLocation": "#/foo",
+                        "keyword": "minItems",
+                        "error": "The array should contain at least 2 items, but 0 were found."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "patternProperty validates nonproperty",
+        "data": {"fxo": [1, 2]},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/patternProperties/f.o",
+                    "instanceLocation": "#/fxo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/patternProperties/f.o/minItems",
+                        "instanceLocation": "#/fxo",
+                        "keyword": "minItems"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "patternProperty invalidates nonproperty",
+        "data": {"fxo": []},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.o/minItems",
+            "instanceLocation": "#/fxo",
+            "keyword": "minItems",
+            "error": "The array should contain at least 2 items, but 0 were found."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/patternProperties/f.o/minItems",
+            "instanceLocation": "#/fxo",
+            "keyword": "minItems",
+            "error": "The array should contain at least 2 items, but 0 were found."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/patternProperties/f.o",
+                    "instanceLocation": "#/fxo",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/patternProperties/f.o/minItems",
+                        "instanceLocation": "#/fxo",
+                        "keyword": "minItems",
+                        "error": "The array should contain at least 2 items, but 0 were found."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "additionalProperty ignores property",
+        "data": {"bar": []},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/type",
+                        "instanceLocation": "#/bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "additionalProperty validates others",
+        "data": {"quux": 3},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/quux",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/quux",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "additionalProperty invalidates others",
+        "data": {"quux": "foo"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/quux",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties/type",
+            "instanceLocation": "#/quux",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/patternProperties",
+                "instanceLocation": "#",
+                "keyword": "patternProperties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Any properties not covered by `properties` and `patternProperties` failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/additionalProperties",
+                    "instanceLocation": "#/quux",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/additionalProperties/type",
+                        "instanceLocation": "#/quux",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "properties with boolean schema",
+    "schema": {"properties": {"foo": true, "bar": false}},
+    "tests": [
+      {
+        "description": "no property present is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "only 'true' property present is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "only 'false' property present is invalid",
+        "data": {"bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "both properties present is invalid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar",
+            "instanceLocation": "#/bar",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "properties with escaped characters",
+    "schema": {
+      "properties": {
+        "foo\nbar": {"type": "number"},
+        "foo\"bar": {"type": "number"},
+        "foo\bar": {"type": "number"},
+        "foo\rbar": {"type": "number"},
+        "foo\tbar": {"type": "number"},
+        "foo\fbar": {"type": "number"}
+      }
+    },
+    "tests": [
+      {
+        "description": "object with all numbers is valid",
+        "data": {
+          "foo\nbar": 1,
+          "foo\"bar": 1,
+          "foo\bar": 1,
+          "foo\rbar": 1,
+          "foo\tbar": 1,
+          "foo\fbar": 1
+        },
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\nbar",
+                    "instanceLocation": "#/foo\nbar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\nbar/type",
+                        "instanceLocation": "#/foo\nbar",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\"bar",
+                    "instanceLocation": "#/foo\"bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\"bar/type",
+                        "instanceLocation": "#/foo\"bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\bar",
+                    "instanceLocation": "#/foo\bar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\bar/type",
+                        "instanceLocation": "#/foo\bar",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\rbar",
+                    "instanceLocation": "#/foo\rbar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\rbar/type",
+                        "instanceLocation": "#/foo\rbar",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\tbar",
+                    "instanceLocation": "#/foo\tbar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\tbar/type",
+                        "instanceLocation": "#/foo\tbar",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\fbar",
+                    "instanceLocation": "#/foo\fbar",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\fbar/type",
+                        "instanceLocation": "#/foo\fbar",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with strings is invalid",
+        "data": {
+          "foo\nbar": "1",
+          "foo\"bar": "1",
+          "foo\bar": "1",
+          "foo\rbar": "1",
+          "foo\tbar": "1",
+          "foo\fbar": "1"
+        },
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\nbar/type",
+                "instanceLocation": "#/foo\nbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\"bar/type",
+                "instanceLocation": "#/foo\"bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\bar/type",
+                "instanceLocation": "#/foo\bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\rbar/type",
+                "instanceLocation": "#/foo\rbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\tbar/type",
+                "instanceLocation": "#/foo\tbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\fbar/type",
+                "instanceLocation": "#/foo\fbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties",
+            "instanceLocation": "#",
+            "keyword": "properties",
+            "error": "At least one subschema failed validation.",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\nbar/type",
+                "instanceLocation": "#/foo\nbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\"bar/type",
+                "instanceLocation": "#/foo\"bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\bar/type",
+                "instanceLocation": "#/foo\bar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\rbar/type",
+                "instanceLocation": "#/foo\rbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\tbar/type",
+                "instanceLocation": "#/foo\tbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/foo\fbar/type",
+                "instanceLocation": "#/foo\fbar",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\nbar",
+                    "instanceLocation": "#/foo\nbar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\nbar/type",
+                        "instanceLocation": "#/foo\nbar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\"bar",
+                    "instanceLocation": "#/foo\"bar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\"bar/type",
+                        "instanceLocation": "#/foo\"bar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\bar",
+                    "instanceLocation": "#/foo\bar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\bar/type",
+                        "instanceLocation": "#/foo\bar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\rbar",
+                    "instanceLocation": "#/foo\rbar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\rbar/type",
+                        "instanceLocation": "#/foo\rbar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\tbar",
+                    "instanceLocation": "#/foo\tbar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\tbar/type",
+                        "instanceLocation": "#/foo\tbar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\fbar",
+                    "instanceLocation": "#/foo\fbar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\fbar/type",
+                        "instanceLocation": "#/foo\fbar",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/propertyNames.json
+++ b/tests/draft2019-04/propertyNames.json
@@ -1,0 +1,400 @@
+[
+  {
+    "description": "propertyNames validation",
+    "schema": {"propertyNames": {"maxLength": 3}},
+    "tests": [
+      {
+        "description": "all property names valid",
+        "data": {"f": {}, "foo": {}},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/f",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/propertyNames/maxLength",
+                        "instanceLocation": "#/f",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/propertyNames/maxLength",
+                        "instanceLocation": "#/foo",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "some property names invalid",
+        "data": {"foo": {}, "foobar": {}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/propertyNames/maxLength",
+            "instanceLocation": "#/foobar",
+            "keyword": "maxLength",
+            "error": "The string should be at most 3 characters long, but was 6."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/propertyNames/maxLength",
+            "instanceLocation": "#/foobar",
+            "keyword": "maxLength",
+            "error": "The string should be at most 3 characters long, but was 6."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames",
+                "error": "Properties [\"foo\",\"foobar\"] have names that failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/foo",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/propertyNames/maxLength",
+                        "instanceLocation": "#/foo",
+                        "keyword": "maxLength"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/foobar",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/propertyNames/maxLength",
+                        "instanceLocation": "#/foobar",
+                        "keyword": "maxLength",
+                        "error": "The string should be at most 3 characters long, but was 6."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object without properties is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [1, 2, 3, 4],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "foobar",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "propertyNames with boolean schema true",
+    "schema": {"propertyNames": true},
+    "tests": [
+      {
+        "description": "object with any properties is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "propertyNames with boolean schema false",
+    "schema": {"propertyNames": false},
+    "tests": [
+      {
+        "description": "object with any properties is invalid",
+        "data": {"foo": 1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/propertyNames",
+            "instanceLocation": "#/foo",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/propertyNames",
+            "instanceLocation": "#/foo",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames",
+                "error": "Properties [\"foo\"] have names that failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/propertyNames",
+                    "instanceLocation": "#/foo",
+                    "error": "No value is valid against the false schema."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/propertyNames",
+                "instanceLocation": "#",
+                "keyword": "propertyNames"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/ref.json
+++ b/tests/draft2019-04/ref.json
@@ -1,0 +1,3797 @@
+[
+  {
+    "description": "root pointer ref",
+    "schema": {
+      "properties": {"foo": {"$ref": "#"}},
+      "additionalProperties": false
+    },
+    "tests": [
+      {
+        "description": "match",
+        "data": {"foo": false},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/properties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "properties"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/additionalProperties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "additionalProperties"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "recursive match",
+        "data": {"foo": {"foo": false}},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/properties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "properties",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/foo/$ref/properties/foo/$ref",
+                                "instanceLocation": "#/foo/foo",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/foo/$ref/properties/foo/$ref",
+                                    "instanceLocation": "#/foo/foo",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/foo/$ref/properties/foo/$ref/properties",
+                                        "instanceLocation": "#/foo/foo",
+                                        "keyword": "properties"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/foo/$ref/properties/foo/$ref/additionalProperties",
+                                        "instanceLocation": "#/foo/foo",
+                                        "keyword": "additionalProperties"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/additionalProperties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "additionalProperties"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch",
+        "data": {"bar": false},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/additionalProperties",
+            "instanceLocation": "#",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties",
+                "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "recursive mismatch",
+        "data": {"foo": {"bar": false}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/$ref/additionalProperties",
+            "instanceLocation": "#/foo",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/$ref/additionalProperties",
+            "instanceLocation": "#/foo",
+            "keyword": "additionalProperties",
+            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/properties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "properties"
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/foo/$ref/additionalProperties",
+                            "instanceLocation": "#/foo",
+                            "keyword": "additionalProperties",
+                            "error": "Properties not covered by `properties` and `patternProperties` are not allowed."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/additionalProperties",
+                "instanceLocation": "#",
+                "keyword": "additionalProperties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "relative pointer ref to object",
+    "schema": {
+      "properties": {
+        "foo": {"type": "integer"},
+        "bar": {"$ref": "#/properties/foo"}
+      }
+    },
+    "tests": [
+      {
+        "description": "match",
+        "data": {"bar": 3},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar/$ref",
+                    "instanceLocation": "#/bar",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/bar/$ref",
+                        "instanceLocation": "#/bar",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/bar/$ref/type",
+                            "instanceLocation": "#/bar",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch",
+        "data": {"bar": true},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar/$ref/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/bar/$ref/type",
+            "instanceLocation": "#/bar",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/bar/$ref",
+                    "instanceLocation": "#/bar",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/bar/$ref",
+                        "instanceLocation": "#/bar",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/bar/$ref/type",
+                            "instanceLocation": "#/bar",
+                            "keyword": "type",
+                            "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "relative pointer ref to array",
+    "schema": {"items": [{"type": "integer"}, {"$ref": "#/items/0"}]},
+    "tests": [
+      {
+        "description": "match array",
+        "data": [1, 2],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "mismatch array",
+        "data": [1, "foo"],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/1/$ref/type",
+            "instanceLocation": "#/1",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/1/$ref/type",
+            "instanceLocation": "#/1",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items/0",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/0/type",
+                        "instanceLocation": "#/0",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items/1/$ref",
+                    "instanceLocation": "#/1",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/1/$ref",
+                        "instanceLocation": "#/1",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/1/$ref/type",
+                            "instanceLocation": "#/1",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "escaped pointer ref",
+    "schema": {
+      "properties": {
+        "tilda": {"$ref": "#/tilda~0field"},
+        "slash": {"$ref": "#/slash~1field"},
+        "percent": {"$ref": "#/percent%25field"}
+      },
+      "tilda~field": {"type": "integer"},
+      "slash/field": {"type": "integer"},
+      "percent%field": {"type": "integer"}
+    },
+    "tests": [
+      {
+        "description": "slash invalid",
+        "data": {"slash": "aoeu"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/slash/$ref/type",
+            "instanceLocation": "#/slash",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/slash/$ref/type",
+            "instanceLocation": "#/slash",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/slash/$ref",
+                    "instanceLocation": "#/slash",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/slash/$ref",
+                        "instanceLocation": "#/slash",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/slash/$ref/type",
+                            "instanceLocation": "#/slash",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "tilda invalid",
+        "data": {"tilda": "aoeu"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/tilda/$ref/type",
+            "instanceLocation": "#/tilda",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/tilda/$ref/type",
+            "instanceLocation": "#/tilda",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/tilda/$ref",
+                    "instanceLocation": "#/tilda",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/tilda/$ref",
+                        "instanceLocation": "#/tilda",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/tilda/$ref/type",
+                            "instanceLocation": "#/tilda",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "percent invalid",
+        "data": {"percent": "aoeu"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/percent/$ref/type",
+            "instanceLocation": "#/percent",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/percent/$ref/type",
+            "instanceLocation": "#/percent",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/percent/$ref",
+                    "instanceLocation": "#/percent",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/percent/$ref",
+                        "instanceLocation": "#/percent",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/percent/$ref/type",
+                            "instanceLocation": "#/percent",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "slash valid",
+        "data": {"slash": 123},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/slash/$ref",
+                    "instanceLocation": "#/slash",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/slash/$ref",
+                        "instanceLocation": "#/slash",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/slash/$ref/type",
+                            "instanceLocation": "#/slash",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "tilda valid",
+        "data": {"tilda": 123},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/tilda/$ref",
+                    "instanceLocation": "#/tilda",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/tilda/$ref",
+                        "instanceLocation": "#/tilda",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/tilda/$ref/type",
+                            "instanceLocation": "#/tilda",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "percent valid",
+        "data": {"percent": 123},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/percent/$ref",
+                    "instanceLocation": "#/percent",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/percent/$ref",
+                        "instanceLocation": "#/percent",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/percent/$ref/type",
+                            "instanceLocation": "#/percent",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "nested refs",
+    "schema": {
+      "definitions": {
+        "a": {"type": "integer"},
+        "b": {"$ref": "#/definitions/a"},
+        "c": {"$ref": "#/definitions/b"}
+      },
+      "$ref": "#/definitions/c"
+    },
+    "tests": [
+      {
+        "description": "nested ref valid",
+        "data": 5,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/$ref",
+                "instanceLocation": "#",
+                "keyword": "$ref",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/$ref/$ref",
+                    "instanceLocation": "#",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/$ref/$ref/$ref",
+                        "instanceLocation": "#",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/$ref/$ref/type",
+                            "instanceLocation": "#",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "nested ref invalid",
+        "data": "a",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref/$ref/$ref/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/$ref/$ref/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/$ref",
+                "instanceLocation": "#",
+                "keyword": "$ref",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/$ref/$ref",
+                    "instanceLocation": "#",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/$ref/$ref/$ref",
+                        "instanceLocation": "#",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/$ref/$ref/$ref/type",
+                            "instanceLocation": "#",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "ref overrides any sibling keywords",
+    "schema": {
+      "definitions": {"reffed": {"type": "array"}},
+      "properties": {"foo": {"$ref": "#/definitions/reffed", "maxItems": 2}}
+    },
+    "tests": [
+      {
+        "description": "ref valid",
+        "data": {"foo": []},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/type",
+                            "instanceLocation": "#/foo",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ref valid, maxItems ignored",
+        "data": {"foo": [1, 2, 3]},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo/$ref/type",
+                            "instanceLocation": "#/foo",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ref invalid",
+        "data": {"foo": "string"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/$ref/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo/$ref/type",
+            "instanceLocation": "#/foo",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo/$ref",
+                    "instanceLocation": "#/foo",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo/$ref",
+                        "instanceLocation": "#/foo",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/foo/$ref/type",
+                            "instanceLocation": "#/foo",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "remote ref, containing refs itself",
+    "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+    "tests": [
+      {
+        "description": "remote ref valid",
+        "data": {"minLength": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref/title",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+            "instanceLocation": "#",
+            "keyword": "title",
+            "annotation": "Core schema meta-schema"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref/title",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+            "instanceLocation": "#",
+            "keyword": "title",
+            "annotation": "Core schema meta-schema"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                "instanceLocation": "#",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/title",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                    "instanceLocation": "#",
+                    "keyword": "title",
+                    "annotation": "Core schema meta-schema"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/definitions",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                    "instanceLocation": "#",
+                    "keyword": "definitions"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/properties",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                    "instanceLocation": "#",
+                    "keyword": "properties",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/$ref/properties/minLength/$ref",
+                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/minLength/$ref",
+                        "instanceLocation": "#/minLength",
+                        "keyword": "$ref",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/$ref/properties/minLength/$ref",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0",
+                            "instanceLocation": "#/minLength",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/$ref/properties/minLength/$ref/allOf",
+                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf",
+                                "instanceLocation": "#/minLength",
+                                "keyword": "allOf",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/0/$ref",
+                                    "instanceLocation": "#/minLength",
+                                    "keyword": "$ref",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger",
+                                        "instanceLocation": "#/minLength",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/type",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/type",
+                                            "instanceLocation": "#/minLength",
+                                            "keyword": "type"
+                                          },
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/minimum",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/minimum",
+                                            "instanceLocation": "#/minLength",
+                                            "keyword": "minimum"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/1",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/1",
+                                    "instanceLocation": "#/minLength",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/1/default",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/1/default",
+                                        "instanceLocation": "#/minLength",
+                                        "keyword": "default"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/default",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                    "instanceLocation": "#",
+                    "keyword": "default"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "remote ref invalid",
+        "data": {"minLength": -1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/minimum",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/minimum",
+            "instanceLocation": "#/minLength",
+            "keyword": "minimum",
+            "error": "The value -1 should be at least 0."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/minimum",
+            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/minimum",
+            "instanceLocation": "#/minLength",
+            "keyword": "minimum",
+            "error": "The value -1 should be at least 0."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#",
+                "instanceLocation": "#",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/title",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/title",
+                    "instanceLocation": "#",
+                    "keyword": "title",
+                    "annotation": "Core schema meta-schema"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/definitions",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions",
+                    "instanceLocation": "#",
+                    "keyword": "definitions"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/properties",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties",
+                    "instanceLocation": "#",
+                    "keyword": "properties",
+                    "error": "At least one subschema failed validation.",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/$ref/properties/minLength/$ref",
+                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/properties/minLength/$ref",
+                        "instanceLocation": "#/minLength",
+                        "keyword": "$ref",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/$ref/properties/minLength/$ref",
+                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0",
+                            "instanceLocation": "#/minLength",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/$ref/properties/minLength/$ref/allOf",
+                                "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf",
+                                "instanceLocation": "#/minLength",
+                                "keyword": "allOf",
+                                "error": "1 of 2 subschemas failed validation.",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/0/$ref",
+                                    "instanceLocation": "#/minLength",
+                                    "keyword": "$ref",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger",
+                                        "instanceLocation": "#/minLength",
+                                        "errors": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/type",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/type",
+                                            "instanceLocation": "#/minLength",
+                                            "keyword": "type"
+                                          },
+                                          {
+                                            "valid": false,
+                                            "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/0/$ref/minimum",
+                                            "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger/minimum",
+                                            "instanceLocation": "#/minLength",
+                                            "keyword": "minimum",
+                                            "error": "The value -1 should be at least 0."
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/1",
+                                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/1",
+                                    "instanceLocation": "#/minLength",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/$ref/properties/minLength/$ref/allOf/1/default",
+                                        "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0/allOf/1/default",
+                                        "instanceLocation": "#/minLength",
+                                        "keyword": "default"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/default",
+                    "absoluteKeywordLocation": "http://json-schema.org/draft-07/schema#/default",
+                    "instanceLocation": "#",
+                    "keyword": "default"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "property named $ref that is not a reference",
+    "schema": {"properties": {"$ref": {"type": "string"}}},
+    "tests": [
+      {
+        "description": "property named $ref valid",
+        "data": {"$ref": "a"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/$ref",
+                    "instanceLocation": "#/$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/$ref/type",
+                        "instanceLocation": "#/$ref",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "property named $ref invalid",
+        "data": {"$ref": 2},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/$ref/type",
+            "instanceLocation": "#/$ref",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/$ref/type",
+            "instanceLocation": "#/$ref",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/$ref",
+                    "instanceLocation": "#/$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/$ref/type",
+                        "instanceLocation": "#/$ref",
+                        "keyword": "type",
+                        "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "$ref to boolean schema true",
+    "schema": {"$ref": "#/definitions/bool", "definitions": {"bool": true}},
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "instanceLocation": "#"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "$ref to boolean schema false",
+    "schema": {"$ref": "#/definitions/bool", "definitions": {"bool": false}},
+    "tests": [
+      {
+        "description": "any value is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "error": "No value is valid against the false schema."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref",
+                "instanceLocation": "#",
+                "error": "No value is valid against the false schema."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "Recursive references between schemas",
+    "schema": {
+      "$id": "http://localhost:1234/tree",
+      "description": "tree of nodes",
+      "type": "object",
+      "properties": {
+        "meta": {"type": "string"},
+        "nodes": {"type": "array", "items": {"$ref": "node"}}
+      },
+      "required": ["meta", "nodes"],
+      "definitions": {
+        "node": {
+          "$id": "http://localhost:1234/node",
+          "description": "node",
+          "type": "object",
+          "properties": {
+            "value": {"type": "number"},
+            "subtree": {"$ref": "tree"}
+          },
+          "required": ["value"]
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid tree",
+        "data": {
+          "meta": "root",
+          "nodes": [
+            {
+              "value": 1,
+              "subtree": {
+                "meta": "child",
+                "nodes": [{"value": 1.1}, {"value": 1.2}]
+              }
+            },
+            {
+              "value": 2,
+              "subtree": {
+                "meta": "child",
+                "nodes": [{"value": 2.1}, {"value": 2.2}]
+              }
+            }
+          ]
+        },
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "annotations": [
+              {"valid": true, "keywordLocation": "#", "instanceLocation": "#"},
+              {
+                "valid": true,
+                "keywordLocation": "#/description",
+                "instanceLocation": "#",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items",
+                "instanceLocation": "#/nodes",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#",
+                    "instanceLocation": "#/nodes/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/0",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                        "instanceLocation": "#/nodes/0/subtree",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                            "instanceLocation": "#/nodes/0/subtree",
+                            "keyword": "description",
+                            "annotation": "tree of nodes"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                            "instanceLocation": "#/nodes/0/subtree/nodes",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                "keyword": "description",
+                                "annotation": "node"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                "keyword": "description",
+                                "annotation": "node"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#",
+                    "instanceLocation": "#/nodes/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/1",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                        "instanceLocation": "#/nodes/1/subtree",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                            "instanceLocation": "#/nodes/1/subtree",
+                            "keyword": "description",
+                            "annotation": "tree of nodes"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                            "instanceLocation": "#/nodes/1/subtree/nodes",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                "keyword": "description",
+                                "annotation": "node"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                "keyword": "description",
+                                "annotation": "node"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                "instanceLocation": "#/nodes/0",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/0",
+                    "keyword": "description",
+                    "annotation": "node"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                    "instanceLocation": "#/nodes/0/subtree",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                        "instanceLocation": "#/nodes/0/subtree",
+                        "keyword": "description",
+                        "annotation": "tree of nodes"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                        "instanceLocation": "#/nodes/0/subtree/nodes",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                            "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                            "keyword": "description",
+                            "annotation": "node"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                            "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                            "keyword": "description",
+                            "annotation": "node"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                "instanceLocation": "#/nodes/1",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/1",
+                    "keyword": "description",
+                    "annotation": "node"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                    "instanceLocation": "#/nodes/1/subtree",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                        "instanceLocation": "#/nodes/1/subtree",
+                        "keyword": "description",
+                        "annotation": "tree of nodes"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                        "instanceLocation": "#/nodes/1/subtree/nodes",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                            "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                            "keyword": "description",
+                            "annotation": "node"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                            "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                            "keyword": "description",
+                            "annotation": "node"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/0",
+                "keyword": "description",
+                "annotation": "node"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                "instanceLocation": "#/nodes/0/subtree",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                    "instanceLocation": "#/nodes/0/subtree",
+                    "keyword": "description",
+                    "annotation": "tree of nodes"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                    "instanceLocation": "#/nodes/0/subtree/nodes",
+                    "keyword": "items",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                        "keyword": "description",
+                        "annotation": "node"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                "instanceLocation": "#/nodes/0/subtree",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                "instanceLocation": "#/nodes/0/subtree/nodes",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                    "keyword": "description",
+                    "annotation": "node"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                    "keyword": "description",
+                    "annotation": "node"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                "keyword": "description",
+                "annotation": "node"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                "keyword": "description",
+                "annotation": "node"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/1",
+                "keyword": "description",
+                "annotation": "node"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                "instanceLocation": "#/nodes/1/subtree",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                    "instanceLocation": "#/nodes/1/subtree",
+                    "keyword": "description",
+                    "annotation": "tree of nodes"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                    "instanceLocation": "#/nodes/1/subtree/nodes",
+                    "keyword": "items",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                        "keyword": "description",
+                        "annotation": "node"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                "instanceLocation": "#/nodes/1/subtree",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                "instanceLocation": "#/nodes/1/subtree/nodes",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                    "keyword": "description",
+                    "annotation": "node"
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                    "keyword": "description",
+                    "annotation": "node"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                "keyword": "description",
+                "annotation": "node"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                "keyword": "description",
+                "annotation": "node"
+              }
+            ]
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/description",
+                "instanceLocation": "#",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties/nodes/items",
+                "instanceLocation": "#/nodes",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#",
+                    "instanceLocation": "#/nodes/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/0",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                        "instanceLocation": "#/nodes/0/subtree",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                            "instanceLocation": "#/nodes/0/subtree",
+                            "keyword": "description",
+                            "annotation": "tree of nodes"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                            "instanceLocation": "#/nodes/0/subtree/nodes",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                "keyword": "description",
+                                "annotation": "node"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                "keyword": "description",
+                                "annotation": "node"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes/items/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/node#",
+                    "instanceLocation": "#/nodes/1",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/description",
+                        "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                        "instanceLocation": "#/nodes/1",
+                        "keyword": "description",
+                        "annotation": "node"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                        "instanceLocation": "#/nodes/1/subtree",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                            "instanceLocation": "#/nodes/1/subtree",
+                            "keyword": "description",
+                            "annotation": "tree of nodes"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                            "instanceLocation": "#/nodes/1/subtree/nodes",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                "keyword": "description",
+                                "annotation": "node"
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                "keyword": "description",
+                                "annotation": "node"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/description",
+                "instanceLocation": "#",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/meta",
+                    "instanceLocation": "#/meta",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/meta/type",
+                        "instanceLocation": "#/meta",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/nodes",
+                    "instanceLocation": "#/nodes",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/type",
+                        "instanceLocation": "#/nodes",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/items",
+                        "instanceLocation": "#/nodes",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                            "instanceLocation": "#/nodes/0",
+                            "keyword": "$ref",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                "instanceLocation": "#/nodes/0",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "description",
+                                    "annotation": "node"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "type"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/properties",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "properties",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/value",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                        "instanceLocation": "#/nodes/0/value",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/value/type",
+                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                            "instanceLocation": "#/nodes/0/value",
+                                            "keyword": "type"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/subtree/$ref",
+                                        "instanceLocation": "#/nodes/0/subtree",
+                                        "keyword": "$ref",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                            "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                                            "instanceLocation": "#/nodes/0/subtree",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "description",
+                                                "annotation": "tree of nodes"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/type",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/type",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "type"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "properties",
+                                                "annotations": [
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta",
+                                                    "instanceLocation": "#/nodes/0/subtree/meta",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta/type",
+                                                        "instanceLocation": "#/nodes/0/subtree/meta",
+                                                        "keyword": "type"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes",
+                                                    "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/type",
+                                                        "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                        "keyword": "type"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                                                        "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                        "keyword": "items",
+                                                        "annotations": [
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/0/subtree/nodes/1/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/0/subtree/nodes/1/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/required",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/required",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "required"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/definitions",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/definitions",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "definitions"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/required",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "required"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                            "instanceLocation": "#/nodes/1",
+                            "keyword": "$ref",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                "instanceLocation": "#/nodes/1",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "description",
+                                    "annotation": "node"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "type"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/properties",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "properties",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/value",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                        "instanceLocation": "#/nodes/1/value",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/value/type",
+                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                            "instanceLocation": "#/nodes/1/value",
+                                            "keyword": "type"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/subtree/$ref",
+                                        "instanceLocation": "#/nodes/1/subtree",
+                                        "keyword": "$ref",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                            "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                                            "instanceLocation": "#/nodes/1/subtree",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "description",
+                                                "annotation": "tree of nodes"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/type",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/type",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "type"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "properties",
+                                                "annotations": [
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta",
+                                                    "instanceLocation": "#/nodes/1/subtree/meta",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta/type",
+                                                        "instanceLocation": "#/nodes/1/subtree/meta",
+                                                        "keyword": "type"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes",
+                                                    "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/type",
+                                                        "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                        "keyword": "type"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                                                        "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                        "keyword": "items",
+                                                        "annotations": [
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/1/subtree/nodes/0/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/1/subtree/nodes/0/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/1/subtree/nodes/1/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/1/subtree/nodes/1/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/required",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/required",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "required"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/definitions",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/definitions",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "definitions"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/required",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "required"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "invalid tree",
+        "data": {
+          "meta": "root",
+          "nodes": [
+            {
+              "value": 1,
+              "subtree": {
+                "meta": "child",
+                "nodes": [{"value": "string is invalid"}, {"value": 1.2}]
+              }
+            },
+            {
+              "value": 2,
+              "subtree": {
+                "meta": "child",
+                "nodes": [{"value": 2.1}, {"value": 2.2}]
+              }
+            }
+          ]
+        },
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+            "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+            "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/description",
+                "instanceLocation": "#",
+                "keyword": "description",
+                "annotation": "tree of nodes"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/meta",
+                    "instanceLocation": "#/meta",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/meta/type",
+                        "instanceLocation": "#/meta",
+                        "keyword": "type"
+                      }
+                    ]
+                  },
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/nodes",
+                    "instanceLocation": "#/nodes",
+                    "errors": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/nodes/type",
+                        "instanceLocation": "#/nodes",
+                        "keyword": "type"
+                      },
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/nodes/items",
+                        "instanceLocation": "#/nodes",
+                        "keyword": "items",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/nodes/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                            "instanceLocation": "#/nodes/0",
+                            "keyword": "$ref",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/nodes/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                "instanceLocation": "#/nodes/0",
+                                "errors": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "description",
+                                    "annotation": "node"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "type"
+                                  },
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/properties",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "properties",
+                                    "error": "At least one subschema failed validation.",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/value",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                        "instanceLocation": "#/nodes/0/value",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/value/type",
+                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                            "instanceLocation": "#/nodes/0/value",
+                                            "keyword": "type"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/subtree/$ref",
+                                        "instanceLocation": "#/nodes/0/subtree",
+                                        "keyword": "$ref",
+                                        "errors": [
+                                          {
+                                            "valid": false,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                            "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                                            "instanceLocation": "#/nodes/0/subtree",
+                                            "errors": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "description",
+                                                "annotation": "tree of nodes"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/type",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/type",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "type"
+                                              },
+                                              {
+                                                "valid": false,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "properties",
+                                                "error": "At least one subschema failed validation.",
+                                                "errors": [
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta",
+                                                    "instanceLocation": "#/nodes/0/subtree/meta",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta/type",
+                                                        "instanceLocation": "#/nodes/0/subtree/meta",
+                                                        "keyword": "type"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": false,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes",
+                                                    "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                    "errors": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/type",
+                                                        "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                        "keyword": "type"
+                                                      },
+                                                      {
+                                                        "valid": false,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                                                        "instanceLocation": "#/nodes/0/subtree/nodes",
+                                                        "keyword": "items",
+                                                        "errors": [
+                                                          {
+                                                            "valid": false,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                            "keyword": "$ref",
+                                                            "errors": [
+                                                              {
+                                                                "valid": false,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                "errors": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": false,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "properties",
+                                                                    "error": "At least one subschema failed validation.",
+                                                                    "errors": [
+                                                                      {
+                                                                        "valid": false,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+                                                                        "errors": [
+                                                                          {
+                                                                            "valid": false,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/0/subtree/nodes/0/value",
+                                                                            "keyword": "type",
+                                                                            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/0",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/0/subtree/nodes/1/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/0/subtree/nodes/1/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/0/subtree/nodes/1",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/required",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/required",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "required"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/definitions",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/definitions",
+                                                "instanceLocation": "#/nodes/0/subtree",
+                                                "keyword": "definitions"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/required",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                    "instanceLocation": "#/nodes/0",
+                                    "keyword": "required"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/nodes/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                            "instanceLocation": "#/nodes/1",
+                            "keyword": "$ref",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/nodes/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                "instanceLocation": "#/nodes/1",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/description",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "description",
+                                    "annotation": "node"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "type"
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/properties",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "properties",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/value",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                        "instanceLocation": "#/nodes/1/value",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/value/type",
+                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                            "instanceLocation": "#/nodes/1/value",
+                                            "keyword": "type"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/subtree/$ref",
+                                        "instanceLocation": "#/nodes/1/subtree",
+                                        "keyword": "$ref",
+                                        "annotations": [
+                                          {
+                                            "valid": true,
+                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref",
+                                            "absoluteKeywordLocation": "http://localhost:1234/tree#",
+                                            "instanceLocation": "#/nodes/1/subtree",
+                                            "annotations": [
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/description",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/description",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "description",
+                                                "annotation": "tree of nodes"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/type",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/type",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "type"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/properties",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "properties",
+                                                "annotations": [
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta",
+                                                    "instanceLocation": "#/nodes/1/subtree/meta",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/meta/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/meta/type",
+                                                        "instanceLocation": "#/nodes/1/subtree/meta",
+                                                        "keyword": "type"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "valid": true,
+                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes",
+                                                    "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes",
+                                                    "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                    "annotations": [
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/type",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/type",
+                                                        "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                        "keyword": "type"
+                                                      },
+                                                      {
+                                                        "valid": true,
+                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items",
+                                                        "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items",
+                                                        "instanceLocation": "#/nodes/1/subtree/nodes",
+                                                        "keyword": "items",
+                                                        "annotations": [
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/1/subtree/nodes/0/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/1/subtree/nodes/0/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/0",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "valid": true,
+                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                            "absoluteKeywordLocation": "http://localhost:1234/tree#/properties/nodes/items/$ref",
+                                                            "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                            "keyword": "$ref",
+                                                            "annotations": [
+                                                              {
+                                                                "valid": true,
+                                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref",
+                                                                "absoluteKeywordLocation": "http://localhost:1234/node#",
+                                                                "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                "annotations": [
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/description",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/description",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "description",
+                                                                    "annotation": "node"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/type",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/type",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "type"
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/properties",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "properties",
+                                                                    "annotations": [
+                                                                      {
+                                                                        "valid": true,
+                                                                        "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value",
+                                                                        "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value",
+                                                                        "instanceLocation": "#/nodes/1/subtree/nodes/1/value",
+                                                                        "annotations": [
+                                                                          {
+                                                                            "valid": true,
+                                                                            "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/properties/value/type",
+                                                                            "absoluteKeywordLocation": "http://localhost:1234/node#/properties/value/type",
+                                                                            "instanceLocation": "#/nodes/1/subtree/nodes/1/value",
+                                                                            "keyword": "type"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "valid": true,
+                                                                    "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/properties/nodes/items/$ref/required",
+                                                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                                                    "instanceLocation": "#/nodes/1/subtree/nodes/1",
+                                                                    "keyword": "required"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/required",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/required",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "required"
+                                              },
+                                              {
+                                                "valid": true,
+                                                "keywordLocation": "#/properties/nodes/items/$ref/properties/subtree/$ref/definitions",
+                                                "absoluteKeywordLocation": "http://localhost:1234/tree#/definitions",
+                                                "instanceLocation": "#/nodes/1/subtree",
+                                                "keyword": "definitions"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/nodes/items/$ref/required",
+                                    "absoluteKeywordLocation": "http://localhost:1234/node#/required",
+                                    "instanceLocation": "#/nodes/1",
+                                    "keyword": "required"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "refs with quote",
+    "schema": {
+      "properties": {"foo\"bar": {"$ref": "#/definitions/foo%22bar"}},
+      "definitions": {"foo\"bar": {"type": "number"}}
+    },
+    "tests": [
+      {
+        "description": "object with numbers is valid",
+        "data": {"foo\"bar": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo\"bar/$ref",
+                    "instanceLocation": "#/foo\"bar",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/foo\"bar/$ref",
+                        "instanceLocation": "#/foo\"bar",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/foo\"bar/$ref/type",
+                            "instanceLocation": "#/foo\"bar",
+                            "keyword": "type"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with strings is invalid",
+        "data": {"foo\"bar": "1"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo\"bar/$ref/type",
+            "instanceLocation": "#/foo\"bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/foo\"bar/$ref/type",
+            "instanceLocation": "#/foo\"bar",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/foo\"bar/$ref",
+                    "instanceLocation": "#/foo\"bar",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/foo\"bar/$ref",
+                        "instanceLocation": "#/foo\"bar",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/foo\"bar/$ref/type",
+                            "instanceLocation": "#/foo\"bar",
+                            "keyword": "type",
+                            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/refRemote.json
+++ b/tests/draft2019-04/refRemote.json
@@ -1,0 +1,1306 @@
+[
+  {
+    "description": "remote ref",
+    "schema": {"$ref": "http://localhost:1234/integer.json"},
+    "tests": [
+      {
+        "description": "remote ref valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/integer.json#",
+                "instanceLocation": "#",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://localhost:1234/integer.json#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "remote ref invalid",
+        "data": "a",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/integer.json#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/integer.json#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/integer.json#",
+                "instanceLocation": "#",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://localhost:1234/integer.json#/type",
+                    "instanceLocation": "#",
+                    "keyword": "type",
+                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "fragment within remote ref",
+    "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+    "tests": [
+      {
+        "description": "remote fragment valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer",
+                "instanceLocation": "#",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+                    "instanceLocation": "#",
+                    "keyword": "type"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "remote fragment invalid",
+        "data": "a",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer",
+                "instanceLocation": "#",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/type",
+                    "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+                    "instanceLocation": "#",
+                    "keyword": "type",
+                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "ref within remote ref",
+    "schema": {"$ref": "http://localhost:1234/subSchemas.json#/refToInteger"},
+    "tests": [
+      {
+        "description": "ref within ref valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/$ref/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/refToInteger/$ref",
+                "instanceLocation": "#",
+                "keyword": "$ref",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/$ref/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer",
+                    "instanceLocation": "#",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/$ref/$ref/type",
+                        "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+                        "instanceLocation": "#",
+                        "keyword": "type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ref within ref invalid",
+        "data": "a",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/$ref/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/$ref/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#/$ref",
+            "instanceLocation": "#",
+            "keyword": "$ref",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/$ref/$ref",
+                "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/refToInteger/$ref",
+                "instanceLocation": "#",
+                "keyword": "$ref",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/$ref/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer",
+                    "instanceLocation": "#",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/$ref/$ref/type",
+                        "absoluteKeywordLocation": "http://localhost:1234/subSchemas.json#/integer/type",
+                        "instanceLocation": "#",
+                        "keyword": "type",
+                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "base URI change",
+    "schema": {
+      "$id": "http://localhost:1234/",
+      "items": {"$id": "folder/", "items": {"$ref": "folderInteger.json"}}
+    },
+    "tests": [
+      {
+        "description": "base URI change ref valid",
+        "data": [[1]],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/0",
+                        "keyword": "items",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/items/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/items/items/$ref",
+                            "instanceLocation": "#/0/0",
+                            "keyword": "$ref",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/items/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                "instanceLocation": "#/0/0",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/items/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                    "instanceLocation": "#/0/0",
+                                    "keyword": "type"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "base URI change ref invalid",
+        "data": [["a"]],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/items/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/0/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/items/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/0/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/items",
+                "instanceLocation": "#",
+                "keyword": "items",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/items",
+                    "instanceLocation": "#/0",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/items/items",
+                        "instanceLocation": "#/0",
+                        "keyword": "items",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/items/items/$ref",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/items/items/$ref",
+                            "instanceLocation": "#/0/0",
+                            "keyword": "$ref",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/items/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                "instanceLocation": "#/0/0",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/items/items/$ref/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                    "instanceLocation": "#/0/0",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "base URI change - change folder",
+    "schema": {
+      "$id": "http://localhost:1234/scope_change_defs1.json",
+      "type": "object",
+      "properties": {"list": {"$ref": "#/definitions/baz"}},
+      "definitions": {
+        "baz": {
+          "$id": "folder/",
+          "type": "array",
+          "items": {"$ref": "folderInteger.json"}
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": {"list": [1]},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/list/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/scope_change_defs1.json#/properties/list/$ref",
+                    "instanceLocation": "#/list",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/list/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz",
+                        "instanceLocation": "#/list",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/type",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/type",
+                            "instanceLocation": "#/list",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/items",
+                            "instanceLocation": "#/list",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/items/$ref",
+                                "instanceLocation": "#/list/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                    "instanceLocation": "#/list/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                        "instanceLocation": "#/list/0",
+                                        "keyword": "type"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": {"list": ["a"]},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/list/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/list/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/list/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/scope_change_defs1.json#/properties/list/$ref",
+                    "instanceLocation": "#/list",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/list/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz",
+                        "instanceLocation": "#/list",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/type",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/type",
+                            "instanceLocation": "#/list",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/list/$ref/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/items",
+                            "instanceLocation": "#/list",
+                            "keyword": "items",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/items/$ref",
+                                "instanceLocation": "#/list/0",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                    "instanceLocation": "#/list/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                        "instanceLocation": "#/list/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "base URI change - change folder in subschema",
+    "schema": {
+      "$id": "http://localhost:1234/scope_change_defs2.json",
+      "type": "object",
+      "properties": {"list": {"$ref": "#/definitions/baz/definitions/bar"}},
+      "definitions": {
+        "baz": {
+          "$id": "folder/",
+          "definitions": {
+            "bar": {"type": "array", "items": {"$ref": "folderInteger.json"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": {"list": [1]},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/list/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/scope_change_defs2.json#/properties/list/$ref",
+                    "instanceLocation": "#/list",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/list/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar",
+                        "instanceLocation": "#/list",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/type",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/type",
+                            "instanceLocation": "#/list",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/items",
+                            "instanceLocation": "#/list",
+                            "keyword": "items",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/items/$ref",
+                                "instanceLocation": "#/list/0",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                    "instanceLocation": "#/list/0",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                        "instanceLocation": "#/list/0",
+                                        "keyword": "type"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": {"list": ["a"]},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/list/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+            "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+            "instanceLocation": "#/list/0",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/list/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/scope_change_defs2.json#/properties/list/$ref",
+                    "instanceLocation": "#/list",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/list/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar",
+                        "instanceLocation": "#/list",
+                        "errors": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/list/$ref/type",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/type",
+                            "instanceLocation": "#/list",
+                            "keyword": "type"
+                          },
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/list/$ref/items",
+                            "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/items",
+                            "instanceLocation": "#/list",
+                            "keyword": "items",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/folder/#/definitions/baz/definitions/bar/items/$ref",
+                                "instanceLocation": "#/list/0",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/list/$ref/items/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#",
+                                    "instanceLocation": "#/list/0",
+                                    "errors": [
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/properties/list/$ref/items/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/folder/folderInteger.json#/type",
+                                        "instanceLocation": "#/list/0",
+                                        "keyword": "type",
+                                        "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/definitions",
+                "instanceLocation": "#",
+                "keyword": "definitions"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "root ref in remote ref",
+    "schema": {
+      "$id": "http://localhost:1234/object",
+      "type": "object",
+      "properties": {"name": {"$ref": "name.json#/definitions/orNull"}}
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": {"name": "foo"},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/name/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/object#/properties/name/$ref",
+                    "instanceLocation": "#/name",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/name/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull",
+                        "instanceLocation": "#/name",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/name/$ref/anyOf",
+                            "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf",
+                            "instanceLocation": "#/name",
+                            "keyword": "anyOf",
+                            "annotations": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/0",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0",
+                                "instanceLocation": "#/name",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/0/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0/type",
+                                    "instanceLocation": "#/name",
+                                    "keyword": "type",
+                                    "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/1/$ref",
+                                "instanceLocation": "#/name",
+                                "keyword": "$ref",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#",
+                                    "instanceLocation": "#/name",
+                                    "annotations": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/definitions",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "definitions"
+                                      },
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/type",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "type"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is valid",
+        "data": {"name": null},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/name/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/object#/properties/name/$ref",
+                    "instanceLocation": "#/name",
+                    "keyword": "$ref",
+                    "annotations": [
+                      {
+                        "valid": true,
+                        "keywordLocation": "#/properties/name/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull",
+                        "instanceLocation": "#/name",
+                        "annotations": [
+                          {
+                            "valid": true,
+                            "keywordLocation": "#/properties/name/$ref/anyOf",
+                            "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf",
+                            "instanceLocation": "#/name",
+                            "keyword": "anyOf",
+                            "annotations": [
+                              {
+                                "valid": true,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/0",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0",
+                                "instanceLocation": "#/name",
+                                "annotations": [
+                                  {
+                                    "valid": true,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/0/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0/type",
+                                    "instanceLocation": "#/name",
+                                    "keyword": "type"
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/1/$ref",
+                                "instanceLocation": "#/name",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#",
+                                    "instanceLocation": "#/name",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/definitions",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "definitions"
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/type",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "type",
+                                        "error": "Values of type \"null\" are not one of the allowed types \"string\"."
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object is invalid",
+        "data": {"name": {"name": null}},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/name/$ref/anyOf",
+                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf",
+                "instanceLocation": "#/name",
+                "keyword": "anyOf"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/name/$ref/anyOf/0/type",
+                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0/type",
+                "instanceLocation": "#/name",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/type",
+                "absoluteKeywordLocation": "http://localhost:1234/name.json#/type",
+                "instanceLocation": "#/name",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/properties/name/$ref/anyOf",
+            "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf",
+            "instanceLocation": "#/name",
+            "keyword": "anyOf",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/name/$ref/anyOf/0/type",
+                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0/type",
+                "instanceLocation": "#/name",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/type",
+                "absoluteKeywordLocation": "http://localhost:1234/name.json#/type",
+                "instanceLocation": "#/name",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+              }
+            ]
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "error": "At least one subschema failed validation.",
+                "errors": [
+                  {
+                    "valid": false,
+                    "keywordLocation": "#/properties/name/$ref",
+                    "absoluteKeywordLocation": "http://localhost:1234/object#/properties/name/$ref",
+                    "instanceLocation": "#/name",
+                    "keyword": "$ref",
+                    "errors": [
+                      {
+                        "valid": false,
+                        "keywordLocation": "#/properties/name/$ref",
+                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull",
+                        "instanceLocation": "#/name",
+                        "errors": [
+                          {
+                            "valid": false,
+                            "keywordLocation": "#/properties/name/$ref/anyOf",
+                            "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf",
+                            "instanceLocation": "#/name",
+                            "keyword": "anyOf",
+                            "errors": [
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/0",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0",
+                                "instanceLocation": "#/name",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/0/type",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/0/type",
+                                    "instanceLocation": "#/name",
+                                    "keyword": "type",
+                                    "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+                                  }
+                                ]
+                              },
+                              {
+                                "valid": false,
+                                "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions/orNull/anyOf/1/$ref",
+                                "instanceLocation": "#/name",
+                                "keyword": "$ref",
+                                "errors": [
+                                  {
+                                    "valid": false,
+                                    "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref",
+                                    "absoluteKeywordLocation": "http://localhost:1234/name.json#",
+                                    "instanceLocation": "#/name",
+                                    "errors": [
+                                      {
+                                        "valid": true,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/definitions",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/definitions",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "definitions"
+                                      },
+                                      {
+                                        "valid": false,
+                                        "keywordLocation": "#/properties/name/$ref/anyOf/1/$ref/type",
+                                        "absoluteKeywordLocation": "http://localhost:1234/name.json#/type",
+                                        "instanceLocation": "#/name",
+                                        "keyword": "type",
+                                        "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/required.json
+++ b/tests/draft2019-04/required.json
@@ -1,0 +1,372 @@
+[
+  {
+    "description": "required validation",
+    "schema": {"properties": {"foo": {}, "bar": {}}, "required": ["foo"]},
+    "tests": [
+      {
+        "description": "present required property is valid",
+        "data": {"foo": 1},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/foo",
+                    "instanceLocation": "#/foo"
+                  }
+                ]
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-present required property is invalid",
+        "data": {"bar": 1},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties",
+                "annotations": [
+                  {
+                    "valid": true,
+                    "keywordLocation": "#/properties/bar",
+                    "instanceLocation": "#/bar"
+                  }
+                ]
+              },
+              {
+                "valid": false,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\"] are required."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores arrays",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores strings",
+        "data": "",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "required default validation",
+    "schema": {"properties": {"foo": {}}},
+    "tests": [
+      {
+        "description": "not required by default",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "required with empty array",
+    "schema": {"properties": {"foo": {}}, "required": []},
+    "tests": [
+      {
+        "description": "property not required",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/properties",
+                "instanceLocation": "#",
+                "keyword": "properties"
+              },
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "required with escaped characters",
+    "schema": {
+      "required": [
+        "foo\nbar",
+        "foo\"bar",
+        "foo\bar",
+        "foo\rbar",
+        "foo\tbar",
+        "foo\fbar"
+      ]
+    },
+    "tests": [
+      {
+        "description": "object with all properties present is valid",
+        "data": {
+          "foo\nbar": 1,
+          "foo\"bar": 1,
+          "foo\bar": 1,
+          "foo\rbar": 1,
+          "foo\tbar": 1,
+          "foo\fbar": 1
+        },
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object with some properties missing is invalid",
+        "data": {"foo\nbar": "1", "foo\"bar": "1"},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\\\bar\",\"foo\rbar\",\"foo\tbar\",\"foo\fbar\"] are required."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/required",
+            "instanceLocation": "#",
+            "keyword": "required",
+            "error": "The properties [\"foo\\\bar\",\"foo\rbar\",\"foo\tbar\",\"foo\fbar\"] are required."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/required",
+                "instanceLocation": "#",
+                "keyword": "required",
+                "error": "The properties [\"foo\\\bar\",\"foo\rbar\",\"foo\tbar\",\"foo\fbar\"] are required."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/type.json
+++ b/tests/draft2019-04/type.json
@@ -1,0 +1,2703 @@
+[
+  {
+    "description": "integer type matches integers",
+    "schema": {"type": "integer"},
+    "tests": [
+      {
+        "description": "an integer is an integer",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not an integer",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not an integer",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is still not an integer, even if it looks like one",
+        "data": "1",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not an integer",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not an integer",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is not an integer",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not an integer",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"integer\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"integer\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"integer\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "number type matches numbers",
+    "schema": {"type": "number"},
+    "tests": [
+      {
+        "description": "an integer is a number",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is a number",
+        "data": 1.1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not a number",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is still not a number, even if it looks like one",
+        "data": "1",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not a number",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not a number",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is not a number",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not a number",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"number\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"number\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"number\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "string type matches strings",
+    "schema": {"type": "string"},
+    "tests": [
+      {
+        "description": "1 is not a string",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not a string",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is a string",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is still a string, even if it looks like a number",
+        "data": "1",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an empty string is still a string",
+        "data": "",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not a string",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not a string",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is not a string",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not a string",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "object type matches objects",
+    "schema": {"type": "object"},
+    "tests": [
+      {
+        "description": "an integer is not an object",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not an object",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not an object",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is an object",
+        "data": {},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not an object",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is not an object",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not an object",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"object\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"object\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"object\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "array type matches arrays",
+    "schema": {"type": "array"},
+    "tests": [
+      {
+        "description": "an integer is not an array",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not an array",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not an array",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not an array",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is an array",
+        "data": [],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is not an array",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not an array",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"array\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"array\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"array\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "boolean type matches booleans",
+    "schema": {"type": "boolean"},
+    "tests": [
+      {
+        "description": "an integer is not a boolean",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "zero is not a boolean",
+        "data": 0,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not a boolean",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not a boolean",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an empty string is not a boolean",
+        "data": "",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not a boolean",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not a boolean",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "true is a boolean",
+        "data": true,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "false is a boolean",
+        "data": false,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is not a boolean",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types \"boolean\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "null type matches only the null object",
+    "schema": {"type": "null"},
+    "tests": [
+      {
+        "description": "an integer is not null",
+        "data": 1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is not null",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "zero is not null",
+        "data": 0,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is not null",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an empty string is not null",
+        "data": "",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is not null",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is not null",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "true is not null",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "false is not null",
+        "data": false,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types \"null\"."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is null",
+        "data": null,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "multiple types can be specified in an array",
+    "schema": {"type": ["integer", "string"]},
+    "tests": [
+      {
+        "description": "an integer is valid",
+        "data": 1,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a string is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a float is invalid",
+        "data": 1.1,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types [\"integer\",\"string\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an object is invalid",
+        "data": {},
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"object\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"object\" are not one of the allowed types [\"integer\",\"string\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "an array is invalid",
+        "data": [],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"array\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"array\" are not one of the allowed types [\"integer\",\"string\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "a boolean is invalid",
+        "data": true,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"boolean\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"boolean\" are not one of the allowed types [\"integer\",\"string\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is invalid",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types [\"integer\",\"string\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types [\"integer\",\"string\"]."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "type as array with one item",
+    "schema": {"type": "string"},
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types \"string\"."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "type: array or object",
+    "schema": {"type": ["array", "object"]},
+    "tests": [
+      {
+        "description": "array is valid",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object is valid",
+        "data": {"foo": 123},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"object\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"object\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is invalid",
+        "data": null,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"null\" are not one of the allowed types [\"array\",\"object\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"null\" are not one of the allowed types [\"array\",\"object\"]."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "description": "type: array, object or null",
+    "schema": {"type": ["array", "null", "object"]},
+    "tests": [
+      {
+        "description": "array is valid",
+        "data": [1, 2, 3],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "object is valid",
+        "data": {"foo": 123},
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "null is valid",
+        "data": null,
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"number\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/type",
+            "instanceLocation": "#",
+            "keyword": "type",
+            "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/type",
+                "instanceLocation": "#",
+                "keyword": "type",
+                "error": "Values of type \"string\" are not one of the allowed types [\"array\",\"null\",\"object\"]."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/draft2019-04/uniqueItems.json
+++ b/tests/draft2019-04/uniqueItems.json
@@ -1,0 +1,434 @@
+[
+  {
+    "description": "uniqueItems validation",
+    "schema": {"uniqueItems": true},
+    "tests": [
+      {
+        "description": "unique array of integers is valid",
+        "data": [1, 2],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-unique array of integers is invalid",
+        "data": [1, 1],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "numbers are unique if mathematically unequal",
+        "data": [1, 1, 1],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "unique array of objects is valid",
+        "data": [{"foo": "bar"}, {"foo": "baz"}],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-unique array of objects is invalid",
+        "data": [{"foo": "bar"}, {"foo": "bar"}],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "unique array of nested objects is valid",
+        "data": [
+          {"foo": {"bar": {"baz": true}}},
+          {"foo": {"bar": {"baz": false}}}
+        ],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-unique array of nested objects is invalid",
+        "data": [
+          {"foo": {"bar": {"baz": true}}},
+          {"foo": {"bar": {"baz": true}}}
+        ],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "unique array of arrays is valid",
+        "data": [["foo"], ["bar"]],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-unique array of arrays is invalid",
+        "data": [["foo"], ["foo"]],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "1 and true are unique",
+        "data": [1, true],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "0 and false are unique",
+        "data": [0, false],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "unique heterogeneous types are valid",
+        "data": [{}, [1], true, null, 1],
+        "valid": true,
+        "output": {
+          "basic": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "detailed": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#"
+          },
+          "verbose": {
+            "valid": true,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "annotations": [
+              {
+                "valid": true,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "description": "non-unique heterogeneous types are invalid",
+        "data": [{}, [1], true, null, {}, 1],
+        "valid": false,
+        "output": {
+          "basic": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "detailed": {
+            "valid": false,
+            "keywordLocation": "#/uniqueItems",
+            "instanceLocation": "#",
+            "keyword": "uniqueItems",
+            "error": "Array contains multiple instances of at least one value."
+          },
+          "verbose": {
+            "valid": false,
+            "keywordLocation": "#",
+            "instanceLocation": "#",
+            "errors": [
+              {
+                "valid": false,
+                "keywordLocation": "#/uniqueItems",
+                "instanceLocation": "#",
+                "keyword": "uniqueItems",
+                "error": "Array contains multiple instances of at least one value."
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This is essentially the draft-07 test suite with the addition of the expected output.  I generated the output as I ran the test suite in [Manatee.Json](/gregsdennis/Manatee.Json).

It's missing a few things:

1. Some of the optional tests don't pass (for various reasons), so these aren't included.  I can look at adding them manually, but it would be a serious undertaking to make all of them pass in .Net (e.g. `zeroTerminatedFloats: "a float is not an integer even without fractional part"` just isn't going to happen since I don't save the string representation of numeric values, so I can't test for integer vs fraction-less float).
2. I didn't create any tests for the keywords, formats, etc. that are new as of this draft.
3. There should be tests that validate annotation collection.  Maybe these should be optional since annotation collection is not required.

Resolves #247