### PR TITLE
Rename definitions to $defs in the 2019-06 draft.

### DIFF
--- a/tests/draft2019-06/defs.json
+++ b/tests/draft2019-06/defs.json
@@ -5,11 +5,7 @@
         "tests": [
             {
                 "description": "valid definition schema",
-                "data": {
-                    "definitions": {
-                        "foo": {"type": "integer"}
-                    }
-                },
+                "data": {"$defs": {"foo": {"type": "integer"}}},
                 "valid": true
             }
         ]
@@ -20,11 +16,7 @@
         "tests": [
             {
                 "description": "invalid definition schema",
-                "data": {
-                    "definitions": {
-                        "foo": {"type": 1}
-                    }
-                },
+                "data": {"$defs": {"foo": {"type": 1}}},
                 "valid": false
             }
         ]

--- a/tests/draft2019-06/items.json
+++ b/tests/draft2019-06/items.json
@@ -133,13 +133,13 @@
     {
         "description": "items and subitems",
         "schema": {
-            "definitions": {
+            "$defs": {
                 "item": {
                     "type": "array",
                     "additionalItems": false,
                     "items": [
-                        { "$ref": "#/definitions/sub-item" },
-                        { "$ref": "#/definitions/sub-item" }
+                        { "$ref": "#/$defs/sub-item" },
+                        { "$ref": "#/$defs/sub-item" }
                     ]
                 },
                 "sub-item": {
@@ -150,9 +150,9 @@
             "type": "array",
             "additionalItems": false,
             "items": [
-                { "$ref": "#/definitions/item" },
-                { "$ref": "#/definitions/item" },
-                { "$ref": "#/definitions/item" }
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" }
             ]
         },
         "tests": [

--- a/tests/draft2019-06/ref.json
+++ b/tests/draft2019-06/ref.json
@@ -120,12 +120,12 @@
     {
         "description": "nested refs",
         "schema": {
-            "definitions": {
+            "$defs": {
                 "a": {"type": "integer"},
-                "b": {"$ref": "#/definitions/a"},
-                "c": {"$ref": "#/definitions/b"}
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
             },
-            "$ref": "#/definitions/c"
+            "$ref": "#/$defs/c"
         },
         "tests": [
             {
@@ -143,14 +143,14 @@
     {
         "description": "ref overrides any sibling keywords",
         "schema": {
-            "definitions": {
+            "$defs": {
                 "reffed": {
                     "type": "array"
                 }
             },
             "properties": {
                 "foo": {
-                    "$ref": "#/definitions/reffed",
+                    "$ref": "#/$defs/reffed",
                     "maxItems": 2
                 }
             }
@@ -212,8 +212,8 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
-            "$ref": "#/definitions/bool",
-            "definitions": {
+            "$ref": "#/$defs/bool",
+            "$defs": {
                 "bool": true
             }
         },
@@ -228,8 +228,8 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
-            "$ref": "#/definitions/bool",
-            "definitions": {
+            "$ref": "#/$defs/bool",
+            "$defs": {
                 "bool": false
             }
         },
@@ -255,7 +255,7 @@
                 }
             },
             "required": ["meta", "nodes"],
-            "definitions": {
+            "$defs": {
                 "node": {
                     "$id": "http://localhost:1234/node",
                     "description": "node",
@@ -333,9 +333,9 @@
         "description": "refs with quote",
         "schema": {
             "properties": {
-                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
             },
-            "definitions": {
+            "$defs": {
                 "foo\"bar": {"type": "number"}
             }
         },

--- a/tests/draft2019-06/refRemote.json
+++ b/tests/draft2019-06/refRemote.json
@@ -76,10 +76,8 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs1.json",
             "type" : "object",
-            "properties": {
-                "list": {"$ref": "#/definitions/baz"}
-            },
-            "definitions": {
+            "properties": {"list": {"$ref": "#/$defs/baz"}},
+            "$defs": {
                 "baz": {
                     "$id": "folder/",
                     "type": "array",
@@ -105,13 +103,11 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
-            "properties": {
-                "list": {"$ref": "#/definitions/baz/definitions/bar"}
-            },
-            "definitions": {
+            "properties": {"list": {"$ref": "#/$defs/baz/$defs/bar"}},
+            "$defs": {
                 "baz": {
                     "$id": "folder/",
-                    "definitions": {
+                    "$defs": {
                         "bar": {
                             "type": "array",
                             "items": {"$ref": "folderInteger.json"}
@@ -139,7 +135,7 @@
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name.json#/definitions/orNull"}
+                "name": {"$ref": "name.json#/$defs/orNull"}
             }
         },
         "tests": [


### PR DESCRIPTION
As per https://json-schema.org/work-in-progress/WIP-jsonschema-validation.html#rfc.appendix.C

Refs #265 

Although :( at

> Renamed to "$defs" to match "$ref" and be shorter to type.

I don't like "shorter to type" as a reason to do anything personally :/ but hey that's as usual on me to say when noticing that change. Oh well.

There's also a few places in the WIP that still say `definitions`. Will find wherever that should be filed.