### PR TITLE
Distinguish booleans and numbers, thanks to Hypothesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ for more information.
 
 * [jsonschema](https://github.com/Julian/jsonschema)
 * [fastjsonschema](https://github.com/seznam/python-fastjsonschema)
+* [hypothesis-jsonschema](https://github.com/Zac-HD/hypothesis-jsonschema)
 
 ### Ruby ###
 

--- a/tests/draft2019-06/anyOf.json
+++ b/tests/draft2019-06/anyOf.json
@@ -159,5 +159,31 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is ivalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-06/const.json
+++ b/tests/draft2019-06/const.json
@@ -82,5 +82,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {"const": false},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {"const": true},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match false",
+        "schema": {"const": 0},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {"const": 1},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-06/enum.json
+++ b/tests/draft2019-06/enum.json
@@ -91,5 +91,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-06/uniqueItems.json
+++ b/tests/draft2019-06/uniqueItems.json
@@ -19,6 +19,16 @@
                 "valid": false
             },
             {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
                 "description": "unique array of objects is valid",
                 "data": [{"foo": "bar"}, {"foo": "baz"}],
                 "valid": true

--- a/tests/draft4/anyOf.json
+++ b/tests/draft4/anyOf.json
@@ -126,5 +126,31 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is ivalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/enum.json
+++ b/tests/draft4/enum.json
@@ -91,5 +91,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -19,6 +19,16 @@
                 "valid": false
             },
             {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
                 "description": "unique array of objects is valid",
                 "data": [{"foo": "bar"}, {"foo": "baz"}],
                 "valid": true

--- a/tests/draft6/anyOf.json
+++ b/tests/draft6/anyOf.json
@@ -159,5 +159,31 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is ivalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/const.json
+++ b/tests/draft6/const.json
@@ -82,5 +82,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {"const": false},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {"const": true},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match false",
+        "schema": {"const": 0},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {"const": 1},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/enum.json
+++ b/tests/draft6/enum.json
@@ -91,5 +91,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -19,6 +19,16 @@
                 "valid": false
             },
             {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
                 "description": "unique array of objects is valid",
                 "data": [{"foo": "bar"}, {"foo": "baz"}],
                 "valid": true

--- a/tests/draft7/anyOf.json
+++ b/tests/draft7/anyOf.json
@@ -159,5 +159,31 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is ivalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/const.json
+++ b/tests/draft7/const.json
@@ -82,5 +82,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {"const": false},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {"const": true},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match false",
+        "schema": {"const": 0},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {"const": 1},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/enum.json
+++ b/tests/draft7/enum.json
@@ -91,5 +91,89 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -19,6 +19,16 @@
                 "valid": false
             },
             {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
                 "description": "unique array of objects is valid",
                 "data": [{"foo": "bar"}, {"foo": "baz"}],
                 "valid": true


### PR DESCRIPTION
While working on some optimisations in [`hypothesis-jsonschema`](https://github.com/Zac-HD/hypothesis-jsonschema) (now in the README), I discovered that while [the spec says](https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.3)

> Two JSON instances are said to be equal if and only if they are of the same type and have the same value according to the data model.

...but Python for example considers that `False == 0 and 1 == True`.  So I've added tests that will check that implementations do not consider zero equal to false or one equal to true, plus #256 which would also have been useful to me.

Caveat: I've only added these for draft7, as I don't know the other drafts well enough to be confident of the expected behaviour.  Happy to copy them across given some directions :smile: