### PR TITLE
Add valid instance for contains, type constraint in oneOf tests

### DIFF
--- a/tests/draft6/contains.json
+++ b/tests/draft6/contains.json
@@ -89,6 +89,11 @@
                 "description": "empty array is invalid",
                 "data": [],
                 "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/contains.json
+++ b/tests/draft7/contains.json
@@ -89,6 +89,11 @@
                 "description": "empty array is invalid",
                 "data": [],
                 "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
This closes #273 and better expresses the intent of the latter test.