### PR TITLE
Tests for ECMA 262 regex dialect

### DIFF
--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -9,5 +9,186 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\a$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\a",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0007",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -9,5 +9,186 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\a$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\a",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0007",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -9,5 +9,186 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\a$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\a",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0007",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -9,5 +9,186 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\a$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\a",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0007",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "data": "\\u00a0",
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This is a follow-up to #235, based on the research I did (and test suite I wrote) for my new Python library [`js-regex`](https://pypi.org/project/js-regex/) with a view to supporting it in Julian/jsonschema#607.

- Literal `\a` matches the ascii BEL character
- Literal `\cC` (with any a-zA-Z character) matches control characters
- `\d`, `\D`, `\w`, `\W`, `\s`, and `\S` match *ASCII* characters of the specific class, not any unicode char of those classes.

FYI all files are identical across the various drafts.