### PR TITLE
Replace the control escape \\a with \\t in ecmascript-regex.json

### DIFF
--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -30,20 +30,20 @@
         ]
     },
     {
-        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
             "type": "string",
-            "pattern": "^\\a$"
+            "pattern": "^\\t$"
         },
         "tests": [
             {
                 "description": "does not match",
-                "data": "\\a",
+                "data": "\\t",
                 "valid": false
             },
             {
                 "description": "matches",
-                "data": "\u0007",
+                "data": "\u0009",
                 "valid": true
             }
         ]

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -30,20 +30,20 @@
         ]
     },
     {
-        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
             "type": "string",
-            "pattern": "^\\a$"
+            "pattern": "^\\t$"
         },
         "tests": [
             {
                 "description": "does not match",
-                "data": "\\a",
+                "data": "\\t",
                 "valid": false
             },
             {
                 "description": "matches",
-                "data": "\u0007",
+                "data": "\u0009",
                 "valid": true
             }
         ]

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -30,20 +30,20 @@
         ]
     },
     {
-        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
             "type": "string",
-            "pattern": "^\\a$"
+            "pattern": "^\\t$"
         },
         "tests": [
             {
                 "description": "does not match",
-                "data": "\\a",
+                "data": "\\t",
                 "valid": false
             },
             {
                 "description": "matches",
-                "data": "\u0007",
+                "data": "\u0009",
                 "valid": true
             }
         ]

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -30,20 +30,20 @@
         ]
     },
     {
-        "description": "ECMA 262 regex converts \\a to ascii BEL",
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
             "type": "string",
-            "pattern": "^\\a$"
+            "pattern": "^\\t$"
         },
         "tests": [
             {
                 "description": "does not match",
-                "data": "\\a",
+                "data": "\\t",
                 "valid": false
             },
             {
                 "description": "matches",
-                "data": "\u0007",
+                "data": "\u0009",
                 "valid": true
             }
         ]


### PR DESCRIPTION
At least this fixes the wrong test case reported in issue #309