### PR TITLE
Expand and update a number of draft-2019-09 tests

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -42,8 +42,10 @@ REMOTES = {
         },
     },
     "subSchemas.json": {
-        u"integer": {u"type": u"integer"},
-        u"refToInteger": {u"$ref": u"#/integer"},
+        u"$defs": {
+            u"integer": {u"type": u"integer"},
+            u"refToInteger": {u"$ref": u"#/$defs/integer"},
+        }
     },
     "folder/folderInteger.json": {u"type": u"integer"}
 }

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -42,6 +42,10 @@ REMOTES = {
         },
     },
     "subSchemas.json": {
+        u"integer": {u"type": u"integer"},
+        u"refToInteger": {u"$ref": u"#/integer"},
+    },
+    "subSchemas-defs.json": {
         u"$defs": {
             u"integer": {u"type": u"integer"},
             u"refToInteger": {u"$ref": u"#/$defs/integer"},

--- a/remotes/subSchemas-defs.json
+++ b/remotes/subSchemas-defs.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/remotes/subSchemas.json
+++ b/remotes/subSchemas.json
@@ -1,8 +1,10 @@
 {
-    "integer": {
-        "type": "integer"
-    },
-    "refToInteger": {
-        "$ref": "#/integer"
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
     }
 }

--- a/remotes/subSchemas.json
+++ b/remotes/subSchemas.json
@@ -1,10 +1,8 @@
 {
-    "$defs": {
-        "integer": {
-            "type": "integer"
-        },
-        "refToInteger": {
-            "$ref": "#/$defs/integer"
-        }
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
     }
 }

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -76,15 +76,9 @@
         "description": "escaped pointer ref",
         "schema": {
             "$defs": {
-                "tilda~field": {
-                    "type": "integer"
-                },
-                "slash/field": {
-                    "type": "integer"
-                },
-                "percent%field": {
-                    "type": "integer"
-                }
+                "tilda~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
             },
             "properties": {
                 "tilda": {"$ref": "#/$defs/tilda~0field"},

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -75,13 +75,21 @@
     {
         "description": "escaped pointer ref",
         "schema": {
-            "tilda~field": {"type": "integer"},
-            "slash/field": {"type": "integer"},
-            "percent%field": {"type": "integer"},
+            "$defs": {
+                "tilda~field": {
+                    "type": "integer"
+                },
+                "slash/field": {
+                    "type": "integer"
+                },
+                "percent%field": {
+                    "type": "integer"
+                }
+            },
             "properties": {
-                "tilda": {"$ref": "#/tilda~0field"},
-                "slash": {"$ref": "#/slash~1field"},
-                "percent": {"$ref": "#/percent%25field"}
+                "tilda": {"$ref": "#/$defs/tilda~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
             }
         },
         "tests": [

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -17,7 +17,7 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/$defs/integer"},
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -34,7 +34,7 @@
     {
         "description": "ref within remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+            "$ref": "http://localhost:1234/subSchemas.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -76,7 +76,7 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs1.json",
             "type" : "object",
-            "properties": {"list": {"$ref": "#/$defs/baz"}},
+            "properties": {"list": {"$ref": "folder/"}},
             "$defs": {
                 "baz": {
                     "$id": "folder/",
@@ -103,7 +103,7 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
-            "properties": {"list": {"$ref": "#/$defs/baz/$defs/bar"}},
+            "properties": {"list": {"$ref": "folder/#/$defs/bar"}},
             "$defs": {
                 "baz": {
                     "$id": "folder/",

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -17,7 +17,7 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/$defs/integer"},
+        "schema": {"$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"},
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -34,7 +34,7 @@
     {
         "description": "ref within remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/subSchemas.json#/$defs/refToInteger"
+            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
             {

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "anyOf with false unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": false,
+            "anyOf": [
+                {"items": {"type": "string"}},
+                {"items": [true, true]}
+            ]
+        },
+        "tests": [
+            {
+                "description": "all strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "one item is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "two items are valid",
+                "data": [1, "two"],
+                "valid": true
+            },
+            {
+                "description": "three items are invalid",
+                "data": [1, "two", "three"],
+                "valid": false
+            },
+            {
+                "description": "four strings are valid",
+                "data": ["one", "two", "three", "four"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "complex unevaluated schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": {
+                "allOf": [{"minLength": 3}, {"type": "string"}]
+            },
+            "if": {"items": [{"type": "integer"}, {"type":  "array"}]}
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "if passes with one item",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "if passes with two items",
+                "data": [1, [2, 3]],
+                "valid": true
+            },
+            {
+                "description": "if passes with third valid unevaluated item",
+                "data": [1, [2, 3], "long-string"],
+                "valid": true
+            },
+            {
+                "description": "if passes with third invalid unevaluated item",
+                "data": [1, [2, 3], "zz"],
+                "valid": false
+            },
+            {
+                "description": "if fails with all valid unevaluated items",
+                "data": ["all", "long", "strings"],
+                "valid": true
+            },
+            {
+                "description": "if and unevaluated items fail",
+                "data": ["a", "b", "c"],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -1,21 +1,21 @@
 [
     {
-        "description": "can peer inside allOf, results in no-op",
+        "description": "allOf with false unevaluatedProperties",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "unevaluatedProperties": false,
             "allOf": [
-              {
-                "properties": {
-                  "foo": { "type": ["string", "null"] },
-                  "bar": { "type": ["string", "null"] }
+                {
+                    "properties": {
+                        "foo": { "type": ["string", "null"] },
+                        "bar": { "type": ["string", "null"] }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "not": { "enum": [ null ] }
+                    }
                 }
-              },
-              {
-                "additionalProperties": {
-                  "not": { "enum": [ null ] }
-                }
-              }
             ]
         },
         "tests": [
@@ -27,6 +27,64 @@
             {
                 "description": "null prop is invalid",
                 "data": { "bar": "foo", "bob": null },
+                "valid": false
+            },
+            {
+              "description": "named property with wrong type is invalid",
+              "data": { "bar": "foo", "bob": "who?" },
+              "valid": true
+            }
+        ]
+    },
+    {
+        "description": "complex unevaluated schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedProperties": {
+                "allOf": [{"minLength": 3}, {"type":  "string"}]
+            },
+            "if": {
+                "properties":  {
+                    "foo": {"type": "integer"},
+                    "arr": {"type": "array"}
+                },
+                "required": ["foo"]
+            }
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "if passes",
+                "data": {"foo": 3, "arr": [1,2]},
+                "valid": true
+            },
+            {
+                "description": "if passes with valid uneval",
+                "data": {"foo": 3, "arr": [1,2], "uneval": "long-string"},
+                "valid": true
+            },
+            {
+                "description": "if passes with invalid short uneval",
+                "data": {"foo": 3, "arr": [1,2], "uneval": "zz"},
+                "valid": false
+            },
+            {
+                "description": "if fails, and uneval fails because of array",
+                "data": {"foo": "not-an-int", "arr": [1,2], "uneval": "long-string"},
+                "valid": false
+            },
+            {
+                "description": "if fails with valid uneval",
+                "data": {"foo": "not-an-int", "uneval": "long-string"},
+                "valid": true
+            },
+            {
+                "description": "if fails with invalid uneval",
+                "data": {"foo": "zz", "uneval": "long-string"},
                 "valid": false
             }
         ]


### PR DESCRIPTION
This is a small pile of corrections and new tests from testing against a draft 2019-09 implementation I've been working on. Qualitative edits include:

 - Hoisting a bunch of schemas into the well-known `$defs` location, as the use of arbitrary keywords is undefined behavior per 8.2.4.4
 - Canonical-izing `$ref` keywords in remoteRefs.json (per 8.2.2.2, support of non-canonical URI is optional).
 - Expanded const & maximum / minimum tests.
 - `dependent` => `dependentRequired` or `dependentSchemas`.
 - Bugfix: `$ref` keyword, as an in-place application, no longer overrides keywords of the parent.
 - New tests for `unevaluatedItems`, and `unevaluatedProperties` tests with non-trivial unevaluated schemas.