### PR TITLE
Add nested allOf, oneOf tests

### DIFF
--- a/tests/draft2019-09/allOf.json
+++ b/tests/draft2019-09/allOf.json
@@ -214,5 +214,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/oneOf.json
+++ b/tests/draft2019-09/oneOf.json
@@ -244,5 +244,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/allOf.json
+++ b/tests/draft4/allOf.json
@@ -181,5 +181,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/anyOf.json
+++ b/tests/draft4/anyOf.json
@@ -152,5 +152,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/oneOf.json
+++ b/tests/draft4/oneOf.json
@@ -200,5 +200,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/allOf.json
+++ b/tests/draft6/allOf.json
@@ -214,5 +214,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/anyOf.json
+++ b/tests/draft6/anyOf.json
@@ -185,5 +185,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/oneOf.json
+++ b/tests/draft6/oneOf.json
@@ -244,5 +244,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/allOf.json
+++ b/tests/draft7/allOf.json
@@ -214,5 +214,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/anyOf.json
+++ b/tests/draft7/anyOf.json
@@ -185,5 +185,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/oneOf.json
+++ b/tests/draft7/oneOf.json
@@ -244,5 +244,31 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
I realized that the comparable test found in "anyOf" was failing on my validator; I added these to ensure that allOf & oneOf were also working similarly (they weren't).

Filing upstream for great posterity.