### PR TITLE
added test to illustrate $ref defining a new scope

### DIFF
--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -357,5 +357,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "prop1": "match",
+                "prop2": 1,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -375,9 +375,11 @@
         },
         "tests": [
             {
-                "prop1": "match",
-                "prop2": 1,
-                "valid": true
+                "description": "referenced subschema doesn't see annoations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Had a discussion about @handrews around this and thought it'd be a good test.

Basically `$ref` provides an additional layer of indirection that maintains `unevaluatedProperties`'s inability to see the rest of the schema.

So that
```
{
    "$defs": {
        "unevaluatedDef": {
            "unevaluatedProperties": false
        }
    },
    "properties": {
        "prop1": {"type": "string"}
    },
    "$ref": "#/$defs/unevaluatedDef"
}
```
becomes
```
{
    "properties": {
        "prop1": {"type": "string"}
    },
    "$new-scope": {
        "unevaluatedProperties": false
    }
}
```
(where `$new-scope` is essentially a no-op, except that it isolates what it contains)

rather than
```
{
    "properties": {
        "prop1": {"type": "string"}
    },
    "unevaluatedProperties": false
}
```
It illustrates how `$ref` resolution behaves when it's adjacent to other keywords.