### PR TITLE
[329] Add tests for uniqueItems=false

### DIFF
--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -89,7 +89,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
         "tests": [
@@ -138,8 +138,8 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
-            "uniqueItems": true, 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
             "additionalItems": false
         },
         "tests": [
@@ -162,6 +162,177 @@
                 "description": "[true, true] from items array is not valid",
                 "data": [true, true],
                 "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
             },
             {
                 "description": "extra items are invalid even if unique",

--- a/tests/draft3/uniqueItems.json
+++ b/tests/draft3/uniqueItems.json
@@ -79,7 +79,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
         "tests": [
@@ -128,8 +128,8 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
-            "uniqueItems": true, 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
             "additionalItems": false
         },
         "tests": [
@@ -152,6 +152,167 @@
                 "description": "[true, true] from items array is not valid",
                 "data": [true, true],
                 "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
             },
             {
                 "description": "extra items are invalid even if unique",

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -89,7 +89,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
         "tests": [
@@ -138,8 +138,8 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
-            "uniqueItems": true, 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
             "additionalItems": false
         },
         "tests": [
@@ -162,6 +162,177 @@
                 "description": "[true, true] from items array is not valid",
                 "data": [true, true],
                 "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
             },
             {
                 "description": "extra items are invalid even if unique",

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -89,7 +89,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
         "tests": [
@@ -138,8 +138,8 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
-            "items": [{"type": "boolean"}, {"type": "boolean"}], 
-            "uniqueItems": true, 
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
             "additionalItems": false
         },
         "tests": [
@@ -162,6 +162,177 @@
                 "description": "[true, true] from items array is not valid",
                 "data": [true, true],
                 "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
             },
             {
                 "description": "extra items are invalid even if unique",

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -169,5 +169,176 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This simply duplicates all the uniqueItems=true tests and makes
appropriate changes. All drafts are affected.

Closes #329