### PR TITLE
[264] Add pattern tests for non-BMP code points

### DIFF
--- a/tests/draft2019-09/pattern.json
+++ b/tests/draft2019-09/pattern.json
@@ -55,5 +55,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/patternProperties.json
+++ b/tests/draft2019-09/patternProperties.json
@@ -147,5 +147,52 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐉🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": { "D": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": { "DD": 1 },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft3/pattern.json
+++ b/tests/draft3/pattern.json
@@ -55,5 +55,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft3/patternProperties.json
+++ b/tests/draft3/patternProperties.json
@@ -111,5 +111,52 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐉🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": { "D": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": { "DD": 1 },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/pattern.json
+++ b/tests/draft4/pattern.json
@@ -55,5 +55,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/patternProperties.json
+++ b/tests/draft4/patternProperties.json
@@ -116,5 +116,52 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐉🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": { "D": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": { "DD": 1 },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/pattern.json
+++ b/tests/draft6/pattern.json
@@ -55,5 +55,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/patternProperties.json
+++ b/tests/draft6/patternProperties.json
@@ -147,5 +147,52 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐉🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": { "D": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": { "DD": 1 },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/pattern.json
+++ b/tests/draft7/pattern.json
@@ -55,5 +55,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/patternProperties.json
+++ b/tests/draft7/patternProperties.json
@@ -147,5 +147,52 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "non-BMP, checks for proper surrogate pair handling for UTF-16",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐉🐉": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": { "D": 1 },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": { "DD": 1 },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This adds both "pattern" and "patternProperties" tests. All drafts
are affected.

Closes #264