### PR TITLE
disambiguate underline from git conflict marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 JSON Schema Test Suite [![Build Status](https://github.com/json-schema-org/JSON-Schema-Test-Suite/workflows/Test%20Suite%20Sanity%20Checking/badge.svg)](https://github.com/json-schema-org/JSON-Schema-Test-Suite/actions?query=workflow%3A%22Test+Suite+Sanity+Checking%22)
-======================
+======
 
 This repository contains a set of JSON objects that implementors of JSON Schema
 validation libraries can use to test their validators.


### PR DESCRIPTION
Some tools object to `=======` appearing at the beginning of a line, thinking it is indicating a git conflict.