### PR TITLE
[348] Add reference-to-unknown-keyword tests to earlier drafts

### DIFF
--- a/tests/draft2019-09/optional/refToUnknownKeyword.json
+++ b/tests/draft2019-09/optional/refToUnknownKeyword.json
@@ -1,6 +1,6 @@
 [
     {
-        "description": "reference of a root arbitrary keyword ",
+        "description": "reference to a root arbitrary keyword ",
         "schema": {
             "unknown-keyword": {"type": "integer"},
             "properties": {
@@ -21,7 +21,7 @@
         ]
     },
     {
-        "description": "reference of an arbitrary keyword of a sub-schema",
+        "description": "reference to an arbitrary keyword of a sub-schema",
         "schema": {
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},

--- a/tests/draft3/optional/refToUnknownKeyword.json
+++ b/tests/draft3/optional/refToUnknownKeyword.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "reference to a root arbitrary keyword ",
+        "schema": {
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference to an arbitrary keyword of a sub-schema",
+        "schema": {
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft4/optional/refToUnknownKeyword.json
+++ b/tests/draft4/optional/refToUnknownKeyword.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "reference to a root arbitrary keyword ",
+        "schema": {
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference to an arbitrary keyword of a sub-schema",
+        "schema": {
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft6/optional/refToUnknownKeyword.json
+++ b/tests/draft6/optional/refToUnknownKeyword.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "reference to a root arbitrary keyword ",
+        "schema": {
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference to an arbitrary keyword of a sub-schema",
+        "schema": {
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/refToUnknownKeyword.json
+++ b/tests/draft7/optional/refToUnknownKeyword.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "reference to a root arbitrary keyword ",
+        "schema": {
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference to an arbitrary keyword of a sub-schema",
+        "schema": {
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Also renaming "reference of" to "reference to".

Closes #348