### PR TITLE
[244] Add a bunch of meta-schema tests

### DIFF
--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -126,5 +126,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: array",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema additionalItems: number",
+                "data": {
+                    "additionalItems": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalItems: string",
+                "data": {
+                    "additionalItems": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalItems: array",
+                "data": {
+                    "additionalItems": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalItems: null",
+                "data": {
+                    "additionalItems": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean additionalItems",
+                "data": {
+                    "additionalItems": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object additionalItems",
+                "data": {
+                    "additionalItems": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/additionalProperties.json
+++ b/tests/draft2019-09/additionalProperties.json
@@ -129,5 +129,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: object",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema additionalProperties: number",
+                "data": {
+                    "additionalProperties": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalProperties: string",
+                "data": {
+                    "additionalProperties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalProperties: array",
+                "data": {
+                    "additionalProperties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema additionalProperties: null",
+                "data": {
+                    "additionalProperties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean additionalProperties",
+                "data": {
+                    "additionalProperties": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object additionalProperties",
+                "data": {
+                    "additionalProperties": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/allOf.json
+++ b/tests/draft2019-09/allOf.json
@@ -290,5 +290,104 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: Boolean logic",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array allOf: number",
+                "data": {
+                    "allOf": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array allOf: string",
+                "data": {
+                    "allOf": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array allOf: Boolean",
+                "data": {
+                    "allOf": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array allOf: object",
+                "data": {
+                    "allOf": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array allOf: null",
+                "data": {
+                    "allOf": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty allOf",
+                "data": {
+                    "allOf": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema allOf: string",
+                "data": {
+                    "allOf": [ "integer" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema allOf: number",
+                "data": {
+                    "allOf": [ 1 ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema allOf: null",
+                "data": {
+                    "allOf": [ null ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema allOf: array",
+                "data": {
+                    "allOf": [ [] ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid allOf: boolean schema",
+                "data": {
+                    "allOf": [ true ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid allOf: empty schema",
+                "data": {
+                    "allOf": [ {} ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid allOf: schema",
+                "data": {
+                    "allOf": [ { "type": "integer" } ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/anchor.json
+++ b/tests/draft2019-09/anchor.json
@@ -77,5 +77,95 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema core tests: $anchor",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $anchor: number",
+                "data": {
+                    "$anchor": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $anchor: Boolean",
+                "data": {
+                    "$anchor": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $anchor: null",
+                "data": {
+                    "$anchor": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $anchor: array",
+                "data": {
+                    "$anchor": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $anchor: object",
+                "data": {
+                    "$anchor": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $anchor",
+                "data": {
+                    "$anchor": "himom"
+                },
+                "valid": true
+            },
+            {
+                "description": "Invalid $anchor: starts with invalid",
+                "data": {
+                    "$anchor": "-himom"
+                },
+                "valid": false
+              },
+            {
+                "description": "Invalid $anchor: ends with invalid",
+                "data": {
+                    "$anchor": "himom@"
+                },
+                "valid": false
+            },
+            {
+                "description": "Fragment syntax disallowed",
+                "data": {
+                    "$ref": "#foo",
+                    "$defs": {
+                        "A": {
+                            "$anchor": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid characters disallowed",
+                "data": {
+                    "$ref": "#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$anchor": "/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/anyOf.json
+++ b/tests/draft2019-09/anyOf.json
@@ -185,5 +185,104 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: Boolean logic",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array anyOf: number",
+                "data": {
+                    "anyOf": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array anyOf: string",
+                "data": {
+                    "anyOf": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array anyOf: Boolean",
+                "data": {
+                    "anyOf": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array anyOf: object",
+                "data": {
+                    "anyOf": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array anyOf: null",
+                "data": {
+                    "anyOf": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty anyOf",
+                "data": {
+                    "anyOf": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema anyOf: string",
+                "data": {
+                    "anyOf": [ "integer" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema anyOf: number",
+                "data": {
+                    "anyOf": [ 1 ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema anyOf: null",
+                "data": {
+                    "anyOf": [ null ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema anyOf: array",
+                "data": {
+                    "anyOf": [ [] ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid anyOf: boolean schema",
+                "data": {
+                    "anyOf": [ true ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid anyOf: empty schema",
+                "data": {
+                    "anyOf": [ {} ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid anyOf: schema",
+                "data": {
+                    "anyOf": [ { "type": "integer" } ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/comment.json
+++ b/tests/draft2019-09/comment.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema core tests: $comment",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $comment: number",
+                "data": {
+                    "$comment": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $comment: Boolean",
+                "data": {
+                    "$comment": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $comment: null",
+                "data": {
+                    "$comment": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $comment: array",
+                "data": {
+                    "$comment": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $comment: object",
+                "data": {
+                    "$comment": {}
+                },
+                "valid": false
+              },
+            {
+                "description": "Valid $comment",
+                "data": {
+                    "$comment": "This is a fine comment!"
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/const.json
+++ b/tests/draft2019-09/const.json
@@ -338,5 +338,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: const",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Anything goes for const",
+                "data": {
+                    "const": 1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/contains.json
+++ b/tests/draft2019-09/contains.json
@@ -125,5 +125,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: array",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema contains: number",
+                "data": {
+                    "contains": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contains: string",
+                "data": {
+                    "contains": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contains: array",
+                "data": {
+                    "contains": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contains: null",
+                "data": {
+                    "contains": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean contains",
+                "data": {
+                    "contains": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object contains",
+                "data": {
+                    "contains": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/default.json
+++ b/tests/draft2019-09/default.json
@@ -45,5 +45,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema meta-data tests: default",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "default can be anything",
+                "data": {
+                    "default": [ {} ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/defs.json
+++ b/tests/draft2019-09/defs.json
@@ -20,5 +20,120 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema core tests: $defs",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object $defs: number",
+                "data": {
+                    "$defs": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $defs: Boolean",
+                "data": {
+                    "$defs": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $defs: null",
+                "data": {
+                    "$defs": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $defs: array",
+                "data": {
+                    "$defs": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $defs: string",
+                "data": {
+                    "$defs": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $defs schema: boolean",
+                "data": {
+                    "$defs": {
+                        "theprop": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid $defs schema: object",
+                "data": {
+                    "$defs": {
+                        "theprop": {}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid $defs schema: good subschema",
+                "data": {
+                    "$defs": {
+                        "theprop": { "type": "integer" }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Invalid $defs schema: string",
+                "data": {
+                    "$defs": {
+                        "theprop": "hello"
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $defs schema: number",
+                "data": {
+                    "$defs": {
+                        "theprop": 1
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $defs schema: null",
+                "data": {
+                    "$defs": {
+                        "theprop": null
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $defs schema: array",
+                "data": {
+                    "$defs": {
+                        "theprop": []
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $defs schema: bad subschema",
+                "data": {
+                    "$defs": {
+                        "theprop": { "type": 1 }
+                    }
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/dependentRequired.json
+++ b/tests/draft2019-09/dependentRequired.json
@@ -138,5 +138,75 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: objects",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object dependentRequired: string",
+                "data": {
+                    "dependentRequired": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentRequired: Boolean",
+                "data": {
+                    "dependentRequired": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentRequired: null",
+                "data": {
+                    "dependentRequired": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentRequired: number",
+                "data": {
+                    "dependentRequired": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentRequired: array",
+                "data": {
+                    "dependentRequired": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string array dependentRequired",
+                "data": {
+                    "dependentRequired": {
+                        "hello": [ 1, "there" ]
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-unique string array dependentRequired",
+                "data": {
+                    "dependentRequired": {
+                        "hello": [ "there", "there" ]
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "String array dependentRequired",
+                "data": {
+                    "dependentRequired": {
+                        "hello": [ "there" ]
+                    }
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/dependentSchemas.json
+++ b/tests/draft2019-09/dependentSchemas.json
@@ -110,5 +110,109 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: conditional",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object dependentSchemas: string",
+                "data": {
+                    "dependentSchemas": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentSchemas: Boolean",
+                "data": {
+                    "dependentSchemas": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentSchemas: null",
+                "data": {
+                    "dependentSchemas": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentSchemas: number",
+                "data": {
+                    "dependentSchemas": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object dependentSchemas: array",
+                "data": {
+                    "dependentSchemas": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in dependentSchemas: string",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": "there"
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in dependentSchemas: null",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": null
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in dependentSchemas: number",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": 1
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in dependentSchemas: array",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": []
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean property in dependentSchemas",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Object property in dependentSchemas",
+                "data": {
+                    "dependentSchemas": {
+                        "hello": {}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Empty dependentSchemas",
+                "data": {
+                    "dependentSchemas": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/deprecated.json
+++ b/tests/draft2019-09/deprecated.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: deprecated",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-Boolean deprecated: number",
+                "data": {
+                    "deprecated": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean deprecated: string",
+                "data": {
+                    "deprecated": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean deprecated: null",
+                "data": {
+                    "deprecated": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean deprecated: array",
+                "data": {
+                    "deprecated": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean deprecated: object",
+                "data": {
+                    "deprecated": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid deprecated: Boolean",
+                "data": {
+                    "deprecated": true
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/description.json
+++ b/tests/draft2019-09/description.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: description",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string description: number",
+                "data": {
+                    "description": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string description: Boolean",
+                "data": {
+                    "description": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string description: null",
+                "data": {
+                    "description": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string description: array",
+                "data": {
+                    "description": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string description: object",
+                "data": {
+                    "description": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid description: string",
+                "data": {
+                    "description": "Tome"
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/enum.json
+++ b/tests/draft2019-09/enum.json
@@ -222,5 +222,62 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: enum",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array enum: number",
+                "data": {
+                    "enum": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array enum: string",
+                "data": {
+                    "enum": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array enum: Boolean",
+                "data": {
+                    "enum": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array enum: object",
+                "data": {
+                    "enum": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array enum: null",
+                "data": {
+                    "enum": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty enum is valid",
+                "data": {
+                    "enum": []
+                },
+                "valid": true
+            },
+            {
+                "description": "Non-unique enums are valid",
+                "data": {
+                    "enum": [ "hello", "hello" ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/examples.json
+++ b/tests/draft2019-09/examples.json
@@ -1,0 +1,56 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: examples",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array examples: number",
+                "data": {
+                    "examples": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array examples: string",
+                "data": {
+                    "examples": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array examples: null",
+                "data": {
+                    "examples": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array examples: Boolean",
+                "data": {
+                    "examples": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array examples: object",
+                "data": {
+                    "examples": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid examples: array of anything",
+                "data": {
+                    "examples": [
+                        true,
+                        "hello",
+                        {}
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/exclusiveMaximum.json
+++ b/tests/draft2019-09/exclusiveMaximum.json
@@ -26,5 +26,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: numeric instances",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number exclusiveMaximum: string",
+                "data": {
+                    "exclusiveMaximum": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMaximum: Boolean",
+                "data": {
+                    "exclusiveMaximum": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMaximum: array",
+                "data": {
+                    "exclusiveMaximum": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMaximum: object",
+                "data": {
+                    "exclusiveMaximum": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMaximum: null",
+                "data": {
+                    "exclusiveMaximum": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid exclusiveMaximum: number",
+                "data": {
+                    "exclusiveMaximum": 1.1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/exclusiveMinimum.json
+++ b/tests/draft2019-09/exclusiveMinimum.json
@@ -26,5 +26,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: numeric instances",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number exclusiveMinimum: string",
+                "data": {
+                    "exclusiveMinimum": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMinimum: Boolean",
+                "data": {
+                    "exclusiveMinimum": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMinimum: array",
+                "data": {
+                    "exclusiveMinimum": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMinimum: object",
+                "data": {
+                    "exclusiveMinimum": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number exclusiveMinimum: null",
+                "data": {
+                    "exclusiveMinimum": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid exclusiveMinimum: number",
+                "data": {
+                    "exclusiveMinimum": 1.1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/format.json
+++ b/tests/draft2019-09/format.json
@@ -682,5 +682,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema format tests",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string format: number",
+                "data": {
+                    "format": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string format: Boolean",
+                "data": {
+                    "format": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string format: null",
+                "data": {
+                    "format": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string format: array",
+                "data": {
+                    "format": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string format: object",
+                "data": {
+                    "format": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid format: string",
+                "data": {
+                    "format": "uri-reference"
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/id.json
+++ b/tests/draft2019-09/id.json
@@ -202,5 +202,62 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema core tests: $id",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $id: number",
+                "data": {
+                    "$id": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $id: Boolean",
+                "data": {
+                    "$id": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $id: null",
+                "data": {
+                    "$id": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $id: array",
+                "data": {
+                    "$id": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $id: object",
+                "data": {
+                    "$id": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $id",
+                "data": {
+                    "$id": "http://example.com/foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "Invalid $id: doesn't match pattern",
+                "data": {
+                    "$id": "#a"
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/if-then-else.json
+++ b/tests/draft2019-09/if-then-else.json
@@ -224,5 +224,139 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: conditional",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema if: number",
+                "data": {
+                    "if": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema if: string",
+                "data": {
+                    "if": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema if: array",
+                "data": {
+                    "if": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema if: null",
+                "data": {
+                    "if": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean if",
+                "data": {
+                    "if": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object if",
+                "data": {
+                    "if": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "Non-schema then: number",
+                "data": {
+                    "then": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema then: string",
+                "data": {
+                    "then": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema then: array",
+                "data": {
+                    "then": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema then: null",
+                "data": {
+                    "then": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean then",
+                "data": {
+                    "then": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object then",
+                "data": {
+                    "then": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "Non-schema else: number",
+                "data": {
+                    "else": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema else: string",
+                "data": {
+                    "else": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema else: array",
+                "data": {
+                    "else": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema else: null",
+                "data": {
+                    "else": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean else",
+                "data": {
+                    "else": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object else",
+                "data": {
+                    "else": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -246,5 +246,76 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: array",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema items: number",
+                "data": {
+                    "items": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema items: string",
+                "data": {
+                    "items": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema items: null",
+                "data": {
+                    "items": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean items",
+                "data": {
+                    "items": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object items",
+                "data": {
+                    "items": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "Empty array items",
+                "data": {
+                    "items": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema array items: string",
+                "data": {
+                    "items": [ "integer" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid array items: schema",
+                "data": {
+                    "items": [ { "type": "integer" } ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid array items: empty schema",
+                "data": {
+                    "items": [ {} ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxContains.json
+++ b/tests/draft2019-09/maxContains.json
@@ -75,5 +75,69 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: arrays",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number maxContains: string",
+                "data": {
+                    "maxContains": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxContains: Boolean",
+                "data": {
+                    "maxContains": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxContains: array",
+                "data": {
+                    "maxContains": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxContains: object",
+                "data": {
+                    "maxContains": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxContains: null",
+                "data": {
+                    "maxContains": null
+                },
+                "valid": false
+            },
+            {
+                "description": "maxContains is negative",
+                "data": {
+                    "maxContains": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "maxContains is floating-point",
+                "data": {
+                    "maxContains": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid maxContains: integer",
+                "data": {
+                    "maxContains": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxItems.json
+++ b/tests/draft2019-09/maxItems.json
@@ -24,5 +24,69 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: arrays",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number maxItems: string",
+                "data": {
+                    "maxItems": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxItems: Boolean",
+                "data": {
+                    "maxItems": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxItems: array",
+                "data": {
+                    "maxItems": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxItems: object",
+                "data": {
+                    "maxItems": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxItems: null",
+                "data": {
+                    "maxItems": null
+                },
+                "valid": false
+            },
+            {
+                "description": "maxItems is negative",
+                "data": {
+                    "maxItems": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "maxItems is floating-point",
+                "data": {
+                    "maxItems": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid maxItems: integer",
+                "data": {
+                    "maxItems": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxLength.json
+++ b/tests/draft2019-09/maxLength.json
@@ -29,5 +29,69 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: strings",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number maxLength: string",
+                "data": {
+                    "maxLength": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxLength: Boolean",
+                "data": {
+                    "maxLength": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxLength: array",
+                "data": {
+                    "maxLength": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxLength: object",
+                "data": {
+                    "maxLength": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxLength: null",
+                "data": {
+                    "maxLength": null
+                },
+                "valid": false
+            },
+            {
+                "description": "maxLength is negative",
+                "data": {
+                    "maxLength": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "maxLength is floating-point",
+                "data": {
+                    "maxLength": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid maxLength: integer",
+                "data": {
+                    "maxLength": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxProperties.json
+++ b/tests/draft2019-09/maxProperties.json
@@ -50,5 +50,69 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: objects",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number maxProperties: string",
+                "data": {
+                    "maxProperties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxProperties: Boolean",
+                "data": {
+                    "maxProperties": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxProperties: array",
+                "data": {
+                    "maxProperties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxProperties: object",
+                "data": {
+                    "maxProperties": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maxProperties: null",
+                "data": {
+                    "maxProperties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "maxProperties is negative",
+                "data": {
+                    "maxProperties": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "maxProperties is floating-point",
+                "data": {
+                    "maxProperties": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid maxProperties: integer",
+                "data": {
+                    "maxProperties": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maximum.json
+++ b/tests/draft2019-09/maximum.json
@@ -50,5 +50,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: numeric instances",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number maximum: string",
+                "data": {
+                    "maximum": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maximum: Boolean",
+                "data": {
+                    "maximum": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maximum: array",
+                "data": {
+                    "maximum": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maximum: object",
+                "data": {
+                    "maximum": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number maximum: null",
+                "data": {
+                    "maximum": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid maximum: number",
+                "data": {
+                    "maximum": 1.1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minContains.json
+++ b/tests/draft2019-09/minContains.json
@@ -168,5 +168,69 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: arrays",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number minContains: string",
+                "data": {
+                    "minContains": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minContains: Boolean",
+                "data": {
+                    "minContains": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minContains: array",
+                "data": {
+                    "minContains": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minContains: object",
+                "data": {
+                    "minContains": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minContains: null",
+                "data": {
+                    "minContains": null
+                },
+                "valid": false
+            },
+            {
+                "description": "minContains is negative",
+                "data": {
+                    "minContains": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "minContains is floating-point",
+                "data": {
+                    "minContains": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid minContains: integer",
+                "data": {
+                    "minContains": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minItems.json
+++ b/tests/draft2019-09/minItems.json
@@ -24,5 +24,69 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: arrays",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number minItems: string",
+                "data": {
+                    "minItems": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minItems: Boolean",
+                "data": {
+                    "minItems": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minItems: array",
+                "data": {
+                    "minItems": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minItems: object",
+                "data": {
+                    "minItems": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minItems: null",
+                "data": {
+                    "minItems": null
+                },
+                "valid": false
+            },
+            {
+                "description": "minItems is negative",
+                "data": {
+                    "minItems": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "minItems is floating-point",
+                "data": {
+                    "minItems": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid minItems: integer",
+                "data": {
+                    "minItems": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minLength.json
+++ b/tests/draft2019-09/minLength.json
@@ -29,5 +29,69 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: strings",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number minLength: string",
+                "data": {
+                    "minLength": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minLength: Boolean",
+                "data": {
+                    "minLength": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minLength: array",
+                "data": {
+                    "minLength": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minLength: object",
+                "data": {
+                    "minLength": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minLength: null",
+                "data": {
+                    "minLength": null
+                },
+                "valid": false
+            },
+            {
+                "description": "minLength is negative",
+                "data": {
+                    "minLength": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "minLength is floating-point",
+                "data": {
+                    "minLength": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid minLength: integer",
+                "data": {
+                    "minLength": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minProperties.json
+++ b/tests/draft2019-09/minProperties.json
@@ -34,5 +34,69 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: objects",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number minProperties: string",
+                "data": {
+                    "minProperties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minProperties: Boolean",
+                "data": {
+                    "minProperties": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minProperties: array",
+                "data": {
+                    "minProperties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minProperties: object",
+                "data": {
+                    "minProperties": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minProperties: null",
+                "data": {
+                    "minProperties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "minProperties is negative",
+                "data": {
+                    "minProperties": -1
+                },
+                "valid": false
+            },
+            {
+                "description": "minProperties is floating-point",
+                "data": {
+                    "minProperties": 1.5
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid minProperties: integer",
+                "data": {
+                    "minProperties": 0
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minimum.json
+++ b/tests/draft2019-09/minimum.json
@@ -65,5 +65,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: numeric instances",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number minimum: string",
+                "data": {
+                    "minimum": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minimum: Boolean",
+                "data": {
+                    "minimum": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minimum: array",
+                "data": {
+                    "minimum": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minimum: object",
+                "data": {
+                    "minimum": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number minimum: null",
+                "data": {
+                    "minimum": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid minimum: number",
+                "data": {
+                    "minimum": 1.1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/multipleOf.json
+++ b/tests/draft2019-09/multipleOf.json
@@ -56,5 +56,62 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: numeric instances",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-number multipleOf: string",
+                "data": {
+                    "multipleOf": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number multipleOf: Boolean",
+                "data": {
+                    "multipleOf": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number multipleOf: array",
+                "data": {
+                    "multipleOf": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number multipleOf: object",
+                "data": {
+                    "multipleOf": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-number multipleOf: null",
+                "data": {
+                    "multipleOf": null
+                },
+                "valid": false
+            },
+            {
+                "description": "multipleOf is zero",
+                "data": {
+                    "multipleOf": 0
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid multipleOf: number",
+                "data": {
+                    "multipleOf": 1.1
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/not.json
+++ b/tests/draft2019-09/not.json
@@ -113,5 +113,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: Boolean logic",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema not: number",
+                "data": {
+                    "not": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema not: string",
+                "data": {
+                    "not": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema not: array",
+                "data": {
+                    "not": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema not: null",
+                "data": {
+                    "not": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean not",
+                "data": {
+                    "not": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object not",
+                "data": {
+                    "not": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/oneOf.json
+++ b/tests/draft2019-09/oneOf.json
@@ -270,5 +270,104 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: Boolean logic",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array oneOf: number",
+                "data": {
+                    "oneOf": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array oneOf: string",
+                "data": {
+                    "oneOf": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array oneOf: Boolean",
+                "data": {
+                    "oneOf": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array oneOf: object",
+                "data": {
+                    "oneOf": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array oneOf: null",
+                "data": {
+                    "oneOf": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty oneOf",
+                "data": {
+                    "oneOf": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema oneOf: string",
+                "data": {
+                    "oneOf": [ "integer" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema oneOf: number",
+                "data": {
+                    "oneOf": [ 1 ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema oneOf: null",
+                "data": {
+                    "oneOf": [ null ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Not-a-schema oneOf: array",
+                "data": {
+                    "oneOf": [ [] ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid oneOf: boolean schema",
+                "data": {
+                    "oneOf": [ true ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid oneOf: empty schema",
+                "data": {
+                    "oneOf": [ {} ]
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid oneOf: schema",
+                "data": {
+                    "oneOf": [ { "type": "integer" } ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/optional/content.json
+++ b/tests/draft2019-09/optional/content.json
@@ -73,5 +73,155 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema content tests: contentEncoding",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string contentEncoding: number",
+                "data": {
+                    "contentEncoding": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentEncoding: Boolean",
+                "data": {
+                    "contentEncoding": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentEncoding: null",
+                "data": {
+                    "contentEncoding": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentEncoding: array",
+                "data": {
+                    "contentEncoding": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentEncoding: object",
+                "data": {
+                    "contentEncoding": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid contentEncoding",
+                "data": {
+                    "contentEncoding": "base64"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Meta-schema content tests: contentMediaType",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string contentMediaType: number",
+                "data": {
+                    "contentMediaType": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentMediaType: Boolean",
+                "data": {
+                    "contentMediaType": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentMediaType: null",
+                "data": {
+                    "contentMediaType": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentMediaType: array",
+                "data": {
+                    "contentMediaType": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string contentMediaType: object",
+                "data": {
+                    "contentMediaType": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid contentMediaType",
+                "data": {
+                    "contentMediaType": "text/plain"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Meta-schema content tests: contentSchema",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema contentSchema: number",
+                "data": {
+                    "contentSchema": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contentSchema: string",
+                "data": {
+                    "contentSchema": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contentSchema: array",
+                "data": {
+                    "contentSchema": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema contentSchema: null",
+                "data": {
+                    "contentSchema": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean contentSchema",
+                "data": {
+                    "contentSchema": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object contentSchema",
+                "data": {
+                    "contentSchema": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/pattern.json
+++ b/tests/draft2019-09/pattern.json
@@ -55,5 +55,48 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: strings",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string pattern: number",
+                "data": {
+                    "pattern": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string pattern: Boolean",
+                "data": {
+                    "pattern": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string pattern: array",
+                "data": {
+                    "pattern": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string pattern: object",
+                "data": {
+                    "pattern": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string pattern: null",
+                "data": {
+                    "pattern": null
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/patternProperties.json
+++ b/tests/draft2019-09/patternProperties.json
@@ -152,5 +152,109 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: object",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object patternProperties: string",
+                "data": {
+                    "patternProperties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object patternProperties: Boolean",
+                "data": {
+                    "patternProperties": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object patternProperties: null",
+                "data": {
+                    "patternProperties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object patternProperties: number",
+                "data": {
+                    "patternProperties": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object patternProperties: array",
+                "data": {
+                    "patternProperties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in patternProperties: string",
+                "data": {
+                    "patternProperties": {
+                        "hello": "there"
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in patternProperties: null",
+                "data": {
+                    "patternProperties": {
+                        "hello": null
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in patternProperties: number",
+                "data": {
+                    "patternProperties": {
+                        "hello": 1
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in patternProperties: array",
+                "data": {
+                    "patternProperties": {
+                        "hello": []
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean property in patternProperties",
+                "data": {
+                    "patternProperties": {
+                        "hello": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Object property in patternProperties",
+                "data": {
+                    "patternProperties": {
+                        "hello": {}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Empty patternProperties",
+                "data": {
+                    "patternProperties": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/properties.json
+++ b/tests/draft2019-09/properties.json
@@ -163,5 +163,109 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: object",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object properties: string",
+                "data": {
+                    "properties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object properties: Boolean",
+                "data": {
+                    "properties": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object properties: null",
+                "data": {
+                    "properties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object properties: number",
+                "data": {
+                    "properties": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object properties: array",
+                "data": {
+                    "properties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in properties: string",
+                "data": {
+                    "properties": {
+                        "hello": "there"
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in properties: null",
+                "data": {
+                    "properties": {
+                        "hello": null
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in properties: number",
+                "data": {
+                    "properties": {
+                        "hello": 1
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema property in properties: array",
+                "data": {
+                    "properties": {
+                        "hello": []
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean property in properties",
+                "data": {
+                    "properties": {
+                        "hello": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Object property in properties",
+                "data": {
+                    "properties": {
+                        "hello": {}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Empty properties",
+                "data": {
+                    "properties": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/propertyNames.json
+++ b/tests/draft2019-09/propertyNames.json
@@ -74,5 +74,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: object",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema propertyNames: number",
+                "data": {
+                    "propertyNames": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema propertyNames: string",
+                "data": {
+                    "propertyNames": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema propertyNames: array",
+                "data": {
+                    "propertyNames": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema propertyNames: null",
+                "data": {
+                    "propertyNames": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean propertyNames",
+                "data": {
+                    "propertyNames": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object propertyNames",
+                "data": {
+                    "propertyNames": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/readOnly.json
+++ b/tests/draft2019-09/readOnly.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: readOnly",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-Boolean readOnly: number",
+                "data": {
+                    "readOnly": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean readOnly: string",
+                "data": {
+                    "readOnly": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean readOnly: null",
+                "data": {
+                    "readOnly": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean readOnly: array",
+                "data": {
+                    "readOnly": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean readOnly: object",
+                "data": {
+                    "readOnly": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid readOnly: Boolean",
+                "data": {
+                    "readOnly": true
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/recursiveAnchor.json
+++ b/tests/draft2019-09/recursiveAnchor.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "Meta-schema core tests: $recursiveAnchor",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-Boolean $recursiveAnchor: number",
+                "data": {
+                    "$recursiveAnchor": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean $recursiveAnchor: string",
+                "data": {
+                    "$recursiveAnchor": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean $recursiveAnchor: null",
+                "data": {
+                    "$recursiveAnchor": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean $recursiveAnchor: array",
+                "data": {
+                    "$recursiveAnchor": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean $recursiveAnchor: object",
+                "data": {
+                    "$recursiveAnchor": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $recursiveAnchor: true",
+                "data": {
+                    "$recursiveAnchor": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Valid $recursiveAnchor: false",
+                "data": {
+                    "$recursiveAnchor": false
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/recursiveRef.json
+++ b/tests/draft2019-09/recursiveRef.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema core tests: $recursiveRef",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $recursiveRef: number",
+                "data": {
+                    "$recursiveRef": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $recursiveRef: Boolean",
+                "data": {
+                    "$recursiveRef": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $recursiveRef: null",
+                "data": {
+                    "$recursiveRef": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $recursiveRef: array",
+                "data": {
+                    "$recursiveRef": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $recursiveRef: object",
+                "data": {
+                    "$recursiveRef": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $recursiveRef",
+                "data": {
+                    "$recursiveRef": "#"
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -407,5 +407,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema core tests: $ref",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $ref: number",
+                "data": {
+                    "$ref": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $ref: Boolean",
+                "data": {
+                    "$ref": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $ref: null",
+                "data": {
+                    "$ref": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $ref: array",
+                "data": {
+                    "$ref": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $ref: object",
+                "data": {
+                    "$ref": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $ref",
+                "data": {
+                    "$ref": "#/data"
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/required.json
+++ b/tests/draft2019-09/required.json
@@ -101,5 +101,76 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: objects",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-array required: string",
+                "data": {
+                    "required": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array required: Boolean",
+                "data": {
+                    "required": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array required: null",
+                "data": {
+                    "required": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array required: object",
+                "data": {
+                    "required": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-array required: number",
+                "data": {
+                    "required": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "required with duplicates",
+                "data": {
+                    "required": [ "hello", "hello" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string array required",
+                "data": {
+                    "required": [ "hello", 1 ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty array required",
+                "data": {
+                    "required": []
+                },
+                "valid": true
+            },
+            {
+                "description": "One-element array required",
+                "data": {
+                    "required": [ "hello" ]
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/schema.json
+++ b/tests/draft2019-09/schema.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema core tests: $schema",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string $schema: number",
+                "data": {
+                    "$schema": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $schema: Boolean",
+                "data": {
+                    "$schema": true
+                },
+                "valid": false
+              },
+            {
+                "description": "Non-string $schema: null",
+                "data": {
+                    "$schema": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $schema: array",
+                "data": {
+                    "$schema": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string $schema: object",
+                "data": {
+                    "$schema": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $schema",
+                "data": {
+                    "$schema": "http://example.com/foo"
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/title.json
+++ b/tests/draft2019-09/title.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: title",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-string title: number",
+                "data": {
+                    "title": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string title: Boolean",
+                "data": {
+                    "title": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string title: null",
+                "data": {
+                    "title": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string title: array",
+                "data": {
+                    "title": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-string title: object",
+                "data": {
+                    "title": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid title: string",
+                "data": {
+                    "title": "Tome"
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/type.json
+++ b/tests/draft2019-09/type.json
@@ -470,5 +470,34 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: type",
+        "schema": {
+        "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Unknown type",
+                "data": {
+                    "type": "float"
+                },
+                "valid": false
+            },
+            {
+                "description": "Duplicate types",
+                "data": {
+                    "type": [ "null", "null" ]
+                },
+                "valid": false
+            },
+            {
+                "description": "Empty types",
+                "data": {
+                    "type": []
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -433,5 +433,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: array",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema unevaluatedItems: number",
+                "data": {
+                    "unevaluatedItems": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedItems: string",
+                "data": {
+                    "unevaluatedItems": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedItems: array",
+                "data": {
+                    "unevaluatedItems": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedItems: null",
+                "data": {
+                    "unevaluatedItems": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean unevaluatedItems",
+                "data": {
+                    "unevaluatedItems": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object unevaluatedItems",
+                "data": {
+                    "unevaluatedItems": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -809,5 +809,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema applicator tests: object",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-schema unevaluatedProperties: number",
+                "data": {
+                    "unevaluatedProperties": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedProperties: string",
+                "data": {
+                    "unevaluatedProperties": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedProperties: array",
+                "data": {
+                    "unevaluatedProperties": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-schema unevaluatedProperties: null",
+                "data": {
+                    "unevaluatedProperties": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Boolean unevaluatedProperties",
+                "data": {
+                    "unevaluatedProperties": true
+                },
+                "valid": true
+            },
+            {
+                "description": "Object unevaluatedProperties",
+                "data": {
+                    "unevaluatedProperties": {}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -380,5 +380,55 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Meta-schema validation tests: arrays",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-Boolean uniqueItems: string",
+                "data": {
+                    "uniqueItems": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean uniqueItems: number",
+                "data": {
+                    "uniqueItems": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean uniqueItems: array",
+                "data": {
+                    "uniqueItems": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean uniqueItems: object",
+                "data": {
+                    "uniqueItems": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean uniqueItems: null",
+                "data": {
+                    "uniqueItems": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid uniqueItems: Boolean",
+                "data": {
+                    "uniqueItems": true
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/vocabulary.json
+++ b/tests/draft2019-09/vocabulary.json
@@ -1,0 +1,99 @@
+[
+    {
+        "description": "Meta-schema core tests: $vocabulary",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-object $vocabulary: number",
+                "data": {
+                    "$vocabulary": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $vocabulary: Boolean",
+                "data": {
+                    "$vocabulary": true
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $vocabulary: null",
+                "data": {
+                    "$vocabulary": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $vocabulary: array",
+                "data": {
+                    "$vocabulary": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-object $vocabulary: string",
+                "data": {
+                    "$vocabulary": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid $vocabulary",
+                "data": {
+                    "$vocabulary": {
+                        "https://json-schema.org/draft/2019-09/vocab/core": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Invalid $vocabulary property: string",
+                "data": {
+                    "$vocabulary": {
+                        "https://json-schema.org/draft/2019-09/vocab/core": "string"
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $vocabulary property: number",
+                "data": {
+                  "$vocabulary": {
+                      "https://json-schema.org/draft/2019-09/vocab/core": 1
+                  }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $vocabulary property: null",
+                "data": {
+                  "$vocabulary": {
+                      "https://json-schema.org/draft/2019-09/vocab/core": null
+                  }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $vocabulary property: array",
+                "data": {
+                    "$vocabulary": {
+                        "https://json-schema.org/draft/2019-09/vocab/core": []
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Invalid $vocabulary property: object",
+                "data": {
+                  "$vocabulary": {
+                      "https://json-schema.org/draft/2019-09/vocab/core": {}
+                  }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/writeOnly.json
+++ b/tests/draft2019-09/writeOnly.json
@@ -1,0 +1,52 @@
+[
+    {
+        "description": "Meta-schema meta-data tests: writeOnly",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Non-Boolean writeOnly: number",
+                "data": {
+                    "writeOnly": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean writeOnly: string",
+                "data": {
+                    "writeOnly": "hello"
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean writeOnly: null",
+                "data": {
+                    "writeOnly": null
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean writeOnly: array",
+                "data": {
+                    "writeOnly": []
+                },
+                "valid": false
+            },
+            {
+                "description": "Non-Boolean writeOnly: object",
+                "data": {
+                    "writeOnly": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "Valid writeOnly: Boolean",
+                "data": {
+                    "writeOnly": true
+                },
+                "valid": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This adds tests using the meta-schema as a schema. This does not test things
that cannot currently be guaranteed to be represented in a schema, for example,
normalized URL requirements and optional "format" for "pattern".

Closes #244