### PR TITLE
some more tests for additionalItems

### DIFF
--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -40,7 +40,17 @@
         },
         "tests": [
             {
-                "description": "fewer number of items present",
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
                 "data": [ 1, 2 ],
                 "valid": true
             },

--- a/tests/draft3/additionalItems.json
+++ b/tests/draft3/additionalItems.json
@@ -40,7 +40,22 @@
         },
         "tests": [
             {
-                "description": "no additional items present",
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
                 "data": [ 1, 2, 3 ],
                 "valid": true
             },
@@ -70,10 +85,10 @@
     },
     {
         "description": "additionalItems are allowed by default",
-        "schema": {"items": []},
+        "schema": {"items": [{"type": "integer"}]},
         "tests": [
             {
-                "description": "only the first items are validated",
+                "description": "only the first item is validated",
                 "data": [1, "foo", false],
                 "valid": true
             }

--- a/tests/draft4/additionalItems.json
+++ b/tests/draft4/additionalItems.json
@@ -40,7 +40,17 @@
         },
         "tests": [
             {
-                "description": "fewer number of items present",
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
                 "data": [ 1, 2 ],
                 "valid": true
             },

--- a/tests/draft6/additionalItems.json
+++ b/tests/draft6/additionalItems.json
@@ -40,7 +40,17 @@
         },
         "tests": [
             {
-                "description": "fewer number of items present",
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
                 "data": [ 1, 2 ],
                 "valid": true
             },

--- a/tests/draft7/additionalItems.json
+++ b/tests/draft7/additionalItems.json
@@ -40,7 +40,17 @@
         },
         "tests": [
             {
-                "description": "fewer number of items present",
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
                 "data": [ 1, 2 ],
                 "valid": true
             },


### PR DESCRIPTION
When the number of data items is fewer than the number of "item" subschemas,
"additionalItems" should not apply at all, even if it is false.