### PR TITLE
Fix two 'minContains' tests that relate to 'contains'

### DIFF
--- a/tests/draft2019-09/minContains.json
+++ b/tests/draft2019-09/minContains.json
@@ -160,12 +160,12 @@
             {
                 "description": "empty data",
                 "data": [ ],
-                "valid": true
+                "valid": false
             },
             {
-                "description": "minContains = 0 makes contains always pass",
+                "description": "minContains = 0 doesn't mean contains passes",
                 "data": [ 2 ],
-                "valid": true
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
'contains' fails regardless of the presence of other keywords.
It also fails for empty arrays.

I erroneously accepted these errors in #366