### PR TITLE
[359] Add unevaluatedProperties/unevaluatedItems cousin tests

### DIFF
--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -413,5 +413,25 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "allOf": [
+                {
+                    "items": [ true ]
+                },
+                {
+                    "unevaluatedItems": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -589,5 +589,29 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins",
+        "schema": {
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
These tests address the case where they're not direct siblings to their
associated properties.

Closes #359