### PR TITLE
Fix ECMA 262 regex whitespace tests.

### DIFF
--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -154,7 +154,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
             "type": "string",
             "pattern": "^\\W$"

--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -173,7 +173,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "description": "ECMA 262 \\s matches whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\s$"
@@ -185,14 +185,59 @@
                 "valid": true
             },
             {
-                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
                 "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
                 "valid": false
             }
         ]
     },
     {
-        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\S$"
@@ -204,8 +249,53 @@
                 "valid": false
             },
             {
-                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
                 "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
                 "valid": true
             }
         ]

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -154,7 +154,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
             "type": "string",
             "pattern": "^\\W$"

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -173,7 +173,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "description": "ECMA 262 \\s matches whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\s$"
@@ -185,14 +185,59 @@
                 "valid": true
             },
             {
-                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
                 "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
                 "valid": false
             }
         ]
     },
     {
-        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\S$"
@@ -204,8 +249,53 @@
                 "valid": false
             },
             {
-                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
                 "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
                 "valid": true
             }
         ]

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -154,7 +154,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
             "type": "string",
             "pattern": "^\\W$"

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -173,7 +173,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "description": "ECMA 262 \\s matches whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\s$"
@@ -185,14 +185,59 @@
                 "valid": true
             },
             {
-                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
                 "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
                 "valid": false
             }
         ]
     },
     {
-        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\S$"
@@ -204,8 +249,53 @@
                 "valid": false
             },
             {
-                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
                 "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
                 "valid": true
             }
         ]

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -154,7 +154,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\w matches everything but ascii letters",
+        "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
             "type": "string",
             "pattern": "^\\W$"

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -173,7 +173,7 @@
         ]
     },
     {
-        "description": "ECMA 262 \\s matches ascii whitespace only",
+        "description": "ECMA 262 \\s matches whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\s$"
@@ -185,14 +185,59 @@
                 "valid": true
             },
             {
-                "description": "latin-1 non-breaking-space does not match (unlike e.g. Python)",
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
                 "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
                 "valid": false
             }
         ]
     },
     {
-        "description": "ECMA 262 \\S matches everything but ascii whitespace",
+        "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
             "type": "string",
             "pattern": "^\\S$"
@@ -204,8 +249,53 @@
                 "valid": false
             },
             {
-                "description": "latin-1 non-breaking-space matches (unlike e.g. Python)",
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
                 "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
                 "valid": true
             }
         ]


### PR DESCRIPTION
Looks like there was a bug at the time of introduction due to #285, which was introduced in #282 and finalized in #286.

1. At the time of introduction (#282), those tests followed a false premise but passed because of a mistype.
2. When the mistype was noticed (#285), `\\` were replaced with `\` (#286).
3. But now the test is invalid as is failing in all implementations.

---

Per ECMA 262 specification:
https://www.ecma-international.org/ecma-262/10.0/index.html#sec-characterclassescape

`\S` refers to `\s`:

> ## Section 21.2.2.12:

> The production `CharacterClassEscape::S` evaluates as follows:
>  1. Return the set of all characters not included in the set returned by `CharacterClassEscape::s`.

`\s` refers to `WhiteSpace`:

> The production `CharacterClassEscape::s` evaluates as follows:
>  1. Return the set of characters containing the characters that are on the right-hand side of the `WhiteSpace` or `LineTerminator` productions.

`WhiteSpace` includes `NBSP` (**U00A0**):
https://www.ecma-international.org/ecma-262/10.0/index.html#prod-WhiteSpace

**That is the exact opposite of what the current test was checking for.**

Also, `WhiteSpace` includes any other Unicode "Space_Separator" code points.

That's not a new addition, same was true in version 6.0, for example:
* https://www.ecma-international.org/ecma-262/6.0/index.html#sec-characterclassescape
* https://www.ecma-international.org/ecma-262/6.0/index.html#sec-white-space