### PR TITLE
Improve uniqueItems validation

### DIFF
--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -96,12 +96,22 @@
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1],
+                "data": [{}, [1], true, null, 1, "{}"],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are invalid",
                 "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
                 "valid": false
             }
         ]

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -96,12 +96,22 @@
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1],
+                "data": [{}, [1], true, null, 1, "{}"],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are invalid",
                 "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
                 "valid": false
             }
         ]

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -96,12 +96,22 @@
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1],
+                "data": [{}, [1], true, null, 1, "{}"],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are invalid",
                 "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
                 "valid": false
             }
         ]

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -96,12 +96,22 @@
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1],
+                "data": [{}, [1], true, null, 1, "{}"],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are invalid",
                 "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
                 "valid": false
             }
         ]


### PR DESCRIPTION
There are lax implementations which are triggered by these two checks

See https://github.com/mafintosh/is-my-json-valid/blob/v2.20.0/index.js#L89-L98

draft3 excluded as it has other checks excluded.