### PR TITLE
Decimal IPs are also not dotted-quad

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -27,6 +27,11 @@
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -27,6 +27,11 @@
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -27,6 +27,11 @@
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -27,6 +27,11 @@
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Per JSON Schema spec, only dotted-quad ips are allowed in ipv4 format.

The tests verified that hex format is not valid here, but they didn't
do the same for decimal format.

Added that missing test.

`2130706433` == `0x7f000001` == `127.0.0.1`