### PR TITLE
draft3: remove outdated assumption about ECMA 262 regex

### DIFF
--- a/tests/draft3/optional/ecmascript-regex.json
+++ b/tests/draft3/optional/ecmascript-regex.json
@@ -7,11 +7,6 @@
                 "description": "[^] is a valid regex",
                 "data": "[^]",
                 "valid": true
-            },
-            {
-                "description": "ECMA 262 has no support for lookbehind",
-                "data": "(?<=foo)bar",
-                "valid": false
             }
         ]
     }


### PR DESCRIPTION
There are at least two testcases with basic assumption changed since the time of introduction:
* `draft3/optional/ecmascript-regex.json/ECMA 262 regex dialect recognition` -- ECMA 262 RegExp have lookbehind support now
* `draft3/optional/format/color.json/validation of CSS colors/an invalid CSS color code` -- `#00332520` is a valid CSS color code now

The [draft03 spec](https://tools.ietf.org/html/draft-zyp-json-schema-03) spec for `color` links to [CSS 2.1](https://www.w3.org/TR/2007/CR-CSS21-20070719/), which indeed doesn't support RGBA colors, so the test looks correct according to the spec (though outdated, but well, it's draft3).

But for regex, this is worse:
>  regex  A regular expression, following the regular expression specification from ECMA 262/Perl 5.

That doesn't specify any ECMA 262 version. And lookbehind is _valid_ since ECMA 262 edition 9 (aka ECMAScript 2018): https://www.ecma-international.org/ecma-262/9.0/, even introduction mentions that:
> This specification also includes four new regular expression features: the dotAll flag, named capture groups, Unicode property escapes, and look-behind assertions.

I believe Perl (mentioned in draft03) also has lookbehind support? https://perldoc.perl.org/perlre.html (see `Lookaround Assertions`).

It probably doesn't make sense to test for rejecting lookbehind regexes in draft3 tests, hence this PR.