### PR TITLE
Extend email format tests

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -12,6 +12,41 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/email.json
+++ b/tests/draft3/optional/format/email.json
@@ -12,6 +12,41 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -12,6 +12,41 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -12,6 +12,41 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -12,6 +12,41 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Before this, [a simple `/@/` check](https://github.com/mafintosh/is-my-json-valid/blob/master/formats.js#L13) passed this format test.

This now extends the test a bit more, to check that local part is checked at least for something.

Symbol check + dot position check is a good indication here, because:
1) It's common and doesn't need implementing more complex logic (quotes etc)
2) Dot is the only symbol which validity depends on the position in the local part

This should trigger most of the naive implementations (e.g. `/@/`) and is still not hard to implement.

JSON Schema uses RFC 5322.

Refs: https://tools.ietf.org/html/rfc5322#page-17
Refs: https://tools.ietf.org/html/rfc5322#page-12

Also, some explanation for the two dots (with links to same RFC pages): https://serverfault.com/questions/395766/are-two-periods-allowed-in-the-local-part-of-an-email-address