### PR TITLE
Run tests on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,21 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8']
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Install tox
       run: python -m pip install tox
     - name: Run the sanity checks

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -53,7 +53,7 @@ REMOTES = {
             u"refToInteger": {u"$ref": u"#/$defs/integer"},
         }
     },
-    "folder/folderInteger.json": {u"type": u"integer"}
+    os.path.join("folder", "folderInteger.json"): {u"type": u"integer"}
 }
 REMOTES_DIR = os.path.join(ROOT_DIR, "remotes")
 
@@ -246,6 +246,9 @@ def main(arguments):
 
         @app.route("/<path:path>")
         def serve_path(path):
+            # Needed to ensure that relative paths are following the OS path
+            # separator convention (linux/mac: `/`, windows: `\`)
+            path = os.path.join(*path.split('/'))
             if path in REMOTES:
                 return jsonify(REMOTES[path])
             return "Document does not exist.", 404

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 from __future__ import print_function
+from codecs import open
 from pprint import pformat
 import argparse
 import errno
@@ -12,6 +13,7 @@ import sys
 import textwrap
 import unittest
 import warnings
+
 
 if getattr(unittest, "skipIf", None) is None:
     unittest.skipIf = lambda cond, msg : lambda fn : fn
@@ -55,12 +57,12 @@ REMOTES = {
 }
 REMOTES_DIR = os.path.join(ROOT_DIR, "remotes")
 
-with open(os.path.join(ROOT_DIR, "test-schema.json")) as schema:
+with open(os.path.join(ROOT_DIR, "test-schema.json"), mode="r", encoding="utf-8") as schema:
     TESTSUITE_SCHEMA = json.load(schema)
 
 def files(paths):
     for path in paths:
-        with open(path) as test_file:
+        with open(path, mode="r", encoding="utf-8") as test_file:
             yield json.load(test_file)
 
 
@@ -93,7 +95,7 @@ class SanityTests(unittest.TestCase):
 
     def test_all_files_are_valid_json(self):
         for path in self.test_files:
-            with open(path) as test_file:
+            with open(path, mode="r", encoding="utf-8") as test_file:
                 try:
                     json.load(test_file)
                 except ValueError as error:
@@ -149,7 +151,7 @@ class SanityTests(unittest.TestCase):
         for parent, _, paths in os.walk(REMOTES_DIR):
             for path in paths:
                 absolute_path = os.path.join(parent, path)
-                with open(absolute_path) as schema_file:
+                with open(absolute_path, mode="r", encoding="utf-8") as schema_file:
                     files[absolute_path] = json.load(schema_file)
 
         expected = {


### PR DESCRIPTION
While running tests on Windows (for a different library) I've noticed that the provided tester (provided by this repo) does now work as expected.

The goal of this PR is to ensure that we're running sanity-checks on all platforms (and many interpreter versions) and to fix the tests that are failing on Windows.

In order to have green checks on Windows we need:
 * explicit encoding on the opened file. `open(..., encoding='...')` is not supported on Python2 so I'm using `codecs.open` as has equivalent behaviour and is supported on Python 2 and 3.5+
 * paths in `REMOTES` need to use the platform specific path separator (linux/mac: `/`, windows: `\`)
