### PR TITLE
Add common lisp implementation to the list (fisxoj/json-schema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ This suite is being used by:
 
 * [jsck](https://github.com/pandastrike/jsck)
 
+### Common Lisp
+
+* [json-schema](https://github.com/fisxoj/json-schema)
+
 ### C++
 
 * [Modern C++ JSON schema validator](https://github.com/pboettch/json-schema-validator)


### PR DESCRIPTION
Hello!

Thanks for the handy test suite.  I've been polishing up my lisp implementation of json-schema and it passes nearly all the suite now, so I'm ready to start listing it places.