### PR TITLE
Add $id values into remote schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@
 const Ajv = require('ajv');
 const jsonSchemaTest = require('json-schema-test');
 
-const refs = {
-  'http://localhost:1234/integer.json': require('./remotes/integer.json'),
-  'http://localhost:1234/subSchemas.json': require('./remotes/subSchemas.json'),
-  'http://localhost:1234/folder/folderInteger.json': require('./remotes/folder/folderInteger.json'),
-  'http://localhost:1234/name.json': require('./remotes/name.json'),
-  'http://localhost:1234/name-defs.json': require('./remotes/name-defs.json')
-};
+const refs = [
+  require('./remotes/integer.json'),
+  require('./remotes/subSchemas.json'),
+  require('./remotes/folder/folderInteger.json'),
+  require('./remotes/name.json'),
+  require('./remotes/name-defs.json')
+];
 
 const SKIP = {
   4: ['optional/zeroTerminatedFloats'],
@@ -32,7 +32,7 @@ const SKIP = {
     ajv.addMetaSchema(require(`ajv/lib/refs/json-schema-draft-0${draft}.json`));
     ajv._opts.defaultMeta = `http://json-schema.org/draft-0${draft}/schema#`;
   }
-  for (const uri in refs) ajv.addSchema(refs[uri], uri);
+  for (const ref of refs) ajv.addSchema(ref, ref.$id);
 
   jsonSchemaTest(ajv, {
     description: `Test suite draft-0${draft}`,

--- a/remotes/folder/folderInteger.json
+++ b/remotes/folder/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$id": "http://localhost:1234/folder/folderInteger.json",
     "type": "integer"
 }

--- a/remotes/integer.json
+++ b/remotes/integer.json
@@ -1,3 +1,4 @@
 {
+    "$id": "http://localhost:1234/integer.json",
     "type": "integer"
 }

--- a/remotes/name-defs.json
+++ b/remotes/name-defs.json
@@ -1,4 +1,5 @@
 {
+    "$id": "http://localhost:1234/name-defs.json",
     "$defs": {
         "orNull": {
             "anyOf": [

--- a/remotes/name.json
+++ b/remotes/name.json
@@ -1,4 +1,5 @@
 {
+    "$id": "http://localhost:1234/name.json",
     "definitions": {
         "orNull": {
             "anyOf": [

--- a/remotes/subSchemas-defs.json
+++ b/remotes/subSchemas-defs.json
@@ -1,4 +1,5 @@
 {
+    "$id": "http://localhost:1234/subSchemas-defs.json",
     "$defs": {
         "integer": {
             "type": "integer"

--- a/remotes/subSchemas.json
+++ b/remotes/subSchemas.json
@@ -1,4 +1,5 @@
 {
+    "$id": "http://localhost:1234/subSchemas.json",
     "integer": {
         "type": "integer"
     },


### PR DESCRIPTION
I believe that that data should be present in the files themselves, not in an external `index.js` file.
Implementers should not be expected to even look there.

This way, `index.js` is not required to understand what is going on, and e.g. a static schema file analyzer can pick up those schemas and link them together.

A further improvement would be to specify `$schema` in all the tests, but that's out of scope of this PR.