### PR TITLE
Remove test that doesn't match RFC 3339 duration grammar

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -69,11 +69,6 @@
               "valid": true
           },
           {
-              "description": "elements may be omitted if their value is zero",
-              "data": "PT1H1S",
-              "valid": true
-          },
-          {
               "description": "one and a half days, in hours",
               "data": "PT36H",
               "valid": true


### PR DESCRIPTION
This test doesn't match the "duration" and "dur-time" production in https://www.rfc-editor.org/rfc/rfc3339#appendix-A. Am I missing something from that RFC that states a component may be omitted? The grammar disallows this, but maybe it's stated somewhere in the text? I can't find it.
(Quote from the spec (sec. 7.3.1): "The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.")