### PR TITLE
One more patternProperties test with boolean schemas

### DIFF
--- a/tests/draft2019-09/patternProperties.json
+++ b/tests/draft2019-09/patternProperties.json
@@ -142,6 +142,11 @@
                 "valid": false
             },
             {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
                 "description": "empty object is valid",
                 "data": {},
                 "valid": true

--- a/tests/draft6/patternProperties.json
+++ b/tests/draft6/patternProperties.json
@@ -142,6 +142,11 @@
                 "valid": false
             },
             {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
                 "description": "empty object is valid",
                 "data": {},
                 "valid": true

--- a/tests/draft7/patternProperties.json
+++ b/tests/draft7/patternProperties.json
@@ -142,6 +142,11 @@
                 "valid": false
             },
             {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
                 "description": "empty object is valid",
                 "data": {},
                 "valid": true


### PR DESCRIPTION
`object with a property matching both true and false is invalid`

I believe this test should be present there =).

Note that the regexps are _not_ anchored.