### PR TITLE
Test that uri format scheme is validated for allowed chars

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -97,6 +97,11 @@
                 "description": "an invalid URI with spaces and missing scheme",
                 "data": ":// should fail",
                 "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -97,6 +97,11 @@
                 "description": "an invalid URI with spaces and missing scheme",
                 "data": ":// should fail",
                 "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -97,6 +97,11 @@
                 "description": "an invalid URI with spaces and missing scheme",
                 "data": ":// should fail",
                 "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -97,6 +97,11 @@
                 "description": "an invalid URI with spaces and missing scheme",
                 "data": ":// should fail",
                 "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
This is simple to implement.
```
scheme      = ALPHA *( ALPHA / DIGIT / + / - / . )
```

In optional, together will all the rest invalid `uri` validation.

Comma because this is _specifically_ targeting `[a-z0-9+-.]` mistype (which can happen if one just copies the chars from the spec in order into a regex), which should be `[a-z0-9+\-.]`, and the only difference is the comma.