### PR TITLE
More optional ipv6 tests

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -112,6 +112,26 @@
                 "description": "ipv4 segment must have 4 octets",
                 "data": "1:2:3:4:1.2.3",
                 "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -132,6 +132,21 @@
                 "description": "zone id is not a part of ipv6 address",
                 "data": "fe80::a%eth1",
                 "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -112,6 +112,26 @@
                 "description": "ipv4 segment must have 4 octets",
                 "data": "1:2:3:4:1.2.3",
                 "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -132,6 +132,21 @@
                 "description": "zone id is not a part of ipv6 address",
                 "data": "fe80::a%eth1",
                 "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -112,6 +112,26 @@
                 "description": "ipv4 segment must have 4 octets",
                 "data": "1:2:3:4:1.2.3",
                 "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -132,6 +132,21 @@
                 "description": "zone id is not a part of ipv6 address",
                 "data": "fe80::a%eth1",
                 "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -112,6 +112,26 @@
                 "description": "ipv4 segment must have 4 octets",
                 "data": "1:2:3:4:1.2.3",
                 "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -132,6 +132,21 @@
                 "description": "zone id is not a part of ipv6 address",
                 "data": "fe80::a%eth1",
                 "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
* Leading/traling whitespace is invalid
* Netmask is not a part of ipv6 address.
* Zone id is not a part of ipv6 address.
* Long valid and invalid addresses

Refs:
* https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.4
* https://tools.ietf.org/html/rfc4291#section-2.2