### PR TITLE
subschema nested ref in remote ref

### DIFF
--- a/remotes/baseUriChange/subSchemaNestedRef.json
+++ b/remotes/baseUriChange/subSchemaNestedRef.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "properties": {
+        "hole": {"$ref": "integer.json"}
+    }
+}

--- a/remotes/nested/foo-ref-string.json
+++ b/remotes/nested/foo-ref-string.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
     "properties": {
-        "hole": {"$ref": "integer.json"}
+        "foo": {"$ref": "string.json"}
     }
 }

--- a/remotes/nested/string.json
+++ b/remotes/nested/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/tests/draft-next/refRemote.json
+++ b/tests/draft-next/refRemote.json
@@ -204,5 +204,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$id": "http://localhost:1234/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -206,27 +206,27 @@
         ]
     },
     {
-        "description": "subschema nested ref in remote ref",
+        "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
-            "$id": "http://localhost:1234/",
+            "$id": "http://localhost:1234/some-id",
             "properties": {
-                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+                "name": {"$ref": "nested/foo-ref-string.json"}
             }
         },
         "tests": [
             {
-                "description": "number is valid",
+                "description": "number is invalid",
                 "data": {
-                    "name": {"hole":  1}
-                },
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {
-                    "name": {"hole":  "a"}
+                    "name": {"foo":  1}
                 },
                 "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -204,5 +204,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "subschema nested ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "properties": {
+                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {
+                    "name": {"hole":  1}
+                },
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {
+                    "name": {"hole":  "a"}
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -204,5 +204,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$id": "http://localhost:1234/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/refRemote.json
+++ b/tests/draft6/refRemote.json
@@ -210,5 +210,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "subschema nested ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "properties": {
+                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {
+                    "name": {"hole":  1}
+                },
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {
+                    "name": {"hole":  "a"}
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/refRemote.json
+++ b/tests/draft6/refRemote.json
@@ -212,27 +212,27 @@
         ]
     },
     {
-        "description": "subschema nested ref in remote ref",
+        "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
-            "$id": "http://localhost:1234/",
+            "$id": "http://localhost:1234/some-id",
             "properties": {
-                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+                "name": {"$ref": "nested/foo-ref-string.json"}
             }
         },
         "tests": [
             {
-                "description": "number is valid",
+                "description": "number is invalid",
                 "data": {
-                    "name": {"hole":  1}
-                },
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {
-                    "name": {"hole":  "a"}
+                    "name": {"foo":  1}
                 },
                 "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/refRemote.json
+++ b/tests/draft7/refRemote.json
@@ -210,5 +210,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "subschema nested ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "properties": {
+                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {
+                    "name": {"hole":  1}
+                },
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {
+                    "name": {"hole":  "a"}
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/refRemote.json
+++ b/tests/draft7/refRemote.json
@@ -212,27 +212,27 @@
         ]
     },
     {
-        "description": "subschema nested ref in remote ref",
+        "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
-            "$id": "http://localhost:1234/",
+            "$id": "http://localhost:1234/some-id",
             "properties": {
-                "name": {"$ref": "folder/subSchemaNestedRef.json"}
+                "name": {"$ref": "nested/foo-ref-string.json"}
             }
         },
         "tests": [
             {
-                "description": "number is valid",
+                "description": "number is invalid",
                 "data": {
-                    "name": {"hole":  1}
-                },
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {
-                    "name": {"hole":  "a"}
+                    "name": {"foo":  1}
                 },
                 "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The following test scenario is added: The base URI remains unchanged, and multiple layers of nested references are used in the sub-schema.

For details:  [601](https://github.com/Julian/jsonschema/issues/601)