### PR TITLE
Add check for non-zero padded days and months

### DIFF
--- a/tests/draft7/format.json
+++ b/tests/draft7/format.json
@@ -292,7 +292,7 @@
             },
             {
                 "description": "invalidates non-padded day dates",
-                "data": "1998-01-1,
+                "data": "1998-01-1",
                 "valid": false
             }
         ]

--- a/tests/draft7/format.json
+++ b/tests/draft7/format.json
@@ -284,6 +284,16 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalidates non-padded month dates",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded day dates",
+                "data": "1998-01-1,
+                "valid": false
             }
         ]
     },


### PR DESCRIPTION
As outlined in [IETF RFC 3559, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6), dates should follow the format `YYYY-MM-DD`, so days or months that are non-zero padded should be invalid.