### PR TITLE
Adds tests for non zero-padded dates

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -51,12 +51,12 @@
             {
                 "description": "invalid non-padded month dates",
                 "data": "1963-6-19T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid non-padded day dates",
                 "data": "1963-06-1T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -47,6 +47,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
                 "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -17,6 +17,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350",
                 "valid": false
+            },
+            {
+                "description": "invalidates non-padded month dates",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded day dates",
+                "data": "1998-01-1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -22,6 +22,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
                 "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -26,12 +26,12 @@
             {
                 "description": "invalid non-padded month dates",
                 "data": "1963-6-19T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid non-padded day dates",
                 "data": "1963-06-1T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date.json
+++ b/tests/draft3/optional/format/date.json
@@ -12,6 +12,21 @@
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded month dates",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded day dates",
+                "data": "1998-01-1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -51,12 +51,12 @@
             {
                 "description": "invalid non-padded month dates",
                 "data": "1963-6-19T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid non-padded day dates",
                 "data": "1963-06-1T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -47,6 +47,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
                 "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -56,12 +56,12 @@
             {
                 "description": "invalid non-padded month dates",
                 "data": "1963-6-19T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid non-padded day dates",
                 "data": "1963-06-1T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -37,7 +37,7 @@
                 "description": "an invalid closing Z after time-zone offset",
                 "data": "1963-06-19T08:30:06.28123+01:00Z",
                 "valid": false
-            },            
+            },
             {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
@@ -52,6 +52,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
                 "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -51,12 +51,12 @@
             {
                 "description": "invalid non-padded month dates",
                 "data": "1963-6-19T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid non-padded day dates",
                 "data": "1963-06-1T08:30:06.283185Z",
-                "valid": true
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -47,6 +47,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
                 "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -17,6 +17,16 @@
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350",
                 "valid": false
+            },
+            {
+                "description": "invalidates non-padded month dates",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded day dates",
+                "data": "1998-01-1",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
As outlined in [IETF RFC 3559, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6), dates should follow the format `YYYY-MM-DD`, so days or months that are non-zero padded should be invalid.

The `date` format was introduced in Draft7 of JSON Schema, so I've only added the tests for that version and `2019-09`.