### PR TITLE
Remove invalid format:regex test; the spec doesn't mandate parsing correctness

### DIFF
--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -1,16 +1,5 @@
 [
     {
-        "description": "ECMA 262 regex non-compliance",
-        "schema": { "format": "regex" },
-        "tests": [
-            {
-                "description": "ECMA 262 has no support for \\Z anchor from .NET",
-                "data": "^\\S(|(.|\\n)*\\S)\\Z",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
             "type": "string",

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -1,16 +1,5 @@
 [
     {
-        "description": "ECMA 262 regex non-compliance",
-        "schema": { "format": "regex" },
-        "tests": [
-            {
-                "description": "ECMA 262 has no support for \\Z anchor from .NET",
-                "data": "^\\S(|(.|\\n)*\\S)\\Z",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
             "type": "string",

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -1,16 +1,5 @@
 [
     {
-        "description": "ECMA 262 regex non-compliance",
-        "schema": { "format": "regex" },
-        "tests": [
-            {
-                "description": "ECMA 262 has no support for \\Z anchor from .NET",
-                "data": "^\\S(|(.|\\n)*\\S)\\Z",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
             "type": "string",

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -1,16 +1,5 @@
 [
     {
-        "description": "ECMA 262 regex non-compliance",
-        "schema": { "format": "regex" },
-        "tests": [
-            {
-                "description": "ECMA 262 has no support for \\Z anchor from .NET",
-                "data": "^\\S(|(.|\\n)*\\S)\\Z",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
             "type": "string",


### PR DESCRIPTION
The spec doesn't mandate that regexes have to be correct. In fact, the regex being valid is only a "SHOULD". See https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.8

The tests should test behaviour, not regex parsing.