### PR TITLE
test validation of keywords which expect integers when their value has a decimal

### DIFF
--- a/tests/draft-next/maxContains.json
+++ b/tests/draft-next/maxContains.json
@@ -87,6 +87,25 @@
         ]
     },
     {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "minContains < maxContains",
         "schema": {
             "contains": { "const": 1 },

--- a/tests/draft-next/maxItems.json
+++ b/tests/draft-next/maxItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft-next/maxLength.json
+++ b/tests/draft-next/maxLength.json
@@ -29,5 +29,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft-next/maxProperties.json
+++ b/tests/draft-next/maxProperties.json
@@ -36,6 +36,22 @@
         ]
     },
     {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "maxProperties = 0 means the object is empty",
         "schema": { "maxProperties": 0 },
         "tests": [

--- a/tests/draft-next/minContains.json
+++ b/tests/draft-next/minContains.json
@@ -91,6 +91,25 @@
         ]
     },
     {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "maxContains = minContains",
         "schema": {
             "contains": { "const": 1 },

--- a/tests/draft-next/minItems.json
+++ b/tests/draft-next/minItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft-next/minLength.json
+++ b/tests/draft-next/minLength.json
@@ -29,5 +29,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft-next/minProperties.json
+++ b/tests/draft-next/minProperties.json
@@ -34,5 +34,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxContains.json
+++ b/tests/draft2019-09/maxContains.json
@@ -52,6 +52,25 @@
         ]
     },
     {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "minContains < maxContains",
         "schema": {
             "contains": {"const": 1},

--- a/tests/draft2019-09/maxItems.json
+++ b/tests/draft2019-09/maxItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxLength.json
+++ b/tests/draft2019-09/maxLength.json
@@ -29,5 +29,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/maxProperties.json
+++ b/tests/draft2019-09/maxProperties.json
@@ -36,6 +36,22 @@
         ]
     },
     {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "maxProperties = 0 means the object is empty",
         "schema": { "maxProperties": 0 },
         "tests": [

--- a/tests/draft2019-09/minContains.json
+++ b/tests/draft2019-09/minContains.json
@@ -91,6 +91,25 @@
         ]
     },
     {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "maxContains = minContains",
         "schema": {
             "contains": {"const": 1},

--- a/tests/draft2019-09/minItems.json
+++ b/tests/draft2019-09/minItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minLength.json
+++ b/tests/draft2019-09/minLength.json
@@ -29,5 +29,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/minProperties.json
+++ b/tests/draft2019-09/minProperties.json
@@ -34,5 +34,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/maxContains.json
+++ b/tests/draft2020-12/maxContains.json
@@ -52,6 +52,25 @@
         ]
     },
     {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "minContains < maxContains",
         "schema": {
             "contains": {"const": 1},

--- a/tests/draft2020-12/maxItems.json
+++ b/tests/draft2020-12/maxItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/maxLength.json
+++ b/tests/draft2020-12/maxLength.json
@@ -29,5 +29,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/maxProperties.json
+++ b/tests/draft2020-12/maxProperties.json
@@ -36,6 +36,22 @@
         ]
     },
     {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "maxProperties = 0 means the object is empty",
         "schema": { "maxProperties": 0 },
         "tests": [

--- a/tests/draft2020-12/minContains.json
+++ b/tests/draft2020-12/minContains.json
@@ -91,6 +91,25 @@
         ]
     },
     {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "maxContains = minContains",
         "schema": {
             "contains": {"const": 1},

--- a/tests/draft2020-12/minItems.json
+++ b/tests/draft2020-12/minItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/minLength.json
+++ b/tests/draft2020-12/minLength.json
@@ -29,5 +29,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/minProperties.json
+++ b/tests/draft2020-12/minProperties.json
@@ -34,5 +34,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/maxItems.json
+++ b/tests/draft6/maxItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/maxLength.json
+++ b/tests/draft6/maxLength.json
@@ -29,5 +29,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/maxProperties.json
+++ b/tests/draft6/maxProperties.json
@@ -36,6 +36,22 @@
         ]
     },
     {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "maxProperties = 0 means the object is empty",
         "schema": { "maxProperties": 0 },
         "tests": [

--- a/tests/draft6/minItems.json
+++ b/tests/draft6/minItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/minLength.json
+++ b/tests/draft6/minLength.json
@@ -29,5 +29,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/minProperties.json
+++ b/tests/draft6/minProperties.json
@@ -34,5 +34,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/maxItems.json
+++ b/tests/draft7/maxItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/maxLength.json
+++ b/tests/draft7/maxLength.json
@@ -29,5 +29,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/maxProperties.json
+++ b/tests/draft7/maxProperties.json
@@ -36,6 +36,22 @@
         ]
     },
     {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "maxProperties = 0 means the object is empty",
         "schema": { "maxProperties": 0 },
         "tests": [

--- a/tests/draft7/minItems.json
+++ b/tests/draft7/minItems.json
@@ -24,5 +24,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/minLength.json
+++ b/tests/draft7/minLength.json
@@ -29,5 +29,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/minProperties.json
+++ b/tests/draft7/minProperties.json
@@ -34,5 +34,21 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
to the best of my understanding this should be valid ("the data model makes no distinction between integers and other numbers" -[core 4.2.1](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2.1)).

my implementation was incorrectly considering this to be a schema error.