### PR TITLE
Add tests for objects in enum

### DIFF
--- a/tests/draft2019-09/enum.json
+++ b/tests/draft2019-09/enum.json
@@ -33,6 +33,16 @@
                 "description": "objects are deep compared",
                 "data": {"foo": false},
                 "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
             }
         ]
     },

--- a/tests/draft4/enum.json
+++ b/tests/draft4/enum.json
@@ -33,6 +33,16 @@
                 "description": "objects are deep compared",
                 "data": {"foo": false},
                 "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
             }
         ]
     },

--- a/tests/draft6/enum.json
+++ b/tests/draft6/enum.json
@@ -33,6 +33,16 @@
                 "description": "objects are deep compared",
                 "data": {"foo": false},
                 "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
             }
         ]
     },

--- a/tests/draft7/enum.json
+++ b/tests/draft7/enum.json
@@ -33,6 +33,16 @@
                 "description": "objects are deep compared",
                 "data": {"foo": false},
                 "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
             }
         ]
     },


### PR DESCRIPTION
Before this, only `false` on completely mismatching objects was tested.

This adds a test that should return `true`, and an additional test for `false`.

Refs: https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.2