### PR TITLE
Check for `multipleOf` overflow

### DIFF
--- a/tests/draft2019-09/multipleOf.json
+++ b/tests/draft2019-09/multipleOf.json
@@ -56,5 +56,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "invalid instance should not raise error when float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/optional/float-overflow.json
+++ b/tests/draft2019-09/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft4/multipleOf.json
+++ b/tests/draft4/multipleOf.json
@@ -56,5 +56,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "invalid instance should not raise error when float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/optional/float-overflow.json
+++ b/tests/draft4/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft6/multipleOf.json
+++ b/tests/draft6/multipleOf.json
@@ -56,5 +56,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "invalid instance should not raise error when float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/optional/float-overflow.json
+++ b/tests/draft6/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/multipleOf.json
+++ b/tests/draft7/multipleOf.json
@@ -56,5 +56,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "invalid instance should not raise error when float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/optional/float-overflow.json
+++ b/tests/draft7/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The spec says that instances are valid if "dividing by this value results in an integer".

This allows integers to be invalid for `multipleOf: 0.5` if float division overflows to infinity (a non-integer); alternatively implementations may choose to implement logic which defines all integers as multiples of 0.5.  Either way, however, implementations must not raise an error due to the overflow of a legal value against a legal schema.

Reference:  https://github.com/Julian/jsonschema/issues/743, cc @Julian 