### PR TITLE
test that literal $refs are not evaluated as keywords

### DIFF
--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -407,5 +407,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -215,5 +215,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -434,5 +434,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -466,5 +466,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -466,5 +466,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
An evaluator should not treat all $ref properties as if they were keywords --
such as literal properties inside "enum" and "const"