### PR TITLE
draft4 float-overflow instance may be considered not an integer

### DIFF
--- a/tests/draft4/optional/float-overflow.json
+++ b/tests/draft4/optional/float-overflow.json
@@ -1,7 +1,7 @@
 [
     {
         "description": "all integers are multiples of 0.5, if overflow is handled",
-        "schema": {"type": "integer", "multipleOf": 0.5},
+        "schema": {"type": "number", "multipleOf": 0.5},
         "tests": [
             {
                 "description": "valid if optional overflow handling is implemented",


### PR DESCRIPTION
the instance data `1e308` is parsed by ruby's JSON parser as a float. since draft4 stipulates no fractional part including 0, this instance fails the `type: integer` validation.

the correctness of this change might be debatable, given the lack of a decimal in the instance, but the type isn't the point of this test; it's the multipleOf, so I'm hoping that is not contentious.