### PR TITLE
Fix $ref with siblings in pre-2019-09 tests

### DIFF
--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -127,7 +127,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{ "$ref": "#/definitions/c" }]
         },
         "tests": [
             {

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -127,7 +127,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{ "$ref": "#/definitions/c" }]
         },
         "tests": [
             {
@@ -239,7 +239,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{ "$ref": "#/definitions/bool" }],
             "definitions": {
                 "bool": true
             }
@@ -255,7 +255,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{ "$ref": "#/definitions/bool" }],
             "definitions": {
                 "bool": false
             }

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -127,7 +127,7 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "allOf": [{ "$ref": "#/definitions/c" }]
         },
         "tests": [
             {
@@ -239,7 +239,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{ "$ref": "#/definitions/bool" }],
             "definitions": {
                 "bool": true
             }
@@ -255,7 +255,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
-            "$ref": "#/definitions/bool",
+            "allOf": [{ "$ref": "#/definitions/bool" }],
             "definitions": {
                 "bool": false
             }


### PR DESCRIPTION
This is something that has been bothering me for a while. I have some time right now, so let's get this fixed. Before the nature of `$ref` was changed in draft 2019-09, any properties with an object with a `$ref` in it were members of the reference where they had no meaning rather than being part of the schema and interpreted as keywords. We have this test ...

```json
{
  "definitions": {
    "a": {"type": "integer"},
    "b": {"$ref": "#/definitions/a"},
    "c": {"$ref": "#/definitions/b"}
  },
  "$ref": "#/definitions/c"
}
```

In this case, `definitions` and everything it contains should be considered part of the reference and ignored. It should not be something the `$ref` can reference, because it's not part of the schema.

This works in a lot of implementations. I think that's wrong, but the behavior in this case is, in the most generous interpretation, is undefined. If a test like this should be kept around at all, it should be with the "optional" tests. I wouldn't even include it in "optional" because it's at best a highly discouraged pattern and I don't think the test suite should encourage it by including an example.