### PR TITLE
Remove draft-04 test that only allows ref for schemas

### DIFF
--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -434,28 +434,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "naive replacement of $ref with its destination is not correct",
-        "schema": {
-            "definitions": {
-                "a_string": { "type": "string" }
-            },
-            "enum": [
-                { "$ref": "#/definitions/a_string" }
-            ]
-        },
-        "tests": [
-            {
-                "description": "do not evaluate the $ref inside the enum",
-                "data": "this is a string",
-                "valid": false
-            },
-            {
-                "description": "match the enum exactly",
-                "data": { "$ref": "#/definitions/a_string" },
-                "valid": true
-            }
-        ]
     }
 ]


### PR DESCRIPTION
In draft-04, there were no restrictions on where you could use `$ref`. Technically, it could be used anywhere, but no implementations at the time supported using `$ref` for anything other than referencing schemas. So, in draft-06 `$ref` was changed to only be allowed where schemas are allowed. Therefore, the test I've deleted is not correct for draft-04, but is correct for draft-06 and up.