### PR TITLE
by default, "format" only annotates, not validates

### DIFF
--- a/tests/draft2019-09/format.json
+++ b/tests/draft2019-09/format.json
@@ -32,6 +32,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid email string is only an annotation by default",
+                "data": "2962",
+                "valid": true
             }
         ]
     },
@@ -67,6 +72,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-email string is only an annotation by default",
+                "data": "2962",
                 "valid": true
             }
         ]
@@ -104,6 +114,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid regex string is only an annotation by default",
+                "data": "^(abc]",
+                "valid": true
             }
         ]
     },
@@ -139,6 +154,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ipv4 string is only an annotation by default",
+                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -176,6 +196,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid ipv6 string is only an annotation by default",
+                "data": "12345::",
+                "valid": true
             }
         ]
     },
@@ -211,6 +236,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-hostname string is only an annotation by default",
+                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -248,6 +278,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid hostname string is only an annotation by default",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": true
             }
         ]
     },
@@ -283,6 +318,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date string is only an annotation by default",
+                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -320,6 +360,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid date-time string is only an annotation by default",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": true
             }
         ]
     },
@@ -355,6 +400,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid time string is only an annotation by default",
+                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -392,6 +442,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid json-pointer string is only an annotation by default",
+                "data": "/foo/bar~",
+                "valid": true
             }
         ]
     },
@@ -427,6 +482,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid relative-json-pointer string is only an annotation by default",
+                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -464,6 +524,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid iri string is only an annotation by default",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": true
             }
         ]
     },
@@ -499,6 +564,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid iri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -536,6 +606,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri string is only an annotation by default",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
             }
         ]
     },
@@ -571,6 +646,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid uri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -608,6 +688,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri-template string is only an annotation by default",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": true
             }
         ]
     },
@@ -644,6 +729,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uuid string is only an annotation by default",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": true
             }
         ]
     },
@@ -679,6 +769,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid duration string is only an annotation by default",
+                "data": "PT1D",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/format.json
+++ b/tests/draft2020-12/format.json
@@ -32,6 +32,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid email string is only an annotation by default",
+                "data": "2962",
+                "valid": true
             }
         ]
     },
@@ -67,6 +72,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-email string is only an annotation by default",
+                "data": "2962",
                 "valid": true
             }
         ]
@@ -104,6 +114,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid regex string is only an annotation by default",
+                "data": "^(abc]",
+                "valid": true
             }
         ]
     },
@@ -139,6 +154,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ipv4 string is only an annotation by default",
+                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -176,6 +196,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid ipv6 string is only an annotation by default",
+                "data": "12345::",
+                "valid": true
             }
         ]
     },
@@ -211,6 +236,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-hostname string is only an annotation by default",
+                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -248,6 +278,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid hostname string is only an annotation by default",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": true
             }
         ]
     },
@@ -283,6 +318,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date string is only an annotation by default",
+                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -320,6 +360,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid date-time string is only an annotation by default",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": true
             }
         ]
     },
@@ -355,6 +400,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid time string is only an annotation by default",
+                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -392,6 +442,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid json-pointer string is only an annotation by default",
+                "data": "/foo/bar~",
+                "valid": true
             }
         ]
     },
@@ -427,6 +482,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid relative-json-pointer string is only an annotation by default",
+                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -464,6 +524,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid iri string is only an annotation by default",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": true
             }
         ]
     },
@@ -499,6 +564,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid iri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -536,6 +606,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri string is only an annotation by default",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
             }
         ]
     },
@@ -571,6 +646,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid uri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -608,6 +688,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri-template string is only an annotation by default",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": true
             }
         ]
     },
@@ -644,6 +729,11 @@
                 "description": "ignores null",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uuid string is only an annotation by default",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": true
             }
         ]
     },
@@ -679,6 +769,11 @@
             {
                 "description": "ignores null",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid duration string is only an annotation by default",
+                "data": "PT1D",
                 "valid": true
             }
         ]


### PR DESCRIPTION
In all cases, the sample data was taken from the first "invalid" case in the corresponding optional/format/\<format\>.json file

For 2020-12 specifically, we should also move these format-annotation tests to format-annotation.json, and move the format-validation tests from optional/format into the main directory along with a `"$schema": <metaschema with format-validation: true>` (and add that metaschema to remotes/), but I'll leave that to another PR.

related: #434