### PR TITLE
reject ipv4 strings with an octet with a leading zero

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -32,6 +32,17 @@
                 "description": "an IP address as an integer (decimal)",
                 "data": "2130706433",
                 "valid": false
+            },
+            {
+                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -32,6 +32,17 @@
                 "description": "an IP address as an integer (decimal)",
                 "data": "2130706433",
                 "valid": false
+            },
+            {
+                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -32,6 +32,17 @@
                 "description": "an IP address as an integer (decimal)",
                 "data": "2130706433",
                 "valid": false
+            },
+            {
+                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -32,6 +32,17 @@
                 "description": "an IP address as an integer (decimal)",
                 "data": "2130706433",
                 "valid": false
+            },
+            {
+                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -32,6 +32,17 @@
                 "description": "an IP address as an integer (decimal)",
                 "data": "2130706433",
                 "valid": false
+            },
+            {
+                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Ensuring implementations reject these values will help guard against this
security vulnerability.
see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/