### PR TITLE
test for confusing not-identifiers in enums

### DIFF
--- a/tests/draft2019-09/anchor.json
+++ b/tests/draft2019-09/anchor.json
@@ -77,5 +77,62 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/id.json
+++ b/tests/draft2019-09/id.json
@@ -202,5 +202,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/anchor.json
+++ b/tests/draft2020-12/anchor.json
@@ -77,5 +77,62 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/id.json
+++ b/tests/draft2020-12/id.json
@@ -204,5 +204,55 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/id.json
+++ b/tests/draft4/id.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+
+]

--- a/tests/draft6/id.json
+++ b/tests/draft6/id.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+
+]

--- a/tests/draft7/id.json
+++ b/tests/draft7/id.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+
+]


### PR DESCRIPTION
A naive implementation would add all $id or $anchors to its list of known
resources, without checking if they are actually in subschemas or the value of
a keyword like enum, const or examples.