### PR TITLE
test that a missing property is not populated by the default in the actual instance data

### DIFF
--- a/tests/draft2019-09/default.json
+++ b/tests/draft2019-09/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            },
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/default.json
+++ b/tests/draft2020-12/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/default.json
+++ b/tests/draft3/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/default.json
+++ b/tests/draft4/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/default.json
+++ b/tests/draft6/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/default.json
+++ b/tests/draft7/default.json
@@ -45,5 +45,35 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Implementations may want to fill in missing properties with their values from "default" before evaluating the schema, which is not correct.