### PR TITLE
test that array-items/prefixItems adjusts the starting position for schema-items/additionalItems

### DIFF
--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -126,5 +126,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -233,5 +233,24 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "prefixItems validation adjusts the starting index for items",
+        "schema": {
+            "prefixItems": [ { "type": "string" } ],
+            "items": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/additionalItems.json
+++ b/tests/draft4/additionalItems.json
@@ -126,5 +126,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/additionalItems.json
+++ b/tests/draft6/additionalItems.json
@@ -126,5 +126,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/additionalItems.json
+++ b/tests/draft7/additionalItems.json
@@ -126,5 +126,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
I noticed this gap in the test coverage when implementing prefixItems for 2020-12.