### PR TITLE
Stricter time format constraints

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -5,8 +5,73 @@
         "tests": [
             {
                 "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:60",
+                "valid": false
             },
             {
                 "description": "an invalid time string",

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "a valid time string with leap second with offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
                 "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -80,7 +80,7 @@
             },
             {
                 "description": "an invalid time string with invalid time with both Z and numoffset",
-                "data": "01:02:03Z+00:60",
+                "data": "01:02:03Z+00:30",
                 "valid": false
             },
             {

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -20,6 +20,11 @@
             },
             {
                 "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
             },

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -5,8 +5,73 @@
         "tests": [
             {
                 "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:60",
+                "valid": false
             },
             {
                 "description": "an invalid time string",

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "a valid time string with leap second with offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
                 "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -80,7 +80,7 @@
             },
             {
                 "description": "an invalid time string with invalid time with both Z and numoffset",
-                "data": "01:02:03Z+00:60",
+                "data": "01:02:03Z+00:30",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -20,6 +20,11 @@
             },
             {
                 "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
             },

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -5,8 +5,73 @@
         "tests": [
             {
                 "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:60",
+                "valid": false
             },
             {
                 "description": "an invalid time string",

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "a valid time string with leap second with offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
                 "description": "a valid time string with second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -80,7 +80,7 @@
             },
             {
                 "description": "an invalid time string with invalid time with both Z and numoffset",
-                "data": "01:02:03Z+00:60",
+                "data": "01:02:03Z+00:30",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -20,6 +20,11 @@
             },
             {
                 "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
                 "data": "08:30:06.283185Z",
                 "valid": true
             },


### PR DESCRIPTION
Based on [RFC3339's ABNF](https://tools.ietf.org/html/rfc3339#section-5.6), I think this should cover all possibilities:

```
   time-hour       = 2DIGIT  ; 00-23
   time-minute     = 2DIGIT  ; 00-59
   time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
                             ; rules
   time-secfrac    = "." 1*DIGIT
   time-numoffset  = ("+" / "-") time-hour ":" time-minute
   time-offset     = "Z" / time-numoffset

   partial-time    = time-hour ":" time-minute ":" time-second
                     [time-secfrac]
   full-time       = partial-time time-offset
```

/c @jnewc