### PR TITLE
Stricter date format constraints

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -9,7 +9,142 @@
                 "valid": true
             },
             {
-                "description": "an invalid date-time string",
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
             },

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -9,7 +9,142 @@
                 "valid": true
             },
             {
-                "description": "an invalid date-time string",
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
             },

--- a/tests/draft3/optional/format/date.json
+++ b/tests/draft3/optional/format/date.json
@@ -9,6 +9,141 @@
                 "valid": true
             },
             {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -9,7 +9,142 @@
                 "valid": true
             },
             {
-                "description": "an invalid date-time string",
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
             },


### PR DESCRIPTION
This adds tests for the date format to ensure that the month day-length is permitted following the [day restrictions](https://tools.ietf.org/html/rfc3339#section-5.7), there is 2 tests for each month (one at last day and one negative at day after). February has two sets of tests for normal and leap years.

> 5.7. Restrictions
> 
>    The grammar element date-mday represents the day number within the
>    current month.  The maximum value varies based on the month and year
>    as follows:
> 
>       Month Number  Month/Year           Maximum value of date-mday
>       ------------  ----------           --------------------------
>       01            January              31
>       02            February, normal     28
>       02            February, leap year  29
>       03            March                31
>       04            April                30
>       05            May                  31
>       06            June                 30
>       07            July                 31
>       08            August               31
>       09            September            30
>       10            October              31
>       11            November             30
>       12            December             31
> 
>    Appendix C contains sample C code to determine if a year is a leap
>    year.

There contains a test for invalid months too.