### PR TITLE
Add test for "contains" with false "if" subschema

### DIFF
--- a/tests/draft2019-09/contains.json
+++ b/tests/draft2019-09/contains.json
@@ -125,5 +125,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/contains.json
+++ b/tests/draft2020-12/contains.json
@@ -125,5 +125,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft6/contains.json
+++ b/tests/draft6/contains.json
@@ -125,5 +125,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/contains.json
+++ b/tests/draft7/contains.json
@@ -125,5 +125,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
An intermediate solution to a problem I've been working on had `contains` failing when an `if` subschema failed.

My implementation only supports drafts 2019-09 and 2020-12, so I'm not 100% sure that this is a valid test for draft6 and draft7.