### PR TITLE
Remove a test for undefined $id behavior

### DIFF
--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -378,32 +378,6 @@
         ]
     },
     {
-        "description": "Location-independent identifier with absolute URI",
-        "schema": {
-            "allOf": [{
-                "$ref": "http://localhost:1234/bar#foo"
-            }],
-            "definitions": {
-                "A": {
-                    "id": "http://localhost:1234/bar#foo",
-                    "type": "integer"
-                }
-            }
-        },
-        "tests": [
-            {
-                "data": 1,
-                "description": "match",
-                "valid": true
-            },
-            {
-                "data": "a",
-                "description": "mismatch",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
             "id": "http://localhost:1234/root",

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -410,32 +410,6 @@
         ]
     },
     {
-        "description": "Location-independent identifier with absolute URI",
-        "schema": {
-            "allOf": [{
-                "$ref": "http://localhost:1234/bar#foo"
-            }],
-            "definitions": {
-                "A": {
-                    "$id": "http://localhost:1234/bar#foo",
-                    "type": "integer"
-                }
-            }
-        },
-        "tests": [
-            {
-                "data": 1,
-                "description": "match",
-                "valid": true
-            },
-            {
-                "data": "a",
-                "description": "mismatch",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
             "$id": "http://localhost:1234/root",

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -410,32 +410,6 @@
         ]
     },
     {
-        "description": "Location-independent identifier with absolute URI",
-        "schema": {
-            "allOf": [{
-                "$ref": "http://localhost:1234/bar#foo"
-            }],
-            "definitions": {
-                "A": {
-                    "$id": "http://localhost:1234/bar#foo",
-                    "type": "integer"
-                }
-            }
-        },
-        "tests": [
-            {
-                "data": 1,
-                "description": "match",
-                "valid": true
-            },
-            {
-                "data": "a",
-                "description": "mismatch",
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
             "$id": "http://localhost:1234/root",


### PR DESCRIPTION
Resolves #486 

While a fragment in an `$id` is not forbidden in draft-04/6/7, it's also
not defined what meaning that fragment has. Therefore, this is testing
for a behavior that is not defined or intended to be defined by the
spec.