### PR TITLE
add test for $ref into $defs where its canonical URI has changed

### DIFF
--- a/remotes/baseUriChangeFolderInSubschema2/folderInteger.json
+++ b/remotes/baseUriChangeFolderInSubschema2/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -130,6 +130,39 @@
         ]
     },
     {
+        "description": "base URI change - change folder in subschema with path from root",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs3.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/$defs/baz/$defs/bar"}
+            },
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema2/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "root ref in remote ref",
         "schema": {
             "$id": "http://localhost:1234/object",

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -130,6 +130,39 @@
         ]
     },
     {
+        "description": "base URI change - change folder in subschema with path from root",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs3.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/$defs/baz/$defs/bar"}
+            },
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema2/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "root ref in remote ref",
         "schema": {
             "$id": "http://localhost:1234/object",

--- a/tests/draft4/refRemote.json
+++ b/tests/draft4/refRemote.json
@@ -105,12 +105,43 @@
         "schema": {
             "id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/definitions/bar"}},
+            "definitions": {
+                "baz": {
+                    "id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema with path from root",
+        "schema": {
+            "id": "http://localhost:1234/scope_change_defs3.json",
+            "type" : "object",
             "properties": {
                 "list": {"$ref": "#/definitions/baz/definitions/bar"}
             },
             "definitions": {
                 "baz": {
-                    "id": "baseUriChangeFolderInSubschema/",
+                    "id": "baseUriChangeFolderInSubschema2/",
                     "definitions": {
                         "bar": {
                             "type": "array",

--- a/tests/draft6/refRemote.json
+++ b/tests/draft6/refRemote.json
@@ -105,12 +105,43 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/definitions/bar"}},
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema with path from root",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs3.json",
+            "type" : "object",
             "properties": {
                 "list": {"$ref": "#/definitions/baz/definitions/bar"}
             },
             "definitions": {
                 "baz": {
-                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$id": "baseUriChangeFolderInSubschema2/",
                     "definitions": {
                         "bar": {
                             "type": "array",

--- a/tests/draft7/refRemote.json
+++ b/tests/draft7/refRemote.json
@@ -105,12 +105,43 @@
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/definitions/bar"}},
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema with path from root",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs3.json",
+            "type" : "object",
             "properties": {
                 "list": {"$ref": "#/definitions/baz/definitions/bar"}
             },
             "definitions": {
                 "baz": {
-                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$id": "baseUriChangeFolderInSubschema2/",
                     "definitions": {
                         "bar": {
                             "type": "array",


### PR DESCRIPTION
I discovered that refRemote.json differs between draft7 (and earlier) and draft2019-09 (and later), and the changed test tests subtly different things -- and some implementations *cough cough* might not ~~resolve the URI correctly~~ properly set the new base uri after navigating the $ref in the second case.