### PR TITLE
Object contains tests

### DIFF
--- a/tests/draft-future/contains.json
+++ b/tests/draft-future/contains.json
@@ -2,7 +2,7 @@
     {
         "description": "contains keyword validation",
         "schema": {
-            "contains": {"minimum": 5}
+            "contains": { "minimum": 5 }
         },
         "tests": [
             {
@@ -62,7 +62,7 @@
     },
     {
         "description": "contains keyword with boolean schema true",
-        "schema": {"contains": true},
+        "schema": { "contains": true },
         "tests": [
             {
                 "description": "any non-empty array is valid",
@@ -78,7 +78,7 @@
     },
     {
         "description": "contains keyword with boolean schema false",
-        "schema": {"contains": false},
+        "schema": { "contains": false },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -106,22 +106,22 @@
         "tests": [
             {
                 "description": "matches items, does not match contains",
-                "data": [ 2, 4, 8 ],
+                "data": [2, 4, 8],
                 "valid": false
             },
             {
                 "description": "does not match items, matches contains",
-                "data": [ 3, 6, 9 ],
+                "data": [3, 6, 9],
                 "valid": false
             },
             {
                 "description": "matches both items and contains",
-                "data": [ 6, 12 ],
+                "data": [6, 12],
                 "valid": true
             },
             {
                 "description": "matches neither items nor contains",
-                "data": [ 1, 5 ],
+                "data": [1, 5],
                 "valid": false
             }
         ]

--- a/tests/draft-future/contains.json
+++ b/tests/draft-future/contains.json
@@ -31,8 +31,33 @@
                 "valid": false
             },
             {
-                "description": "not array is valid",
+                "description": "object with property matching schema (5) is valid",
+                "data": { "a": 3, "b": 4, "c": 5 },
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema (6) is valid",
+                "data": { "a": 3, "b": 4, "c": 6 },
+                "valid": true
+            },
+            {
+                "description": "object with two properties matching schema (5, 6) is valid",
+                "data": { "a": 3, "b": 4, "c": 5, "d": 6 },
+                "valid": true
+            },
+            {
+                "description": "object without properties matching schema is invalid",
+                "data": { "a": 2, "b": 3, "c": 4 },
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
                 "data": {},
+                "valid": false
+            },
+            {
+                "description": "not array or object is valid",
+                "data": 42,
                 "valid": true
             }
         ]
@@ -57,6 +82,21 @@
                 "description": "array without item 5 is invalid",
                 "data": [1, 2, 3, 4],
                 "valid": false
+            },
+            {
+                "description": "object with property 5 is valid",
+                "data": { "a": 3, "b": 4, "c": 5 },
+                "valid": true
+            },
+            {
+                "description": "object with two properties 5 is valid",
+                "data": { "a": 3, "b": 4, "c": 5, "d": 5 },
+                "valid": true
+            },
+            {
+                "description": "object without property 5 is invalid",
+                "data": { "a": 1, "b": 2, "c": 3, "d": 4 },
+                "valid": false
             }
         ]
     },
@@ -72,6 +112,16 @@
             {
                 "description": "empty array is invalid",
                 "data": [],
+                "valid": false
+            },
+            {
+                "description": "any non-empty object is valid",
+                "data": { "a": "foo" },
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
                 "valid": false
             }
         ]
@@ -91,7 +141,17 @@
                 "valid": false
             },
             {
-                "description": "non-arrays are valid",
+                "description": "any non-empty object is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "non-arrays/objects are valid",
                 "data": "contains does not apply to strings",
                 "valid": true
             }
@@ -100,6 +160,7 @@
     {
         "description": "items + contains",
         "schema": {
+            "additionalProperties": { "multipleOf": 2 },
             "items": { "multipleOf": 2 },
             "contains": { "multipleOf": 3 }
         },
@@ -123,6 +184,26 @@
                 "description": "matches neither items nor contains",
                 "data": [1, 5],
                 "valid": false
+            },
+            {
+                "description": "matches additionalProperties, does not match contains",
+                "data": { "a": 2, "b": 4, "c": 8 },
+                "valid": false
+            },
+            {
+                "description": "does not match additionalProperties, matches contains",
+                "data": { "a": 3, "b": 6, "c": 9 },
+                "valid": false
+            },
+            {
+                "description": "matches both additionalProperties and contains",
+                "data": { "a": 6, "b": 12 },
+                "valid": true
+            },
+            {
+                "description": "matches neither additionalProperties nor contains",
+                "data": { "a": 1, "b": 5 },
+                "valid": false
             }
         ]
     },
@@ -143,6 +224,16 @@
             {
                 "description": "empty array is invalid",
                 "data": [],
+                "valid": false
+            },
+            {
+                "description": "any non-empty object is valid",
+                "data": { "a": "foo" },
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
                 "valid": false
             }
         ]

--- a/tests/draft-future/maxContains.json
+++ b/tests/draft-future/maxContains.json
@@ -7,12 +7,12 @@
         "tests": [
             {
                 "description": "one item valid against lone maxContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": true
             },
             {
                 "description": "two items still valid against lone maxContains",
-                "data": [ 1, 2 ],
+                "data": [1, 2],
                 "valid": true
             }
         ]
@@ -20,33 +20,33 @@
     {
         "description": "maxContains with contains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "maxContains": 1
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "all elements match, valid maxContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": true
             },
             {
                 "description": "all elements match, invalid maxContains",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": false
             },
             {
                 "description": "some elements match, valid maxContains",
-                "data": [ 1, 2 ],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "some elements match, invalid maxContains",
-                "data": [ 1, 2, 1 ],
+                "data": [1, 2, 1],
                 "valid": false
             }
         ]
@@ -54,24 +54,24 @@
     {
         "description": "minContains < maxContains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "minContains": 1,
             "maxContains": 3
         },
         "tests": [
             {
                 "description": "actual < minContains < maxContains",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "minContains < actual < maxContains",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": true
             },
             {
                 "description": "minContains < maxContains < actual",
-                "data": [ 1, 1, 1, 1 ],
+                "data": [1, 1, 1, 1],
                 "valid": false
             }
         ]

--- a/tests/draft-future/maxContains.json
+++ b/tests/draft-future/maxContains.json
@@ -14,6 +14,16 @@
                 "description": "two items still valid against lone maxContains",
                 "data": [1, 2],
                 "valid": true
+            },
+            {
+                "description": "one property valid against lone maxContains",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "two properties still valid against lone maxContains",
+                "data": { "a": 1, "b": 2 },
+                "valid": true
             }
         ]
     },
@@ -25,7 +35,7 @@
         },
         "tests": [
             {
-                "description": "empty data",
+                "description": "empty array",
                 "data": [],
                 "valid": false
             },
@@ -48,6 +58,31 @@
                 "description": "some elements match, invalid maxContains",
                 "data": [1, 2, 1],
                 "valid": false
+            },
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "all properties match, valid maxContains",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "all properties match, invalid maxContains",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "some properties match, valid maxContains",
+                "data": { "a": 1, "b": 2 },
+                "valid": true
+            },
+            {
+                "description": "some properties match, invalid maxContains",
+                "data": { "a": 1, "b": 2, "c": 1 },
+                "valid": false
             }
         ]
     },
@@ -60,18 +95,33 @@
         },
         "tests": [
             {
-                "description": "actual < minContains < maxContains",
+                "description": "array with actual < minContains < maxContains",
                 "data": [],
                 "valid": false
             },
             {
-                "description": "minContains < actual < maxContains",
+                "description": "array with minContains < actual < maxContains",
                 "data": [1, 1],
                 "valid": true
             },
             {
-                "description": "minContains < maxContains < actual",
+                "description": "array with minContains < maxContains < actual",
                 "data": [1, 1, 1, 1],
+                "valid": false
+            },
+            {
+                "description": "object with actual < minContains < maxContains",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "object with minContains < actual < maxContains",
+                "data": { "a": 1, "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "object with minContains < maxContains < actual",
+                "data": { "a": 1, "b": 1, "c": 1, "d": 1 },
                 "valid": false
             }
         ]

--- a/tests/draft-future/minContains.json
+++ b/tests/draft-future/minContains.json
@@ -7,7 +7,7 @@
         "tests": [
             {
                 "description": "one item valid against lone minContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": true
             },
             {
@@ -20,33 +20,33 @@
     {
         "description": "minContains=1 with contains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "minContains": 1
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "no elements match",
-                "data": [ 2 ],
+                "data": [2],
                 "valid": false
             },
             {
                 "description": "single element matches, valid minContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": true
             },
             {
                 "description": "some elements match, valid minContains",
-                "data": [ 1, 2 ],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "all elements match, valid minContains",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": true
             }
         ]
@@ -54,38 +54,38 @@
     {
         "description": "minContains=2 with contains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "minContains": 2
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "all elements match, invalid minContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": false
             },
             {
                 "description": "some elements match, invalid minContains",
-                "data": [ 1, 2 ],
+                "data": [1, 2],
                 "valid": false
             },
             {
                 "description": "all elements match, valid minContains (exactly as needed)",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": true
             },
             {
                 "description": "all elements match, valid minContains (more than needed)",
-                "data": [ 1, 1, 1 ],
+                "data": [1, 1, 1],
                 "valid": true
             },
             {
                 "description": "some elements match, valid minContains",
-                "data": [ 1, 2, 1 ],
+                "data": [1, 2, 1],
                 "valid": true
             }
         ]
@@ -93,29 +93,29 @@
     {
         "description": "maxContains = minContains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "maxContains": 2,
             "minContains": 2
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "all elements match, invalid minContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": false
             },
             {
                 "description": "all elements match, invalid maxContains",
-                "data": [ 1, 1, 1 ],
+                "data": [1, 1, 1],
                 "valid": false
             },
             {
                 "description": "all elements match, valid maxContains and minContains",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": true
             }
         ]
@@ -123,29 +123,29 @@
     {
         "description": "maxContains < minContains",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "maxContains": 1,
             "minContains": 3
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": false
             },
             {
                 "description": "invalid minContains",
-                "data": [ 1 ],
+                "data": [1],
                 "valid": false
             },
             {
                 "description": "invalid maxContains",
-                "data": [ 1, 1, 1 ],
+                "data": [1, 1, 1],
                 "valid": false
             },
             {
                 "description": "invalid maxContains and minContains",
-                "data": [ 1, 1 ],
+                "data": [1, 1],
                 "valid": false
             }
         ]
@@ -153,18 +153,18 @@
     {
         "description": "minContains = 0",
         "schema": {
-            "contains": {"const": 1},
+            "contains": { "const": 1 },
             "minContains": 0
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": true
             },
             {
                 "description": "minContains = 0 makes contains always pass",
-                "data": [ 2 ],
+                "data": [2],
                 "valid": true
             }
         ]

--- a/tests/draft-future/unevaluatedProperties.json
+++ b/tests/draft-future/unevaluatedProperties.json
@@ -951,5 +951,54 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties depends on adjacent contains",
+        "schema": {
+            "properties": {
+              "foo": { "type": "number" }
+            },
+            "contains": { "type": "string" },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "bar is evaluated by contains",
+                "data": { "foo": 1, "bar": "foo" },
+                "valid": true
+            },
+            {
+                "description": "contains fails, bar is not evaluated",
+                "data": { "foo": 1, "bar": 2 },
+                "valid": false
+            },
+            {
+                "description": "contains passes, bar is not evaluated",
+                "data": { "foo": 1, "bar": 2, "baz": "foo" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties depends on multiple nested contains",
+        "schema": {
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedProperties": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": { "a": 2, "b": 3, "c": 4, "d": 5, "e": 6 },
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": { "a": 2, "b": 3, "c": 4, "d": 7, "e": 8 },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The next draft adds support allows `contains` to work with objects as well as arrays. This adds tests for `contains` with objects.