### PR TITLE
fix buggy test with $ref in older drafts

### DIFF
--- a/tests/draft6/refRemote.json
+++ b/tests/draft6/refRemote.json
@@ -172,7 +172,9 @@
         "description": "remote ref with ref to definitions",
         "schema": {
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
-            "$ref": "ref-and-definitions.json"
+            "allOf": [
+                { "$ref": "ref-and-definitions.json" }
+            ]
         },
         "tests": [
             {

--- a/tests/draft7/refRemote.json
+++ b/tests/draft7/refRemote.json
@@ -172,7 +172,9 @@
         "description": "remote ref with ref to definitions",
         "schema": {
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
-            "$ref": "ref-and-definitions.json"
+            "allOf": [
+                { "$ref": "ref-and-definitions.json" }
+            ]
         },
         "tests": [
             {


### PR DESCRIPTION
all keywords adjacent to $ref have no effect in draft7 and earlier.