### PR TITLE
collapse all other-data-type format tests together

### DIFF
--- a/tests/draft-future/format.json
+++ b/tests/draft-future/format.json
@@ -1,35 +1,35 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -41,36 +41,36 @@
         ]
     },
     {
-        "description": "validation of IDN e-mail addresses",
-        "schema": {"format": "idn-email"},
+        "description": "idn-email format",
+        "schema": { "format": "idn-email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -82,36 +82,36 @@
         ]
     },
     {
-        "description": "validation of regexes",
-        "schema": {"format": "regex"},
+        "description": "regex format",
+        "schema": { "format": "regex" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -123,36 +123,36 @@
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -164,36 +164,36 @@
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -205,36 +205,36 @@
         ]
     },
     {
-        "description": "validation of IDN hostnames",
-        "schema": {"format": "idn-hostname"},
+        "description": "idn-hostname format",
+        "schema": { "format": "idn-hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -246,36 +246,36 @@
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -287,36 +287,36 @@
         ]
     },
     {
-        "description": "validation of date strings",
-        "schema": {"format": "date"},
+        "description": "date format",
+        "schema": { "format": "date" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -328,36 +328,36 @@
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -369,36 +369,36 @@
         ]
     },
     {
-        "description": "validation of time strings",
-        "schema": {"format": "time"},
+        "description": "time format",
+        "schema": { "format": "time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -410,36 +410,36 @@
         ]
     },
     {
-        "description": "validation of JSON pointers",
-        "schema": {"format": "json-pointer"},
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -451,36 +451,36 @@
         ]
     },
     {
-        "description": "validation of relative JSON pointers",
-        "schema": {"format": "relative-json-pointer"},
+        "description": "relative-json-pointer format",
+        "schema": { "format": "relative-json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -492,36 +492,36 @@
         ]
     },
     {
-        "description": "validation of IRIs",
-        "schema": {"format": "iri"},
+        "description": "iri format",
+        "schema": { "format": "iri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -533,36 +533,36 @@
         ]
     },
     {
-        "description": "validation of IRI references",
-        "schema": {"format": "iri-reference"},
+        "description": "iri-reference format",
+        "schema": { "format": "iri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -574,36 +574,36 @@
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -615,36 +615,36 @@
         ]
     },
     {
-        "description": "validation of URI references",
-        "schema": {"format": "uri-reference"},
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -656,36 +656,36 @@
         ]
     },
     {
-        "description": "validation of URI templates",
-        "schema": {"format": "uri-template"},
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -697,36 +697,36 @@
         ]
     },
     {
-        "description": "validation of UUIDs",
+        "description": "uuid format",
         "schema": { "format": "uuid" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -738,36 +738,36 @@
         ]
     },
     {
-        "description": "validation of durations",
+        "description": "duration format",
         "schema": { "format": "duration" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },

--- a/tests/draft2019-09/format.json
+++ b/tests/draft2019-09/format.json
@@ -1,35 +1,35 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -41,36 +41,36 @@
         ]
     },
     {
-        "description": "validation of IDN e-mail addresses",
-        "schema": {"format": "idn-email"},
+        "description": "idn-email format",
+        "schema": { "format": "idn-email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -82,36 +82,36 @@
         ]
     },
     {
-        "description": "validation of regexes",
-        "schema": {"format": "regex"},
+        "description": "regex format",
+        "schema": { "format": "regex" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -123,36 +123,36 @@
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -164,36 +164,36 @@
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -205,36 +205,36 @@
         ]
     },
     {
-        "description": "validation of IDN hostnames",
-        "schema": {"format": "idn-hostname"},
+        "description": "idn-hostname format",
+        "schema": { "format": "idn-hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -246,36 +246,36 @@
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -287,36 +287,36 @@
         ]
     },
     {
-        "description": "validation of date strings",
-        "schema": {"format": "date"},
+        "description": "date format",
+        "schema": { "format": "date" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -328,36 +328,36 @@
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -369,36 +369,36 @@
         ]
     },
     {
-        "description": "validation of time strings",
-        "schema": {"format": "time"},
+        "description": "time format",
+        "schema": { "format": "time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -410,36 +410,36 @@
         ]
     },
     {
-        "description": "validation of JSON pointers",
-        "schema": {"format": "json-pointer"},
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -451,36 +451,36 @@
         ]
     },
     {
-        "description": "validation of relative JSON pointers",
-        "schema": {"format": "relative-json-pointer"},
+        "description": "relative-json-pointer format",
+        "schema": { "format": "relative-json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -492,36 +492,36 @@
         ]
     },
     {
-        "description": "validation of IRIs",
-        "schema": {"format": "iri"},
+        "description": "iri format",
+        "schema": { "format": "iri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -533,36 +533,36 @@
         ]
     },
     {
-        "description": "validation of IRI references",
-        "schema": {"format": "iri-reference"},
+        "description": "iri-reference format",
+        "schema": { "format": "iri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -574,36 +574,36 @@
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -615,36 +615,36 @@
         ]
     },
     {
-        "description": "validation of URI references",
-        "schema": {"format": "uri-reference"},
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -656,36 +656,36 @@
         ]
     },
     {
-        "description": "validation of URI templates",
-        "schema": {"format": "uri-template"},
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -697,36 +697,36 @@
         ]
     },
     {
-        "description": "validation of UUIDs",
+        "description": "uuid format",
         "schema": { "format": "uuid" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -738,36 +738,36 @@
         ]
     },
     {
-        "description": "validation of durations",
+        "description": "duration format",
         "schema": { "format": "duration" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },

--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -87,26 +87,6 @@
               "description": "weeks cannot be combined with other units",
               "data": "P1Y2W",
               "valid": false
-          },
-          {
-              "description": "null value should be ignored",
-              "data": null,
-              "valid": true
-          },
-          {
-              "description": "number value should be ignored",
-              "data": 1,
-              "valid": true
-          },
-          {
-              "description": "list value should be ignored",
-              "data": [],
-              "valid": true
-          },
-          {
-              "description": "object value should be ignored",
-              "data": {},
-              "valid": true
           }
       ]
   }

--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -64,26 +64,6 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
-            },
-            {
-                "description": "null value should be ignored",
-                "data": null,
-                "valid": true
-            },
-            {
-                "description": "number value should be ignored",
-                "data": 1,
-                "valid": true
-            },
-            {
-                "description": "list value should be ignored",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "object value should be ignored",
-                "data": {},
-                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/format.json
+++ b/tests/draft2020-12/format.json
@@ -1,35 +1,35 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -41,36 +41,36 @@
         ]
     },
     {
-        "description": "validation of IDN e-mail addresses",
-        "schema": {"format": "idn-email"},
+        "description": "idn-email format",
+        "schema": { "format": "idn-email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -82,36 +82,36 @@
         ]
     },
     {
-        "description": "validation of regexes",
-        "schema": {"format": "regex"},
+        "description": "regex format",
+        "schema": { "format": "regex" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -123,36 +123,36 @@
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -164,36 +164,36 @@
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -205,36 +205,36 @@
         ]
     },
     {
-        "description": "validation of IDN hostnames",
-        "schema": {"format": "idn-hostname"},
+        "description": "idn-hostname format",
+        "schema": { "format": "idn-hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -246,36 +246,36 @@
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -287,36 +287,36 @@
         ]
     },
     {
-        "description": "validation of date strings",
-        "schema": {"format": "date"},
+        "description": "date format",
+        "schema": { "format": "date" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -328,36 +328,36 @@
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -369,36 +369,36 @@
         ]
     },
     {
-        "description": "validation of time strings",
-        "schema": {"format": "time"},
+        "description": "time format",
+        "schema": { "format": "time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -410,36 +410,36 @@
         ]
     },
     {
-        "description": "validation of JSON pointers",
-        "schema": {"format": "json-pointer"},
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -451,36 +451,36 @@
         ]
     },
     {
-        "description": "validation of relative JSON pointers",
-        "schema": {"format": "relative-json-pointer"},
+        "description": "relative-json-pointer format",
+        "schema": { "format": "relative-json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -492,36 +492,36 @@
         ]
     },
     {
-        "description": "validation of IRIs",
-        "schema": {"format": "iri"},
+        "description": "iri format",
+        "schema": { "format": "iri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -533,36 +533,36 @@
         ]
     },
     {
-        "description": "validation of IRI references",
-        "schema": {"format": "iri-reference"},
+        "description": "iri-reference format",
+        "schema": { "format": "iri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -574,36 +574,36 @@
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -615,36 +615,36 @@
         ]
     },
     {
-        "description": "validation of URI references",
-        "schema": {"format": "uri-reference"},
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -656,36 +656,36 @@
         ]
     },
     {
-        "description": "validation of URI templates",
-        "schema": {"format": "uri-template"},
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -697,36 +697,36 @@
         ]
     },
     {
-        "description": "validation of UUIDs",
+        "description": "uuid format",
         "schema": { "format": "uuid" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },
@@ -738,36 +738,36 @@
         ]
     },
     {
-        "description": "validation of durations",
+        "description": "duration format",
         "schema": { "format": "duration" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             },

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -87,26 +87,6 @@
               "description": "weeks cannot be combined with other units",
               "data": "P1Y2W",
               "valid": false
-          },
-          {
-              "description": "null value should be ignored",
-              "data": null,
-              "valid": true
-          },
-          {
-              "description": "number value should be ignored",
-              "data": 1,
-              "valid": true
-          },
-          {
-              "description": "list value should be ignored",
-              "data": [],
-              "valid": true
-          },
-          {
-              "description": "object value should be ignored",
-              "data": {},
-              "valid": true
           }
       ]
   }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -64,26 +64,6 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
-            },
-            {
-                "description": "null value should be ignored",
-                "data": null,
-                "valid": true
-            },
-            {
-                "description": "number value should be ignored",
-                "data": 1,
-                "valid": true
-            },
-            {
-                "description": "list value should be ignored",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "object value should be ignored",
-                "data": {},
-                "valid": true
             }
         ]
     }

--- a/tests/draft3/format.json
+++ b/tests/draft3/format.json
@@ -1,360 +1,405 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid email string is only an annotation by default",
+                "data": "2962",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ip-address format",
+        "schema": { "format": "ip-address" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ip-address string is only an annotation by default",
+                "data": "127.0.0.0.1",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ipv6 string is only an annotation by default",
+                "data": "12345::",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "host-name format",
+        "schema": { "format": "host-name" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid host-name string is only an annotation by default",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date-time string is only an annotation by default",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid regex string is only an annotation by default",
+                "data": "^(abc]",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": { "format": "date" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date string is only an annotation by default",
+                "data": "06/19/1963",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": { "format": "time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid time string is only an annotation by default",
+                "data": "08:30:06 PST",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "color format",
+        "schema": { "format": "color" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ip-address"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
             },
             {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of hostnames",
-        "schema": {"format": "host-name"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of regular expressions",
-        "schema": {"format": "regex"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of date strings",
-        "schema": {"format": "date"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of time strings",
-        "schema": {"format": "time"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of CSS colors",
-        "schema": {"format": "color"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
-        "tests": [
-            {
-                "description": "ignores integers",
-                "data": 12,
-                "valid": true
-            },
-            {
-                "description": "ignores floats",
-                "data": 13.7,
-                "valid": true
-            },
-            {
-                "description": "ignores objects",
-                "data": {},
-                "valid": true
-            },
-            {
-                "description": "ignores arrays",
-                "data": [],
-                "valid": true
-            },
-            {
-                "description": "ignores booleans",
-                "data": false,
-                "valid": true
-            },
-            {
-                "description": "ignores null",
-                "data": null,
+                "description": "invalid uri string is only an annotation by default",
+                "data": "//foo.bar/?baz=qux#quux",
                 "valid": true
             }
         ]

--- a/tests/draft4/format.json
+++ b/tests/draft4/format.json
@@ -1,215 +1,215 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }

--- a/tests/draft6/format.json
+++ b/tests/draft6/format.json
@@ -1,323 +1,323 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of JSON pointers",
-        "schema": {"format": "json-pointer"},
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URI references",
-        "schema": {"format": "uri-reference"},
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URI templates",
-        "schema": {"format": "uri-template"},
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }

--- a/tests/draft7/format.json
+++ b/tests/draft7/format.json
@@ -1,611 +1,611 @@
 [
     {
-        "description": "validation of e-mail addresses",
-        "schema": {"format": "email"},
+        "description": "email format",
+        "schema": { "format": "email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IDN e-mail addresses",
-        "schema": {"format": "idn-email"},
+        "description": "idn-email format",
+        "schema": { "format": "idn-email" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of regexes",
-        "schema": {"format": "regex"},
+        "description": "regex format",
+        "schema": { "format": "regex" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IP addresses",
-        "schema": {"format": "ipv4"},
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IPv6 addresses",
-        "schema": {"format": "ipv6"},
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IDN hostnames",
-        "schema": {"format": "idn-hostname"},
+        "description": "idn-hostname format",
+        "schema": { "format": "idn-hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of hostnames",
-        "schema": {"format": "hostname"},
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of date strings",
-        "schema": {"format": "date"},
+        "description": "date format",
+        "schema": { "format": "date" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of date-time strings",
-        "schema": {"format": "date-time"},
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of time strings",
-        "schema": {"format": "time"},
+        "description": "time format",
+        "schema": { "format": "time" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of JSON pointers",
-        "schema": {"format": "json-pointer"},
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of relative JSON pointers",
-        "schema": {"format": "relative-json-pointer"},
+        "description": "relative-json-pointer format",
+        "schema": { "format": "relative-json-pointer" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IRIs",
-        "schema": {"format": "iri"},
+        "description": "iri format",
+        "schema": { "format": "iri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of IRI references",
-        "schema": {"format": "iri-reference"},
+        "description": "iri-reference format",
+        "schema": { "format": "iri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URIs",
-        "schema": {"format": "uri"},
+        "description": "uri format",
+        "schema": { "format": "uri" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URI references",
-        "schema": {"format": "uri-reference"},
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }
         ]
     },
     {
-        "description": "validation of URI templates",
-        "schema": {"format": "uri-template"},
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
         "tests": [
             {
-                "description": "ignores integers",
+                "description": "all string formats ignore integers",
                 "data": 12,
                 "valid": true
             },
             {
-                "description": "ignores floats",
+                "description": "all string formats ignore floats",
                 "data": 13.7,
                 "valid": true
             },
             {
-                "description": "ignores objects",
+                "description": "all string formats ignore objects",
                 "data": {},
                 "valid": true
             },
             {
-                "description": "ignores arrays",
+                "description": "all string formats ignore arrays",
                 "data": [],
                 "valid": true
             },
             {
-                "description": "ignores booleans",
+                "description": "all string formats ignore booleans",
                 "data": false,
                 "valid": true
             },
             {
-                "description": "ignores null",
+                "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
             }


### PR DESCRIPTION
This doesn't remove any checks, just folds them together consistently.