### PR TITLE
add tests for pattern matching with unicode semantics

### DIFF
--- a/tests/draft-future/optional/unicode.json
+++ b/tests/draft-future/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/optional/unicode.json
+++ b/tests/draft2019-09/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2020-12/optional/unicode.json
+++ b/tests/draft2020-12/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft4/optional/unicode.json
+++ b/tests/draft4/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft6/optional/unicode.json
+++ b/tests/draft6/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/unicode.json
+++ b/tests/draft7/optional/unicode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "description": "unicode semantics should be used for all pattern matching",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode semantics should be used for all patternProperties matching",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unicode digits are more than 0 through 9",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Supporting this is now mandatory in draft2020-12.