### PR TITLE
test that dynamic scopes are not always in scope

### DIFF
--- a/tests/draft-future/dynamicRef.json
+++ b/tests/draft-future/dynamicRef.json
@@ -78,7 +78,7 @@
         ]
     },
     {
-        "description": "A $dynamicRef should resolve to the first $dynamicAnchor that is encountered when the schema is evaluated",
+        "description": "A $dynamicRef should resolve to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
         "schema": {
             "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
             "$ref": "list",
@@ -382,6 +382,63 @@
                 "description": "recurse to integerNode - floats are not allowed",
                 "data": { "november": 1.1 },
                 "valid": false
+            }
+        ]
+    },
+    {
+        "description": "after leaving a dynamic scope, it should not be used by a $dynamicRef",
+        "schema": {
+            "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
+            "if": {
+                "$id": "first_scope",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is first_scope#thingy",
+                        "$dynamicAnchor": "thingy",
+                        "type": "number"
+                    }
+                }
+            },
+            "then": {
+                "$id": "second_scope",
+                "$ref": "start",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is second_scope#thingy, the final destination of the $dynamicRef",
+                        "$dynamicAnchor": "thingy",
+                        "type": "null"
+                    }
+                }
+            },
+            "$defs": {
+                "start": {
+                    "$comment": "this is the landing spot from $ref",
+                    "$id": "start",
+                    "$dynamicRef": "inner_scope#thingy"
+                },
+                "thingy": {
+                    "$comment": "this is the first stop for the $dynamicRef",
+                    "$id": "inner_scope",
+                    "$dynamicAnchor": "thingy",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "string matches /$defs/thingy, but the $dynamicRef does not stop here",
+                "data": "a string",
+                "valid": false
+            },
+            {
+                "description": "first_scope is not in dynamic scope for the $dynamicRef",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "/then/$defs/thingy is the final stop for the $dynamicRef",
+                "data": null,
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -78,7 +78,7 @@
         ]
     },
     {
-        "description": "A $dynamicRef should resolve to the first $dynamicAnchor that is encountered when the schema is evaluated",
+        "description": "A $dynamicRef should resolve to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
         "schema": {
             "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
             "$ref": "list",
@@ -382,6 +382,63 @@
                 "description": "recurse to integerNode - floats are not allowed",
                 "data": { "november": 1.1 },
                 "valid": false
+            }
+        ]
+    },
+    {
+        "description": "after leaving a dynamic scope, it should not be used by a $dynamicRef",
+        "schema": {
+            "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
+            "if": {
+                "$id": "first_scope",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is first_scope#thingy",
+                        "$dynamicAnchor": "thingy",
+                        "type": "number"
+                    }
+                }
+            },
+            "then": {
+                "$id": "second_scope",
+                "$ref": "start",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is second_scope#thingy, the final destination of the $dynamicRef",
+                        "$dynamicAnchor": "thingy",
+                        "type": "null"
+                    }
+                }
+            },
+            "$defs": {
+                "start": {
+                    "$comment": "this is the landing spot from $ref",
+                    "$id": "start",
+                    "$dynamicRef": "inner_scope#thingy"
+                },
+                "thingy": {
+                    "$comment": "this is the first stop for the $dynamicRef",
+                    "$id": "inner_scope",
+                    "$dynamicAnchor": "thingy",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "string matches /$defs/thingy, but the $dynamicRef does not stop here",
+                "data": "a string",
+                "valid": false
+            },
+            {
+                "description": "first_scope is not in dynamic scope for the $dynamicRef",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "/then/$defs/thingy is the final stop for the $dynamicRef",
+                "data": null,
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
This is a fun test case; I added comments to make it more clear what is going on.  One can *leave* a dynamic scope just as much as one can enter it (by going down into a schema and then coming back out of it), so it's important to keep an accurate accounting of the current dynamic scopes rather than always just appending to the list.

I had code that worked with all the existing test cases but (because of the particular way I implemented subschema recursion) the dynamic scope list was persistent even after de-recursing from a subschema, and these new test cases failed until I made that correction. I wonder if anyone else's implementation has the same issue! :)