### PR TITLE
Test that UUIDs have dashes in the right spots.

### DIFF
--- a/tests/draft-future/optional/format/uuid.json
+++ b/tests/draft-future/optional/format/uuid.json
@@ -46,6 +46,21 @@
                 "valid": false
             },
             {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -46,6 +46,21 @@
                 "valid": false
             },
             {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -46,6 +46,21 @@
                 "valid": false
             },
             {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true


### PR DESCRIPTION
> uuid:
>    A string instance is valid against this attribute if it is a valid string representation of a UUID, according to [RFC4122]. 

([here](https://json-schema.org/draft/2020-12/json-schema-validation.html))

which says:

> The formal definition of the UUID string representation is
>       provided by the following ABNF [7]:
> 
>       UUID                   = time-low "-" time-mid "-"
>                                time-high-and-version "-"
>                                clock-seq-and-reserved
>                                clock-seq-low "-" node

(CC @nezhar)