### PR TITLE
Added two `not` non-apperant tests 

### DIFF
--- a/tests/draft2019-09/not.json
+++ b/tests/draft2019-09/not.json
@@ -69,7 +69,7 @@
                 "valid": false
             },
             {
-                "description": "mismatch object with different prop",
+                "description": "mismatch object with different property",
                 "data": { "bar": "foo"},
                 "valid": false
             },

--- a/tests/draft2019-09/not.json
+++ b/tests/draft2019-09/not.json
@@ -64,6 +64,16 @@
                 "valid": true
             },
             {
+                "description": "mismatch empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "mismatch object with different prop",
+                "data": { "bar": "foo"},
+                "valid": false
+            },
+            {
                 "description": "mismatch",
                 "data": {"foo": "bar"},
                 "valid": false

--- a/tests/draft2020-12/not.json
+++ b/tests/draft2020-12/not.json
@@ -69,7 +69,7 @@
                 "valid": false
             },
             {
-                "description": "mismatch object with different prop",
+                "description": "mismatch object with different property",
                 "data": { "bar": "foo"},
                 "valid": false
             },

--- a/tests/draft2020-12/not.json
+++ b/tests/draft2020-12/not.json
@@ -64,6 +64,16 @@
                 "valid": true
             },
             {
+                "description": "mismatch empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "mismatch object with different prop",
+                "data": { "bar": "foo"},
+                "valid": false
+            },
+            {
                 "description": "mismatch",
                 "data": {"foo": "bar"},
                 "valid": false

--- a/tests/draft4/not.json
+++ b/tests/draft4/not.json
@@ -69,7 +69,7 @@
                 "valid": false
             },
             {
-                "description": "mismatch object with different prop",
+                "description": "mismatch object with different property",
                 "data": { "bar": "foo"},
                 "valid": false
             },

--- a/tests/draft4/not.json
+++ b/tests/draft4/not.json
@@ -64,6 +64,16 @@
                 "valid": true
             },
             {
+                "description": "mismatch empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "mismatch object with different prop",
+                "data": { "bar": "foo"},
+                "valid": false
+            },
+            {
                 "description": "mismatch",
                 "data": {"foo": "bar"},
                 "valid": false

--- a/tests/draft6/not.json
+++ b/tests/draft6/not.json
@@ -69,7 +69,7 @@
                 "valid": false
             },
             {
-                "description": "mismatch object with different prop",
+                "description": "mismatch object with different property",
                 "data": { "bar": "foo"},
                 "valid": false
             },

--- a/tests/draft6/not.json
+++ b/tests/draft6/not.json
@@ -64,6 +64,16 @@
                 "valid": true
             },
             {
+                "description": "mismatch empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "mismatch object with different prop",
+                "data": { "bar": "foo"},
+                "valid": false
+            },
+            {
                 "description": "mismatch",
                 "data": {"foo": "bar"},
                 "valid": false

--- a/tests/draft7/not.json
+++ b/tests/draft7/not.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "mismatch object with different prop",
+                "description": "mismatch object with different property",
                 "data": { "bar": "foo"},
                 "valid": false
             },

--- a/tests/draft7/not.json
+++ b/tests/draft7/not.json
@@ -59,6 +59,16 @@
                 "valid": true
             },
             {
+                "description": "mismatch empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "mismatch object with different prop",
+                "data": { "bar": "foo"},
+                "valid": false
+            },
+            {
                 "description": "other match",
                 "data": {"foo": 1},
                 "valid": true


### PR DESCRIPTION
When perusing over the `not` test cases, I found two tests that was not clear how it should be handled. The two tests are added to the following schema:
```
{
    "not": {
        "type": "object",
        "properties": {
            "foo": {
                "type": "string"
            }
        }
     }
}
```

To include that empty objects are not allowed, as well as unknown properties.

```
{
    "description": "mismatch empty object",
    "data": {},
    "valid": false
},
{
    "description": "mismatch object with different prop",
    "data": { "bar": "foo"},
    "valid": false
},
```