### PR TITLE
Add test to check that $id resolved against nearest parent, not just immediate parent

### DIFF
--- a/tests/draft-future/ref.json
+++ b/tests/draft-future/ref.json
@@ -541,5 +541,41 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number should pass",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number should fail",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -539,5 +539,41 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number should pass",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number should fail",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -541,5 +541,41 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number should pass",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number should fail",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -467,5 +467,41 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "id": "http://example.com/a.json",
+            "definitions": {
+                "x": {
+                    "id": "http://example.com/b/c.json",
+                    "not": {
+                        "definitions": {
+                            "y": {
+                                "id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number should pass",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number should fail",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -608,5 +608,41 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$id": "http://example.com/a.json",
+            "definitions": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "definitions": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number should pass",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number should fail",
+                "data": "a",
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
I am author of jsonschema validation library. I noticed that the testsuite passes even if $ref resolves to the root schema.
there is no test that verifies that $ref should be resolved against current base uri.

if you accept this testcase, i will update this pull result to add similar test in remaining draft tests.