### PR TITLE
$ref wit id does not test what it is indented to do

### DIFF
--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -207,17 +207,17 @@
             "definitions": {
                 "foo": {
                     "id": "http://localhost:1234/sibling_id/foo.json",
-                    "minimum": 2
+                    "type": "string"
                 },
                 "base_foo": {
                     "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
                     "id": "foo.json",
-                    "minimum": 5
+                    "type": "number"
                 }
             },
             "allOf": [
                 {
-                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not ttp://localhost:1234/sibling_id/foo.json",
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
                     "id": "http://localhost:1234/sibling_id/",
                     "$ref": "foo.json"
                 }
@@ -226,7 +226,7 @@
         "tests": [
             {
                 "description": "$ref resolves to /definitions/foo, data validates",
-                "data": 10,
+                "data": "a",
                 "valid": true
             },
             {

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -182,17 +182,17 @@
             "definitions": {
                 "foo": {
                     "id": "http://localhost:1234/sibling_id/foo.json",
-                    "minimum": 2
+                    "type": "string"
                 },
                 "base_foo": {
                     "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
                     "id": "foo.json",
-                    "minimum": 5
+                    "type": "number"
                 }
             },
             "allOf": [
                 {
-                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not ttp://localhost:1234/sibling_id/foo.json",
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
                     "id": "http://localhost:1234/sibling_id/",
                     "$ref": "foo.json"
                 }
@@ -201,7 +201,7 @@
         "tests": [
             {
                 "description": "$ref resolves to /definitions/foo, data validates",
-                "data": 10,
+                "data": "a",
                 "valid": true
             },
             {

--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -182,17 +182,17 @@
             "definitions": {
                 "foo": {
                     "$id": "http://localhost:1234/sibling_id/foo.json",
-                    "minimum": 2
+                    "type": "string"
                 },
                 "base_foo": {
                     "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
                     "$id": "foo.json",
-                    "minimum": 5
+                    "type": "number"
                 }
             },
             "allOf": [
                 {
-                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not ttp://localhost:1234/sibling_id/foo.json",
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
                     "$id": "http://localhost:1234/sibling_id/",
                     "$ref": "foo.json"
                 }
@@ -201,7 +201,7 @@
         "tests": [
             {
                 "description": "$ref resolves to /definitions/foo, data validates",
-                "data": 10,
+                "data": "a",
                 "valid": true
             },
             {

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -182,17 +182,17 @@
             "definitions": {
                 "foo": {
                     "$id": "http://localhost:1234/sibling_id/foo.json",
-                    "minimum": 2
+                    "type": "string"
                 },
                 "base_foo": {
                     "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
                     "$id": "foo.json",
-                    "minimum": 5
+                    "type": "number"
                 }
             },
             "allOf": [
                 {
-                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not ttp://localhost:1234/sibling_id/foo.json",
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
                     "$id": "http://localhost:1234/sibling_id/",
                     "$ref": "foo.json"
                 }
@@ -201,7 +201,7 @@
         "tests": [
             {
                 "description": "$ref resolves to /definitions/foo, data validates",
-                "data": 10,
+                "data": "a",
                 "valid": true
             },
             {


### PR DESCRIPTION
whether the implementation resolves $ref to
/definitions/foo or /definitions/base_foo
current tests will always pass