### PR TITLE
Revert "by default, "format" only annotates, not validates"

### DIFF
--- a/tests/draft-future/format.json
+++ b/tests/draft-future/format.json
@@ -32,11 +32,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid email string is only an annotation by default",
-                "data": "2962",
-                "valid": true
             }
         ]
     },
@@ -72,11 +67,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-email string is only an annotation by default",
-                "data": "2962",
                 "valid": true
             }
         ]
@@ -114,11 +104,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid regex string is only an annotation by default",
-                "data": "^(abc]",
-                "valid": true
             }
         ]
     },
@@ -154,11 +139,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid ipv4 string is only an annotation by default",
-                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -196,11 +176,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid ipv6 string is only an annotation by default",
-                "data": "12345::",
-                "valid": true
             }
         ]
     },
@@ -236,11 +211,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-hostname string is only an annotation by default",
-                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -278,11 +248,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid hostname string is only an annotation by default",
-                "data": "-a-host-name-that-starts-with--",
-                "valid": true
             }
         ]
     },
@@ -318,11 +283,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid date string is only an annotation by default",
-                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -360,11 +320,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid date-time string is only an annotation by default",
-                "data": "1990-02-31T15:59:60.123-08:00",
-                "valid": true
             }
         ]
     },
@@ -400,11 +355,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid time string is only an annotation by default",
-                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -442,11 +392,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid json-pointer string is only an annotation by default",
-                "data": "/foo/bar~",
-                "valid": true
             }
         ]
     },
@@ -482,11 +427,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid relative-json-pointer string is only an annotation by default",
-                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -524,11 +464,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid iri string is only an annotation by default",
-                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-                "valid": true
             }
         ]
     },
@@ -564,11 +499,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid iri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -606,11 +536,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri string is only an annotation by default",
-                "data": "//foo.bar/?baz=qux#quux",
-                "valid": true
             }
         ]
     },
@@ -646,11 +571,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid uri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -688,11 +608,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri-template string is only an annotation by default",
-                "data": "http://example.com/dictionary/{term:1}/{term",
-                "valid": true
             }
         ]
     },
@@ -729,11 +644,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uuid string is only an annotation by default",
-                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
-                "valid": true
             }
         ]
     },
@@ -769,11 +679,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid duration string is only an annotation by default",
-                "data": "PT1D",
                 "valid": true
             }
         ]

--- a/tests/draft2019-09/format.json
+++ b/tests/draft2019-09/format.json
@@ -32,11 +32,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid email string is only an annotation by default",
-                "data": "2962",
-                "valid": true
             }
         ]
     },
@@ -72,11 +67,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-email string is only an annotation by default",
-                "data": "2962",
                 "valid": true
             }
         ]
@@ -114,11 +104,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid regex string is only an annotation by default",
-                "data": "^(abc]",
-                "valid": true
             }
         ]
     },
@@ -154,11 +139,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid ipv4 string is only an annotation by default",
-                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -196,11 +176,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid ipv6 string is only an annotation by default",
-                "data": "12345::",
-                "valid": true
             }
         ]
     },
@@ -236,11 +211,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-hostname string is only an annotation by default",
-                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -278,11 +248,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid hostname string is only an annotation by default",
-                "data": "-a-host-name-that-starts-with--",
-                "valid": true
             }
         ]
     },
@@ -318,11 +283,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid date string is only an annotation by default",
-                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -360,11 +320,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid date-time string is only an annotation by default",
-                "data": "1990-02-31T15:59:60.123-08:00",
-                "valid": true
             }
         ]
     },
@@ -400,11 +355,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid time string is only an annotation by default",
-                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -442,11 +392,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid json-pointer string is only an annotation by default",
-                "data": "/foo/bar~",
-                "valid": true
             }
         ]
     },
@@ -482,11 +427,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid relative-json-pointer string is only an annotation by default",
-                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -524,11 +464,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid iri string is only an annotation by default",
-                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-                "valid": true
             }
         ]
     },
@@ -564,11 +499,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid iri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -606,11 +536,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri string is only an annotation by default",
-                "data": "//foo.bar/?baz=qux#quux",
-                "valid": true
             }
         ]
     },
@@ -646,11 +571,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid uri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -688,11 +608,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri-template string is only an annotation by default",
-                "data": "http://example.com/dictionary/{term:1}/{term",
-                "valid": true
             }
         ]
     },
@@ -729,11 +644,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uuid string is only an annotation by default",
-                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
-                "valid": true
             }
         ]
     },
@@ -769,11 +679,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid duration string is only an annotation by default",
-                "data": "PT1D",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/format.json
+++ b/tests/draft2020-12/format.json
@@ -32,11 +32,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid email string is only an annotation by default",
-                "data": "2962",
-                "valid": true
             }
         ]
     },
@@ -72,11 +67,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-email string is only an annotation by default",
-                "data": "2962",
                 "valid": true
             }
         ]
@@ -114,11 +104,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid regex string is only an annotation by default",
-                "data": "^(abc]",
-                "valid": true
             }
         ]
     },
@@ -154,11 +139,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid ipv4 string is only an annotation by default",
-                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -196,11 +176,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid ipv6 string is only an annotation by default",
-                "data": "12345::",
-                "valid": true
             }
         ]
     },
@@ -236,11 +211,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid idn-hostname string is only an annotation by default",
-                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -278,11 +248,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid hostname string is only an annotation by default",
-                "data": "-a-host-name-that-starts-with--",
-                "valid": true
             }
         ]
     },
@@ -318,11 +283,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid date string is only an annotation by default",
-                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -360,11 +320,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid date-time string is only an annotation by default",
-                "data": "1990-02-31T15:59:60.123-08:00",
-                "valid": true
             }
         ]
     },
@@ -400,11 +355,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid time string is only an annotation by default",
-                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -442,11 +392,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid json-pointer string is only an annotation by default",
-                "data": "/foo/bar~",
-                "valid": true
             }
         ]
     },
@@ -482,11 +427,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid relative-json-pointer string is only an annotation by default",
-                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -524,11 +464,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid iri string is only an annotation by default",
-                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-                "valid": true
             }
         ]
     },
@@ -564,11 +499,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid iri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -606,11 +536,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri string is only an annotation by default",
-                "data": "//foo.bar/?baz=qux#quux",
-                "valid": true
             }
         ]
     },
@@ -646,11 +571,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid uri-reference string is only an annotation by default",
-                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -688,11 +608,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uri-template string is only an annotation by default",
-                "data": "http://example.com/dictionary/{term:1}/{term",
-                "valid": true
             }
         ]
     },
@@ -729,11 +644,6 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
-            },
-            {
-                "description": "invalid uuid string is only an annotation by default",
-                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
-                "valid": true
             }
         ]
     },
@@ -769,11 +679,6 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
-                "valid": true
-            },
-            {
-                "description": "invalid duration string is only an annotation by default",
-                "data": "PT1D",
                 "valid": true
             }
         ]


### PR DESCRIPTION
This reverts commit 043dc63692a8c9533772dd771cdb32742ca503d2
(and also removes the tests from draft-future, which were copied from
draft2020-12).

According to the spec, "$vocabulary": { "...format-assertion": false }
does not mean "do not assert formats", but rather "if you don't support
format-assertion, you can still load the schema. but if you do support it,
feel free to assert that behaviour if you wish".

ref. https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.2

As such, the data in the removed tests could result in either a true OR a
false result. If we wish to explicitly test "formats are only annotations, and
NOT assertions" behaviour, we will have to define a custom metaschema and
reference that with the $schema keyword, where the metaschema contains:

    "$vocabulary": {
        ...
        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
    }

and does NOT mention the format-assertion vocabulary whatsoever.

This would be a reasonable test of the $vocabulary keyword, too.