### PR TITLE
More ipv6 tests to increase coverage

### DIFF
--- a/tests/draft-future/optional/format/ipv6.json
+++ b/tests/draft-future/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -14,6 +14,16 @@
                 "valid": false
             },
             {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
                 "description": "an IPv6 address with too many components",
                 "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
                 "valid": false
@@ -52,6 +62,11 @@
                 "description": "missing leading octet with omitted octets later",
                 "data": ":2:3:4::8",
                 "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
             },
             {
                 "description": "two sets of double colons is invalid",


### PR DESCRIPTION
These increase coverage by one (different) condition in two of my implementations (one is a linear scan, the other is mixed regex-based).

`trailing 4 hex symbols is valid` is added just as something to compare against.