### PR TITLE
Normalize optional/format/date-time, improve leap seconds tests.

### DIFF
--- a/tests/draft-future/optional/format/date-time.json
+++ b/tests/draft-future/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft-future/optional/format/date-time.json
+++ b/tests/draft-future/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft-future/optional/format/date-time.json
+++ b/tests/draft-future/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -69,6 +69,16 @@
                 "valid": false
             },
             {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -64,7 +64,12 @@
                 "valid": true
             },
             {
-                "description": "a invalid day in date-time string",
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -54,13 +54,23 @@
                 "valid": true
             },
             {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
                 "description": "a invalid day in date-time string",
-                "data": "1990-02-31T15:59:60.123-08:00",
+                "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false
             },
             {
                 "description": "an invalid offset in date-time string",
-                "data": "1990-12-31T15:59:60-24:00",
+                "data": "1990-12-31T15:59:59-24:00",
                 "valid": false
             },
             {


### PR DESCRIPTION
1. First commit copies `an invalid closing Z after time-zone offset` testcase from draft6 to draft2019-09, draft2020-12,  draft7, draft4, draft-future where it was missing.
2. Second commit adds two separate valid tests for leap seconds (like in `optional/format/time`).
3. And also removes leap seconds from `a invalid day in date-time string` and `an invalid offset in date-time string` tests to ensure that they fail because of those reasons and not because of a leap second.

Note that while this uses a valid leap second date (`1998-12-31`, which is stated explicitly in [RFC 3339, Appendix D](https://datatracker.ietf.org/doc/html/rfc3339#appendix-D)) this doesn't test that the validator actually has a list of valid leap seconds and not just verifies the shape per RFC 3339. I.e. there is no test that should fail _because of_ invalid date/leap second combo, as leap seconds come from an external data source and might be introduced later. Even checking that they are in `****-12-31` or `****-06-31` is invalid, as that might be changed in the data source and is not a hard requirement.

Refs: 
* https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.3.1
* https://datatracker.ietf.org/doc/html/rfc3339
* https://datatracker.ietf.org/doc/html/rfc3339#appendix-D