### PR TITLE
test the format-assertion vocabulary with a custom metaschema

### DIFF
--- a/remotes/draft2020-12/format-assertion-false.json
+++ b/remotes/draft2020-12/format-assertion-false.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/2020-12/schema/meta/format-assertion" }
+    ]
+}

--- a/remotes/draft2020-12/format-assertion-true.json
+++ b/remotes/draft2020-12/format-assertion-true.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/2020-12/schema/meta/format-assertion" }
+    ]
+}

--- a/tests/draft-future/optional/format-assertion.json
+++ b/tests/draft-future/optional/format-assertion.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "schema that uses custom metaschema with format-assertion: false",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/false",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: false: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: false: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "schema that uses custom metaschema with format-assertion: true",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/true",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: true: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: true: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/draft2020-12/optional/format-assertion.json
+++ b/tests/draft2020-12/optional/format-assertion.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "schema that uses custom metaschema with format-assertion: false",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/false",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: false: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: false: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "schema that uses custom metaschema with format-assertion: true",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/true",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: true: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: true: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This is our very first test using a custom metaschema. Luckily, since format-assertion is not enabled in the default metaschema, we can enable it here and use it to test the effectiveness of the $schema and $vocabulary keywords.