### PR TITLE
Add and modify uniqueItems tests

### DIFF
--- a/tests/draft-next/uniqueItems.json
+++ b/tests/draft-next/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft-next/uniqueItems.json
+++ b/tests/draft-next/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft2020-12/uniqueItems.json
+++ b/tests/draft2020-12/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft2020-12/uniqueItems.json
+++ b/tests/draft2020-12/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft3/uniqueItems.json
+++ b/tests/draft3/uniqueItems.json
@@ -5,17 +5,27 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
                 "description": "numbers are unique if mathematically unequal",
                 "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
                 "valid": false
             },
             {
@@ -51,7 +61,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft3/uniqueItems.json
+++ b/tests/draft3/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -61,6 +66,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft4/uniqueItems.json
+++ b/tests/draft4/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft6/uniqueItems.json
+++ b/tests/draft6/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -5,11 +5,16 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2, 3],
+                "data": [1, 2],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
                 "data": [1, 2, 1],
                 "valid": false
             },
@@ -71,6 +76,11 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
                 "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },

--- a/tests/draft7/uniqueItems.json
+++ b/tests/draft7/uniqueItems.json
@@ -5,12 +5,12 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [1, 2, 3],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [1, 2, 1],
                 "valid": false
             },
             {
@@ -27,6 +27,16 @@
                 "description": "true is not equal to one",
                 "data": [1, true],
                 "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
             },
             {
                 "description": "unique array of objects is valid",
@@ -61,7 +71,7 @@
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [["foo"], ["bar"], ["foo"]],
                 "valid": false
             },
             {


### PR DESCRIPTION
Fixes #524

Improve `uniqueItems` tests to ensure validators verify all elements of arrays for uniqueness:
- Use more than two items in the test arrays.
- Set the first and last items as non-unique where applicable.
- Add tests for arrays of unique and non-unique strings.