### PR TITLE
Update format-assertion.json

### DIFF
--- a/tests/draft2020-12/optional/format-assertion.json
+++ b/tests/draft2020-12/optional/format-assertion.json
@@ -15,7 +15,7 @@
             {
                 "description": "format-assertion: false: invalid string",
                 "data": "not-an-ipv4",
-                "valid": false
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
when format-assertion=false, whatever the data, result must always be valid