### PR TITLE
Replace non-canonical URIs with canonical ones

### DIFF
--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -362,14 +362,14 @@
                 "title": "any type of node",
                 "$id": "anyLeafNode",
                 "$dynamicAnchor": "foo",
-                "$ref": "main#/$defs/inner"
+                "$ref": "inner"
             },
             "else": {
                 "title": "integer node",
                 "$id": "integerNode",
                 "$dynamicAnchor": "foo",
                 "type": [ "object", "integer" ],
-                "$ref": "main#/$defs/inner"
+                "$ref": "inner"
             }
         },
         "tests": [

--- a/tests/draft2019-09/recursiveRef.json
+++ b/tests/draft2019-09/recursiveRef.json
@@ -330,14 +330,14 @@
                 "title": "any type of node",
                 "$id": "recursiveRef8_anyLeafNode.json",
                 "$recursiveAnchor": true,
-                "$ref": "recursiveRef8_main.json#/$defs/inner"
+                "$ref": "recursiveRef8_inner.json"
             },
             "else": {
                 "title": "integer node",
                 "$id": "recursiveRef8_integerNode.json",
                 "$recursiveAnchor": true,
                 "type": [ "object", "integer" ],
-                "$ref": "recursiveRef8_main.json#/$defs/inner"
+                "$ref": "recursiveRef8_inner.json"
             }
         },
         "tests": [

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -362,14 +362,14 @@
                 "title": "any type of node",
                 "$id": "anyLeafNode",
                 "$dynamicAnchor": "foo",
-                "$ref": "main#/$defs/inner"
+                "$ref": "inner"
             },
             "else": {
                 "title": "integer node",
                 "$id": "integerNode",
                 "$dynamicAnchor": "foo",
                 "type": [ "object", "integer" ],
-                "$ref": "main#/$defs/inner"
+                "$ref": "inner"
             }
         },
         "tests": [


### PR DESCRIPTION
Spec says that implementations may choose not to support addressing schemas by non-canonical URIs (https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.9.2.1). So that tests placed in the main directory probably shouldn't use non-canonical URIs.

I found only one place where such URIs are used, so the fix is pretty simple.