### PR TITLE
added tests for unknown formats

### DIFF
--- a/tests/draft2019-09/optional/format/unknown.json
+++ b/tests/draft2019-09/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2020-12/optional/format/unknown.json
+++ b/tests/draft2020-12/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft4/optional/format/unknown.json
+++ b/tests/draft4/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft6/optional/format/unknown.json
+++ b/tests/draft6/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/format/unknown.json
+++ b/tests/draft7/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
I apparently [broke a thing](https://github.com/gregsdennis/json-everything/issues/203) in my implementation, and it turns out there aren't any tests for unknown formats.

The section moves around a bit between drafts, but the wording is consistent:

> A format attribute can generally only validate a given set of instance types. If the type of the instance to validate is not in this set, validation for this format attribute and instance SHOULD succeed.

I figured the `SHOULD` implies that this should be in the optional tests.