### PR TITLE
Update vocabulary tests for draft-next

### DIFF
--- a/remotes/draft-next/format-assertion-false.json
+++ b/remotes/draft-next/format-assertion-false.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}

--- a/remotes/draft-next/format-assertion-true.json
+++ b/remotes/draft-next/format-assertion-true.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}

--- a/remotes/draft-next/metaschema-no-validation.json
+++ b/remotes/draft-next/metaschema-no-validation.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/draft-next/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/next/meta/core" }
+    ]
+}

--- a/tests/draft-next/optional/format-assertion.json
+++ b/tests/draft-next/optional/format-assertion.json
@@ -3,7 +3,7 @@
         "description": "schema that uses custom metaschema with format-assertion: false",
         "schema": {
             "$id": "https://schema/using/format-assertion/false",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-false.json",
             "format": "ipv4"
         },
         "tests": [
@@ -23,7 +23,7 @@
         "description": "schema that uses custom metaschema with format-assertion: true",
         "schema": {
             "$id": "https://schema/using/format-assertion/true",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-true.json",
             "format": "ipv4"
         },
         "tests": [

--- a/tests/draft-next/vocabulary.json
+++ b/tests/draft-next/vocabulary.json
@@ -3,7 +3,7 @@
         "description": "schema that uses custom metaschema with with no validation vocabulary",
         "schema": {
             "$id": "https://schema/using/no/validation",
-            "$schema": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+            "$schema": "http://localhost:1234/draft-next/metaschema-no-validation.json",
             "properties": {
                 "badProperty": false,
                 "numberProperty": {


### PR DESCRIPTION
The vocabulary tests for draft-next were using the 2020-12 meta-schemas. This updates them to have their own schemas.