### PR TITLE
Add tests for 'unevaluatedX' on invalid types

### DIFF
--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -601,24 +601,24 @@
         },
         "tests": [
             {
-                "description": "null is invalid",
+                "description": "null is not applicable",
                 "data": null,
-                "valid": false
+                "valid": true
             },
             {
-                "description": "number is invalid",
+                "description": "number is not applicable",
                 "data": 42,
-                "valid": false
+                "valid": true
             },
             {
-                "description": "string is invalid",
+                "description": "string is not applicable",
                 "data": "foo",
-                "valid": false
+                "valid": true
             },
             {
-                "description": "object is invalid",
+                "description": "object is not applicable",
                 "data": {},
-                "valid": false
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -593,5 +593,33 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems on non-applicable type",
+        "schema": {
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "number is invalid",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1315,24 +1315,24 @@
         },
         "tests": [
             {
-                "description": "null is invalid",
+                "description": "null is not applicable",
                 "data": null,
-                "valid": false
+                "valid": true
             },
             {
-                "description": "number is invalid",
+                "description": "number is not applicable",
                 "data": 42,
-                "valid": false
+                "valid": true
             },
             {
-                "description": "string is invalid",
+                "description": "string is not applicable",
                 "data": "foo",
-                "valid": false
+                "valid": true
             },
             {
-                "description": "array is invalid",
+                "description": "array is not applicable",
                 "data": [],
-                "valid": false
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1307,5 +1307,33 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties on non-applicable type",
+        "schema": {
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "number is invalid",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Add tests for `unevaluatedItems` and `unevaluatedProperties` on non-applicable types (eg scalars)