### PR TITLE
Require command in test-app invocation args

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -195,7 +195,10 @@ def main(arguments):
 parser = argparse.ArgumentParser(
     description="JSON Schema Test Suite utilities",
 )
-subparsers = parser.add_subparsers(help="utility commands", dest="command")
+subparsers = parser.add_subparsers(
+    help="utility commands", dest="command", metavar="COMMAND"
+)
+subparsers.required = True
 
 check = subparsers.add_parser("check", help="Sanity check the test suite.")
 


### PR DESCRIPTION
Require command to be specified in command-line arguments during invocation of test app `bin/jsonschema_suite`, instead of exiting silently and successfully.

Also set help meta-var to `COMMAND` for a cleaner help output.