### PR TITLE
Replace definitions with $defs for 2019 and later drafts

### DIFF
--- a/remotes/locationIndependentIdentifier.json
+++ b/remotes/locationIndependentIdentifier.json
@@ -1,5 +1,5 @@
 {
-    "definitions": {
+    "$defs": {
         "refToInteger": {
             "$ref": "#foo"
         },

--- a/tests/draft-next/refRemote.json
+++ b/tests/draft-next/refRemote.json
@@ -190,7 +190,7 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -190,7 +190,7 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -190,7 +190,7 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {


### PR DESCRIPTION
#454 brought a small bug for 2019 and later drafts.
The `definitions` keyword should be replaced with `$defs` for these versions.