### PR TITLE
Update the sanity checker to use a version which supports 2019+.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   release:
     types: [published]
   schedule:
-    # Daily at 6:42
+    # Daily at 6:42, arbitrarily as a time that's possibly non-busy
     - cron: '42 6 * * *'
 
 jobs:
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.x'
     - name: Install tox
       run: python -m pip install tox
     - name: Run the sanity checks

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -15,6 +15,17 @@ try:
     import jsonschema.validators
 except ImportError:
     jsonschema = None
+    VALIDATORS = {}
+else:
+    VALIDATORS = {
+        "draft3": jsonschema.validators.Draft3Validator,
+        "draft4": jsonschema.validators.Draft4Validator,
+        "draft6": jsonschema.validators.Draft6Validator,
+        "draft7": jsonschema.validators.Draft7Validator,
+        "draft2019-09": jsonschema.validators.Draft201909Validator,
+        "draft2020-12": jsonschema.validators.Draft202012Validator,
+        "latest": jsonschema.validators.Draft202012Validator,
+    }
 
 
 ROOT_DIR = os.path.abspath(
@@ -22,6 +33,7 @@ ROOT_DIR = os.path.abspath(
 )
 SUITE_ROOT_DIR = os.path.join(ROOT_DIR, "tests")
 REMOTES_DIR = os.path.join(ROOT_DIR, "remotes")
+
 
 with open(os.path.join(ROOT_DIR, "test-schema.json")) as schema:
     TESTSUITE_SCHEMA = json.load(schema)
@@ -114,13 +126,13 @@ class SanityTests(unittest.TestCase):
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
     def test_all_schemas_are_valid(self):
-        for schema in os.listdir(SUITE_ROOT_DIR):
-            schema_validator = jsonschema.validators.validators.get(schema)
-            if schema_validator is not None:
-                test_files = collect(os.path.join(SUITE_ROOT_DIR, schema))
+        for version in os.listdir(SUITE_ROOT_DIR):
+            Validator = VALIDATORS.get(version)
+            if Validator is not None:
+                test_files = collect(os.path.join(SUITE_ROOT_DIR, version))
                 for case in cases(test_files):
                     try:
-                        schema_validator.check_schema(case["schema"])
+                        Validator.check_schema(case["schema"])
                     except jsonschema.SchemaError as error:
                         self.fail("%s contains an invalid schema (%s)" %
                                   (case, error))

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ skipsdist = True
 
 [testenv:sanity]
 # used just for validating the structure of the test case files themselves
-deps = jsonschema==3.2.0
+deps = jsonschema==4.6.1
 commands = {envpython} bin/jsonschema_suite check


### PR DESCRIPTION
It was previously skipping validating newer drafts :/

Refs: #562

(Will have to add this to a checklist of things to do after a new release is out.)