### PR TITLE
Set up default reviewers (the whole test suite team).

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ping the entire test suite team by default.
+*       @json-schema-org/test-suite-team


### PR DESCRIPTION
Closes: #470

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners -- essentially this just makes GH auto-ping the normal group of folks who are interested, to see if one cares to review the PR.