### PR TITLE
Handling nulls in instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If you suspect one, please [file an issue](https://github.com/json-schema-org/JS
            {
                "description": "Invalid: null",
                "data": {
-                   "type": null
+                   "type": "null"
                },
                "valid": false
            }

--- a/tests/draft-next/additionalProperties.json
+++ b/tests/draft-next/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft-next/additionalProperties.json
+++ b/tests/draft-next/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft-next/items.json
+++ b/tests/draft-next/items.json
@@ -252,5 +252,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft-next/items.json
+++ b/tests/draft-next/items.json
@@ -257,7 +257,7 @@
         "description": "items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft-next/patternProperties.json
+++ b/tests/draft-next/patternProperties.json
@@ -152,5 +152,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft-next/prefixItems.json
+++ b/tests/draft-next/prefixItems.json
@@ -81,7 +81,7 @@
     {
         "description": "prefixItems should properly handle null data",
         "schema": {
-            "items": [
+            "prefixItems": [
                 {
                     "type": "null"
                 }

--- a/tests/draft-next/prefixItems.json
+++ b/tests/draft-next/prefixItems.json
@@ -77,5 +77,22 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "prefixItems should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                    "type": null
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft-next/prefixItems.json
+++ b/tests/draft-next/prefixItems.json
@@ -83,7 +83,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft-next/properties.json
+++ b/tests/draft-next/properties.json
@@ -163,5 +163,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -145,5 +145,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalItems should properly handle null data",
+        "schema": {
+            "additionalItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -150,7 +150,7 @@
         "description": "additionalItems should properly handle null data",
         "schema": {
             "additionalItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2019-09/additionalProperties.json
+++ b/tests/draft2019-09/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2019-09/additionalProperties.json
+++ b/tests/draft2019-09/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/contains.json
+++ b/tests/draft2019-09/contains.json
@@ -151,7 +151,7 @@
         "description": "contains should properly handle null data",
         "schema": {
             "contains": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2019-09/contains.json
+++ b/tests/draft2019-09/contains.json
@@ -146,5 +146,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains should properly handle null data",
+        "schema": {
+            "contains": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                "type": null
+                    "type": null
                 }
             ]
         },

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -248,11 +248,28 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
                 "type": null
             }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                "type": null
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -246,5 +246,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -251,7 +251,7 @@
         "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft2019-09/patternProperties.json
+++ b/tests/draft2019-09/patternProperties.json
@@ -152,5 +152,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/properties.json
+++ b/tests/draft2019-09/properties.json
@@ -163,5 +163,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -515,5 +515,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems should properly handle null data",
+        "schema": {
+            "unevaluatedItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -520,7 +520,7 @@
         "description": "unevaluatedItems should properly handle null data",
         "schema": {
             "unevaluatedItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -1348,7 +1348,7 @@
         "description": "unevaluatedProperties should properly handle null data",
         "schema": {
             "unevaluatedProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -1343,5 +1343,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties should properly handle null data",
+        "schema": {
+            "unevaluatedProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/additionalProperties.json
+++ b/tests/draft2020-12/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2020-12/additionalProperties.json
+++ b/tests/draft2020-12/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/contains.json
+++ b/tests/draft2020-12/contains.json
@@ -151,7 +151,7 @@
         "description": "contains should properly handle null data",
         "schema": {
             "contains": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2020-12/contains.json
+++ b/tests/draft2020-12/contains.json
@@ -146,5 +146,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains should properly handle null data",
+        "schema": {
+            "contains": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -252,5 +252,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -257,7 +257,7 @@
         "description": "items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2020-12/patternProperties.json
+++ b/tests/draft2020-12/patternProperties.json
@@ -152,5 +152,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/prefixItems.json
+++ b/tests/draft2020-12/prefixItems.json
@@ -81,7 +81,7 @@
     {
         "description": "prefixItems should properly handle null data",
         "schema": {
-            "items": [
+            "prefixItems": [
                 {
                     "type": "null"
                 }

--- a/tests/draft2020-12/prefixItems.json
+++ b/tests/draft2020-12/prefixItems.json
@@ -77,5 +77,22 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "prefixItems should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                    "type": null
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/prefixItems.json
+++ b/tests/draft2020-12/prefixItems.json
@@ -83,7 +83,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft2020-12/properties.json
+++ b/tests/draft2020-12/properties.json
@@ -163,5 +163,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -630,7 +630,7 @@
         "description": "unevaluatedItems should properly handle null data",
         "schema": {
             "unevaluatedItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -625,5 +625,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems should properly handle null data",
+        "schema": {
+            "unevaluatedItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1348,7 +1348,7 @@
         "description": "unevaluatedProperties should properly handle null data",
         "schema": {
             "unevaluatedProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1343,5 +1343,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties should properly handle null data",
+        "schema": {
+            "unevaluatedProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/additionalItems.json
+++ b/tests/draft3/additionalItems.json
@@ -114,7 +114,7 @@
         "description": "additionalItems should properly handle null data",
         "schema": {
             "additionalItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft3/additionalItems.json
+++ b/tests/draft3/additionalItems.json
@@ -109,5 +109,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "additionalItems should properly handle null data",
+        "schema": {
+            "additionalItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/additionalProperties.json
+++ b/tests/draft3/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft3/additionalProperties.json
+++ b/tests/draft3/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/items.json
+++ b/tests/draft3/items.json
@@ -42,5 +42,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/items.json
+++ b/tests/draft3/items.json
@@ -47,7 +47,7 @@
         "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [
@@ -63,7 +63,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft3/items.json
+++ b/tests/draft3/items.json
@@ -44,11 +44,28 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
                 "type": null
             }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                "type": null
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/draft3/items.json
+++ b/tests/draft3/items.json
@@ -63,7 +63,7 @@
         "schema": {
             "items": [
                 {
-                "type": null
+                    "type": null
                 }
             ]
         },

--- a/tests/draft3/patternProperties.json
+++ b/tests/draft3/patternProperties.json
@@ -111,5 +111,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft3/properties.json
+++ b/tests/draft3/properties.json
@@ -93,5 +93,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/additionalItems.json
+++ b/tests/draft4/additionalItems.json
@@ -145,5 +145,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalItems should properly handle null data",
+        "schema": {
+            "additionalItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/additionalItems.json
+++ b/tests/draft4/additionalItems.json
@@ -150,7 +150,7 @@
         "description": "additionalItems should properly handle null data",
         "schema": {
             "additionalItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft4/additionalProperties.json
+++ b/tests/draft4/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft4/additionalProperties.json
+++ b/tests/draft4/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -193,11 +193,28 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
                 "type": null
             }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                "type": null
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -191,5 +191,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -212,7 +212,7 @@
         "schema": {
             "items": [
                 {
-                "type": null
+                    "type": null
                 }
             ]
         },

--- a/tests/draft4/items.json
+++ b/tests/draft4/items.json
@@ -196,7 +196,7 @@
         "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [
@@ -212,7 +212,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft4/patternProperties.json
+++ b/tests/draft4/patternProperties.json
@@ -116,5 +116,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/properties.json
+++ b/tests/draft4/properties.json
@@ -132,5 +132,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/additionalItems.json
+++ b/tests/draft6/additionalItems.json
@@ -145,5 +145,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalItems should properly handle null data",
+        "schema": {
+            "additionalItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/additionalItems.json
+++ b/tests/draft6/additionalItems.json
@@ -150,7 +150,7 @@
         "description": "additionalItems should properly handle null data",
         "schema": {
             "additionalItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft6/additionalProperties.json
+++ b/tests/draft6/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft6/additionalProperties.json
+++ b/tests/draft6/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/contains.json
+++ b/tests/draft6/contains.json
@@ -125,5 +125,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains should properly handle null data",
+        "schema": {
+            "contains": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/contains.json
+++ b/tests/draft6/contains.json
@@ -130,7 +130,7 @@
         "description": "contains should properly handle null data",
         "schema": {
             "contains": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft6/items.json
+++ b/tests/draft6/items.json
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                "type": null
+                    "type": null
                 }
             ]
         },

--- a/tests/draft6/items.json
+++ b/tests/draft6/items.json
@@ -248,11 +248,28 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
                 "type": null
             }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                "type": null
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/draft6/items.json
+++ b/tests/draft6/items.json
@@ -246,5 +246,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/items.json
+++ b/tests/draft6/items.json
@@ -251,7 +251,7 @@
         "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft6/patternProperties.json
+++ b/tests/draft6/patternProperties.json
@@ -152,5 +152,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/properties.json
+++ b/tests/draft6/properties.json
@@ -163,5 +163,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/additionalItems.json
+++ b/tests/draft7/additionalItems.json
@@ -145,5 +145,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalItems should properly handle null data",
+        "schema": {
+            "additionalItems": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/additionalItems.json
+++ b/tests/draft7/additionalItems.json
@@ -150,7 +150,7 @@
         "description": "additionalItems should properly handle null data",
         "schema": {
             "additionalItems": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft7/additionalProperties.json
+++ b/tests/draft7/additionalProperties.json
@@ -134,7 +134,7 @@
         "description": "additionalProperties should properly handle null data",
         "schema": {
             "additionalProperties": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft7/additionalProperties.json
+++ b/tests/draft7/additionalProperties.json
@@ -129,5 +129,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "additionalProperties should properly handle null data",
+        "schema": {
+            "additionalProperties": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/contains.json
+++ b/tests/draft7/contains.json
@@ -151,7 +151,7 @@
         "description": "contains should properly handle null data",
         "schema": {
             "contains": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [

--- a/tests/draft7/contains.json
+++ b/tests/draft7/contains.json
@@ -146,5 +146,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "contains should properly handle null data",
+        "schema": {
+            "contains": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/items.json
+++ b/tests/draft7/items.json
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                "type": null
+                    "type": null
                 }
             ]
         },

--- a/tests/draft7/items.json
+++ b/tests/draft7/items.json
@@ -248,11 +248,28 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
                 "type": null
             }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items should properly handle null data",
+        "schema": {
+            "items": [
+                {
+                "type": null
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/draft7/items.json
+++ b/tests/draft7/items.json
@@ -246,5 +246,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "items should properly handle null data",
+        "schema": {
+            "items": {
+                "type": null
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/items.json
+++ b/tests/draft7/items.json
@@ -251,7 +251,7 @@
         "description": "single-form items should properly handle null data",
         "schema": {
             "items": {
-                "type": null
+                "type": "null"
             }
         },
         "tests": [
@@ -267,7 +267,7 @@
         "schema": {
             "items": [
                 {
-                    "type": null
+                    "type": "null"
                 }
             ]
         },

--- a/tests/draft7/patternProperties.json
+++ b/tests/draft7/patternProperties.json
@@ -152,5 +152,20 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties should properly handle null data",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/properties.json
+++ b/tests/draft7/properties.json
@@ -163,5 +163,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "properties should properly handle null data",
+        "schema": {
+            "properties": {
+                "foo$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "null properties allowed",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
These tests address a scenario described in [Slack](https://json-schema.slack.com/archives/C8CQ81GKF/p1657055292641779).

Essentially, .Net doesn't separate the ideas of JSON null (pertaining to data) and object reference null (pertaining to programming).  Instead they represent JSON null as object-reference null, and it's caused some problems in my implementation.

These test cases would have caught these issues.

As I suspect it's possible that other languages such as C/C++ or Java may also have similar JSON data model issues, I figured adding these scenarios to the test suite could help.