### PR TITLE
Re-add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "json-schema-test-suite",
+  "version": "0.1.0",
+  "description": "A language agnostic test suite for the JSON Schema specifications",
+  "repository": "github:json-schema-org/JSON-Schema-Test-Suite",
+  "keywords": [
+    "json-schema",
+    "tests"
+  ],
+  "author": "http://json-schema.org",
+  "license": "MIT"
+}


### PR DESCRIPTION
The package.json file is necessary so I can include the test suite as an npm dependency in my implementation. It was recently removed and broke several of my packages.