### PR TITLE
pattern test also test if pattern keyword is missing

### DIFF
--- a/tests/draft2020-12/pattern.json
+++ b/tests/draft2020-12/pattern.json
@@ -55,5 +55,16 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "no pattern keyword",
+        "schema": { "type": "string" },
+        "tests": [
+            {
+                "description": "no pattern in schema is valid",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
I made a mistake in my check pattern function in my [jsonc-daccord](https://github.com/domoslabs/jsonc-daccord) (c implementation). The mistake was that the function didn't return valid if the "pattern" keyword was missing. The pattern test in pattern.json did not find this mistake, but when I started working on patternProperties, the patternProperties.json test would fail inside my check pattern when it was testing a string instance.

I have made this pull request to test the pattern function, that it shall return true if there is not "pattern" keyword.
