### PR TITLE
Strengthen the sanity checks, and fix some minor style or bugs uncovered

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -40,14 +40,14 @@ def files(paths):
     Each test file in the provided paths, as an array of test cases.
     """
     for path in paths:
-        yield json.loads(path.read_text())
+        yield path, json.loads(path.read_text())
 
 
 def cases(paths):
     """
     Each test case within each file in the provided paths.
     """
-    for test_file in files(paths):
+    for _, test_file in files(paths):
         yield from test_file
 
 
@@ -82,37 +82,51 @@ class SanityTests(unittest.TestCase):
         assert cls.remote_files, "Didn't find the remote files!"
         print(f"Found {len(cls.remote_files)} remote files")
 
+    def assertUnique(self, iterable):
+        """
+        Assert that the elements of an iterable are unique.
+        """
+
+        seen, duplicated = set(), set()
+        for each in iterable:
+            if each in seen:
+                duplicated.add(each)
+            seen.add(each)
+        self.assertFalse(duplicated, "Elements are not unique.")
+
     def test_all_test_files_are_valid_json(self):
         """
         All test files contain valid JSON.
         """
         for path in self.test_files:
-            try:
-                json.loads(path.read_text())
-            except ValueError as error:
-                self.fail(f"{path} contains invalid JSON ({error})")
+            with self.subTest(path=path):
+                try:
+                    json.loads(path.read_text())
+                except ValueError as error:
+                    self.fail(f"{path} contains invalid JSON ({error})")
 
     def test_all_remote_files_are_valid_json(self):
         """
         All remote files contain valid JSON.
         """
         for path in self.remote_files:
-            try:
-                json.loads(path.read_text())
-            except ValueError as error:
-                self.fail(f"{path} contains invalid JSON ({error})")
+            with self.subTest(path=path):
+                try:
+                    json.loads(path.read_text())
+                except ValueError as error:
+                    self.fail(f"{path} contains invalid JSON ({error})")
 
     def test_all_descriptions_have_reasonable_length(self):
         """
         All tests have reasonably long descriptions.
         """
         for count, test in enumerate(tests(self.test_files)):
-            description = test["description"]
-            self.assertLess(
-                len(description),
-                70,
-                f"{description!r} is too long! (keep it to less than 70 chars)"
-            )
+            with self.subTest(description=test["description"]):
+                self.assertLess(
+                    len(test["description"]),
+                    70,
+                    "Description is too long (keep it to less than 70 chars)."
+                )
         print(f"Found {count} tests.")
 
     def test_all_descriptions_are_unique(self):
@@ -120,12 +134,10 @@ class SanityTests(unittest.TestCase):
         All test cases have unique test descriptions in their tests.
         """
         for count, case in enumerate(cases(self.test_files)):
-            descriptions = set(test["description"] for test in case["tests"])
-            self.assertEqual(
-                len(descriptions),
-                len(case["tests"]),
-                f"{case!r} contains a duplicate description",
-            )
+            with self.subTest(description=case["description"]):
+                self.assertUnique(
+                    test["description"] for test in case["tests"]
+                )
         print(f"Found {count} test cases.")
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
@@ -141,12 +153,14 @@ class SanityTests(unittest.TestCase):
             if Validator is not None:
                 test_files = collect(version)
                 for case in cases(test_files):
-                    try:
-                        Validator.check_schema(case["schema"])
-                    except jsonschema.SchemaError as error:
-                        self.fail(
-                            f"{case} contains an invalid schema ({error})",
-                        )
+                    with self.subTest(case=case):
+                        try:
+                            Validator.check_schema(case["schema"])
+                        except jsonschema.SchemaError:
+                            self.fail(
+                                "Found an invalid schema."
+                                "See the traceback for details on why."
+                            )
             else:
                 warnings.warn(f"No schema validator for {version.name}")
 
@@ -157,11 +171,12 @@ class SanityTests(unittest.TestCase):
         """
         Validator = jsonschema.validators.validator_for(TESTSUITE_SCHEMA)
         validator = Validator(TESTSUITE_SCHEMA)
-        for tests in files(self.test_files):
-            try:
-                validator.validate(tests)
-            except jsonschema.ValidationError as error:
-                self.fail(str(error))
+        for path, cases in files(self.test_files):
+            with self.subTest(path=path):
+                try:
+                    validator.validate(cases)
+                except jsonschema.ValidationError as error:
+                    self.fail(str(error))
 
 
 def main(arguments):

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -141,7 +141,15 @@ class SanityTests(unittest.TestCase):
                 )
         print(f"Found {count} tests.")
 
-    def test_all_descriptions_are_unique(self):
+    def test_all_case_descriptions_are_unique(self):
+        """
+        All cases have unique descriptions in their files.
+        """
+        for path, cases in files(self.test_files):
+            with self.subTest(path=path):
+                self.assertUnique(case["description"] for case in cases)
+
+    def test_all_test_descriptions_are_unique(self):
         """
         All test cases have unique test descriptions in their tests.
         """

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -116,7 +116,19 @@ class SanityTests(unittest.TestCase):
                 except ValueError as error:
                     self.fail(f"{path} contains invalid JSON ({error})")
 
-    def test_all_descriptions_have_reasonable_length(self):
+    def test_all_case_descriptions_have_reasonable_length(self):
+        """
+        All cases have reasonably long descriptions.
+        """
+        for case in cases(self.test_files):
+            with self.subTest(description=case["description"]):
+                self.assertLess(
+                    len(case["description"]),
+                    150,
+                    "Description is too long (keep it to less than 150 chars)."
+                )
+
+    def test_all_test_descriptions_have_reasonable_length(self):
         """
         All tests have reasonably long descriptions.
         """

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -160,6 +160,32 @@ class SanityTests(unittest.TestCase):
                 )
         print(f"Found {count} test cases.")
 
+    def test_descriptions_do_not_use_modal_verbs(self):
+        """
+        Instead of saying "test that X frobs" or "X should frob" use "X frobs".
+
+        See e.g. https://jml.io/pages/test-docstrings.html
+
+        This test isn't comprehensive (it doesn't catch all the extra
+        verbiage there), but it's just to catch whatever it manages to
+        cover.
+        """
+
+        message = (
+            "In descriptions, don't say 'Test that X frobs' or 'X should "
+            "frob' or 'X should be valid'. Just say 'X frobs' or 'X is "
+            "valid'. It's shorter, and the test suite is entirely about "
+            "what *should* be already. "
+            "See https://jml.io/pages/test-docstrings.html for help."
+        )
+        for test in tests(self.test_files):
+            with self.subTest(description=test["description"]):
+                self.assertNotRegex(
+                    test["description"],
+                    r"\bshould\b",
+                    message,
+                )
+
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
     def test_all_schemas_are_valid(self):
         """

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -185,6 +185,11 @@ class SanityTests(unittest.TestCase):
                     r"\bshould\b",
                     message,
                 )
+                self.assertNotRegex(
+                    test["description"],
+                    r"(?i)\btest(s)? that\b",
+                    message,
+                )
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
     def test_all_schemas_are_valid(self):

--- a/tests/draft-next/anchor.json
+++ b/tests/draft-next/anchor.json
@@ -159,12 +159,12 @@
         },
         "tests": [
             {
-                "description": "$ref should resolve to /$defs/A/allOf/1",
+                "description": "$ref resolves to /$defs/A/allOf/1",
                 "data": "a",
                 "valid": true
             },
             {
-                "description": "$ref should not resolve to /$defs/A/allOf/0",
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
                 "data": 1,
                 "valid": false
             }

--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -374,7 +374,7 @@
         ]
     },
     {
-        "description": "Tests for implementation dynamic anchor and reference link. Reference should be independent of any possible ordering.",
+        "description": "$ref and $dynamicAnchor are independent of order - $defs first",
         "schema": {
             "$id": "http://localhost:1234/strict-extendible-allof-defs-first.json",
             "allOf": [
@@ -424,7 +424,7 @@
         ]
     },
     {
-        "description": "Tests for implementation dynamic anchor and reference link. Reference should be independent of any possible ordering.",
+        "description": "$ref and $dynamicAnchor are independent of order - $ref first",
         "schema": {
             "$id": "http://localhost:1234/strict-extendible-allof-ref-first.json",
             "allOf": [

--- a/tests/draft-next/items.json
+++ b/tests/draft-next/items.json
@@ -214,7 +214,7 @@
         ]
     },
     {
-        "description": "items should not look in applicators, valid case",
+        "description": "items does not look in applicators, valid case",
         "schema": {
             "allOf": [
                 { "prefixItems": [ { "minimum": 3 } ] }
@@ -223,12 +223,12 @@
         },
         "tests": [
             {
-                "description": "prefixItems in allOf should not constrain items, invalid case",
+                "description": "prefixItems in allOf does not constrain items, invalid case",
                 "data": [ 3, 5 ],
                 "valid": false
             },
             {
-                "description": "prefixItems in allOf should not constrain items, valid case",
+                "description": "prefixItems in allOf does not constrain items, valid case",
                 "data": [ 5, 5 ],
                 "valid": true
             }
@@ -254,7 +254,7 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "items with null",
         "schema": {
             "items": {
                 "type": "null"
@@ -262,7 +262,7 @@
         },
         "tests": [
             {
-                "description": "null items allowed",
+                "description": "allows null elements",
                 "data": [ null ],
                 "valid": true
             }

--- a/tests/draft-next/optional/bignum.json
+++ b/tests/draft-next/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft-next/optional/ecmascript-regex.json
+++ b/tests/draft-next/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -395,7 +395,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -480,7 +480,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -534,7 +534,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft-next/optional/ecmascript-regex.json
+++ b/tests/draft-next/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft-next/optional/format/date-time.json
+++ b/tests/draft-next/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft-next/optional/format/date.json
+++ b/tests/draft-next/optional/format/date.json
@@ -214,7 +214,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
             }

--- a/tests/draft-next/optional/format/duration.json
+++ b/tests/draft-next/optional/format/duration.json
@@ -119,7 +119,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
             }

--- a/tests/draft-next/optional/format/ipv4.json
+++ b/tests/draft-next/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft-next/optional/format/ipv6.json
+++ b/tests/draft-next/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft-next/optional/format/time.json
+++ b/tests/draft-next/optional/format/time.json
@@ -189,7 +189,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
             }

--- a/tests/draft-next/prefixItems.json
+++ b/tests/draft-next/prefixItems.json
@@ -79,7 +79,7 @@
         ]
     },
     {
-        "description": "prefixItems should properly handle null data",
+        "description": "prefixItems properly handles null data",
         "schema": {
             "prefixItems": [
                 {

--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -670,7 +670,7 @@
         "description": "simple URN base URI with JSON pointer",
         "schema": {
             "$comment": "URIs do not have to have HTTP(s) schemes",
-            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "#/$defs/bar"}
             },
@@ -807,9 +807,9 @@
     {
         "description": "URN base URI with URN and anchor ref",
         "schema": {
-            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
             "properties": {
-                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#something"}
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
             },
             "$defs": {
                 "bar": {

--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -567,12 +567,12 @@
         },
         "tests": [
             {
-                "description": "number should pass",
+                "description": "number is valid",
                 "data": 1,
                 "valid": true
             },
             {
-                "description": "non-number should fail",
+                "description": "non-number is invalid",
                 "data": "a",
                 "valid": false
             }

--- a/tests/draft2019-09/anchor.json
+++ b/tests/draft2019-09/anchor.json
@@ -159,12 +159,12 @@
         },
         "tests": [
             {
-                "description": "$ref should resolve to /$defs/A/allOf/1",
+                "description": "$ref resolves to /$defs/A/allOf/1",
                 "data": "a",
                 "valid": true
             },
             {
-                "description": "$ref should not resolve to /$defs/A/allOf/0",
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
                 "data": 1,
                 "valid": false
             }

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -263,7 +263,7 @@
         ]
     },
     {
-        "description": "array-form items should properly handle null data",
+        "description": "array-form items with null instance elements",
         "schema": {
             "items": [
                 {
@@ -273,7 +273,7 @@
         },
         "tests": [
             {
-                "description": "null items allowed",
+                "description": "allows null elements",
                 "data": [ null ],
                 "valid": true
             }

--- a/tests/draft2019-09/optional/bignum.json
+++ b/tests/draft2019-09/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -384,7 +384,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -469,7 +469,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -523,7 +523,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -214,7 +214,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -119,7 +119,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -189,7 +189,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
             }

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -567,12 +567,12 @@
         },
         "tests": [
             {
-                "description": "number should pass",
+                "description": "number is valid",
                 "data": 1,
                 "valid": true
             },
             {
-                "description": "non-number should fail",
+                "description": "non-number is invalid",
                 "data": "a",
                 "valid": false
             }

--- a/tests/draft2020-12/anchor.json
+++ b/tests/draft2020-12/anchor.json
@@ -159,12 +159,12 @@
         },
         "tests": [
             {
-                "description": "$ref should resolve to /$defs/A/allOf/1",
+                "description": "$ref resolves to /$defs/A/allOf/1",
                 "data": "a",
                 "valid": true
             },
             {
-                "description": "$ref should not resolve to /$defs/A/allOf/0",
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
                 "data": 1,
                 "valid": false
             }

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -517,7 +517,7 @@
         ]
     },
     {
-        "description": "Tests for implementation dynamic anchor and reference link. Reference should be independent of any possible ordering.",
+        "description": "$ref and $dynamicAnchor are independent of order - $defs first",
         "schema": {
             "$id": "http://localhost:1234/strict-extendible-allof-defs-first.json",
             "allOf": [
@@ -567,7 +567,7 @@
         ]
     },
     {
-        "description": "Tests for implementation dynamic anchor and reference link. Reference should be independent of any possible ordering.",
+        "description": "$ref and $dynamicAnchor are independent of order - $ref first",
         "schema": {
             "$id": "http://localhost:1234/strict-extendible-allof-ref-first.json",
             "allOf": [

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -214,7 +214,7 @@
         ]
     },
     {
-        "description": "items should not look in applicators, valid case",
+        "description": "items does not look in applicators, valid case",
         "schema": {
             "allOf": [
                 { "prefixItems": [ { "minimum": 3 } ] }
@@ -223,12 +223,12 @@
         },
         "tests": [
             {
-                "description": "prefixItems in allOf should not constrain items, invalid case",
+                "description": "prefixItems in allOf does not constrain items, invalid case",
                 "data": [ 3, 5 ],
                 "valid": false
             },
             {
-                "description": "prefixItems in allOf should not constrain items, valid case",
+                "description": "prefixItems in allOf does not constrain items, valid case",
                 "data": [ 5, 5 ],
                 "valid": true
             }
@@ -254,7 +254,7 @@
         ]
     },
     {
-        "description": "items should properly handle null data",
+        "description": "items with null instance elements",
         "schema": {
             "items": {
                 "type": "null"
@@ -262,7 +262,7 @@
         },
         "tests": [
             {
-                "description": "null items allowed",
+                "description": "allows null elements",
                 "data": [ null ],
                 "valid": true
             }

--- a/tests/draft2020-12/optional/bignum.json
+++ b/tests/draft2020-12/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -395,7 +395,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -480,7 +480,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -534,7 +534,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -214,7 +214,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -119,7 +119,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -189,7 +189,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
             }

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -567,12 +567,12 @@
         },
         "tests": [
             {
-                "description": "number should pass",
+                "description": "number is valid",
                 "data": 1,
                 "valid": true
             },
             {
-                "description": "non-number should fail",
+                "description": "non-number is invalid",
                 "data": "a",
                 "valid": false
             }

--- a/tests/draft3/optional/bignum.json
+++ b/tests/draft3/optional/bignum.json
@@ -1,30 +1,13 @@
 [
     {
         "description": "integer",
-        "schema": {"type": "integer"},
+        "schema": { "type": "integer" },
         "tests": [
             {
                 "description": "a bignum is an integer",
                 "data": 12345678910111213141516171819202122232425262728293031,
                 "valid": true
-            }
-        ]
-    },
-    {
-        "description": "number",
-        "schema": {"type": "number"},
-        "tests": [
-            {
-                "description": "a bignum is a number",
-                "data": 98249283749234923498293171823948729348710298301928331,
-                "valid": true
-            }
-        ]
-    },
-    {
-        "description": "integer",
-        "schema": {"type": "integer"},
-        "tests": [
+            },
             {
                 "description": "a negative bignum is an integer",
                 "data": -12345678910111213141516171819202122232425262728293031,
@@ -34,8 +17,13 @@
     },
     {
         "description": "number",
-        "schema": {"type": "number"},
+        "schema": { "type": "number" },
         "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
             {
                 "description": "a negative bignum is a number",
                 "data": -98249283749234923498293171823948729348710298301928331,
@@ -45,7 +33,7 @@
     },
     {
         "description": "string",
-        "schema": {"type": "string"},
+        "schema": { "type": "string" },
         "tests": [
             {
                 "description": "a bignum is not a string",
@@ -55,8 +43,8 @@
         ]
     },
     {
-        "description": "integer comparison",
-        "schema": {"maximum": 18446744073709551615},
+        "description": "maximum integer comparison",
+        "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
                 "description": "comparison works for high numbers",
@@ -80,8 +68,8 @@
         ]
     },
     {
-        "description": "integer comparison",
-        "schema": {"minimum": -18446744073709551615},
+        "description": "minimum integer comparison",
+        "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {
                 "description": "comparison works for very negative numbers",

--- a/tests/draft4/anyOf.json
+++ b/tests/draft4/anyOf.json
@@ -152,31 +152,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "nested anyOf, to check validation semantics",
-        "schema": {
-            "anyOf": [
-                {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            ]
-        },
-        "tests": [
-            {
-                "description": "null is valid",
-                "data": null,
-                "valid": true
-            },
-            {
-                "description": "anything non-null is invalid",
-                "data": 123,
-                "valid": false
-            }
-        ]
     }
 ]

--- a/tests/draft4/optional/bignum.json
+++ b/tests/draft4/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -68,7 +68,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -384,7 +384,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -469,7 +469,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -523,7 +523,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft4/optional/ecmascript-regex.json
+++ b/tests/draft4/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft4/ref.json
+++ b/tests/draft4/ref.json
@@ -493,12 +493,12 @@
         },
         "tests": [
             {
-                "description": "number should pass",
+                "description": "number is valid",
                 "data": 1,
                 "valid": true
             },
             {
-                "description": "non-number should fail",
+                "description": "non-number is invalid",
                 "data": "a",
                 "valid": false
             }

--- a/tests/draft6/anyOf.json
+++ b/tests/draft6/anyOf.json
@@ -185,31 +185,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "nested anyOf, to check validation semantics",
-        "schema": {
-            "anyOf": [
-                {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            ]
-        },
-        "tests": [
-            {
-                "description": "null is valid",
-                "data": null,
-                "valid": true
-            },
-            {
-                "description": "anything non-null is invalid",
-                "data": 123,
-                "valid": false
-            }
-        ]
     }
 ]

--- a/tests/draft6/optional/bignum.json
+++ b/tests/draft6/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -384,7 +384,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -469,7 +469,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -523,7 +523,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft6/optional/ecmascript-regex.json
+++ b/tests/draft6/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft7/anyOf.json
+++ b/tests/draft7/anyOf.json
@@ -185,31 +185,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "nested anyOf, to check validation semantics",
-        "schema": {
-            "anyOf": [
-                {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            ]
-        },
-        "tests": [
-            {
-                "description": "null is valid",
-                "data": null,
-                "valid": true
-            },
-            {
-                "description": "anything non-null is invalid",
-                "data": 123,
-                "valid": false
-            }
-        ]
     }
 ]

--- a/tests/draft7/optional/bignum.json
+++ b/tests/draft7/optional/bignum.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "maximum integer comparison",
         "schema": { "maximum": 18446744073709551615 },
         "tests": [
             {
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "description": "integer comparison",
+        "description": "minimum integer comparison",
         "schema": { "minimum": -18446744073709551615 },
         "tests": [
             {

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "pattern with ASCII ranges",
         "schema": { "pattern": "[a-z]cole" },
         "tests": [
             {
@@ -384,7 +384,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "pattern with non-ASCII digits",
         "schema": { "pattern": "^\\p{digit}+$" },
         "tests": [
             {
@@ -469,7 +469,7 @@
         ]
     },
     {
-        "description": "unicode characters do not match ascii ranges",
+        "description": "patternProperties with ASCII ranges",
         "schema": {
             "type": "object",
             "patternProperties": {
@@ -523,7 +523,7 @@
         ]
     },
     {
-        "description": "unicode digits are more than 0 through 9",
+        "description": "patternProperties with non-ASCII digits",
         "schema": {
             "type": "object",
             "patternProperties": {

--- a/tests/draft7/optional/ecmascript-regex.json
+++ b/tests/draft7/optional/ecmascript-regex.json
@@ -7,12 +7,12 @@
         },
         "tests": [
             {
-                "description": "matches in Python, but should not in jsonschema",
+                "description": "matches in Python, but not in ECMA 262",
                 "data": "abc\\n",
                 "valid": false
             },
             {
-                "description": "should match",
+                "description": "matches",
                 "data": "abc",
                 "valid": true
             }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the date portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
                 "data": "1963-06-1৪T00:00:00Z",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the time portion",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
                 "data": "1963-06-11T0৪:00:00Z",
                 "valid": false
             }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -214,7 +214,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
             }

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -64,7 +64,7 @@
                 "valid": false
             },
             {
-                "description": "leading zeroes should be rejected, as they are treated as octals",
+                "description": "invalid leading zeroes, as they are treated as octals",
                 "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
                 "data": "087.10.0.1",
                 "valid": false
@@ -75,7 +75,7 @@
                 "valid": true
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
             }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -194,12 +194,12 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1:2:3:4:5:6:7:৪",
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected in the ipv4 portion also",
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
             }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -189,7 +189,7 @@
                 "valid": false
             },
             {
-                "description": "non-ascii digits should be rejected",
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
             }

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -634,12 +634,12 @@
         },
         "tests": [
             {
-                "description": "number should pass",
+                "description": "number is valid",
                 "data": 1,
                 "valid": true
             },
             {
-                "description": "non-number should fail",
+                "description": "non-number is invalid",
                 "data": "a",
                 "valid": false
             }


### PR DESCRIPTION
This looks a bit noisy, especially due to fixing across multiple drafts, but it does a few simple things to make the sanity checks a bit better. Only one is newish (mentioned below), the rest are really things we've always really "wanted" but was apparently missing from the sanity check. Specifically the changes here:

* makes the sanity check use "subtests", which basically just means that when CI runs and a sanity test fails because one test in the suite is somehow invalid, the rest of the tests will still be sanity checked, and the PR author will see all the invalid tests not just the first one
* case descriptions are checked for uniqueness too, not just test descriptions (this I could have sworn was already here, but apparently it wasn't, so there were a small number of tests which had non-unique descriptions, including a minor "bug" where some tests were running twice because they were accidentally copy pasted)
* case descriptions are checked for length too, again same as test descriptions (the reasoning is similar for both, though given there are some long case descriptions, I left the length limit longer for now)
* Prevent the use of "test that" or "X should do Y" in test descriptions. This is "new" in the sense that I've only mentioned this in PR reviews once or twice, but it's a stylistic thing which I don't like in test cases (in any language, but here too). Some reasoning is in the commit if that seems controversial, but there were only a few of these in the suite, which were easily removed. Essentially these are "noisy" words which usually can be removed without changing the meaning of the description.

A bit more detail is in each commit message if you're even more curious, but hopefully it's clear that each description changed is at least as good as before.

Feel free to ignore reviewing the Python code if you (future reviewer) aren't comfortable reading it (or feel free to press through and review it).