### PR TITLE
Replace '$defs' with 'definitions' in draft 6,7

### DIFF
--- a/tests/draft6/ref.json
+++ b/tests/draft6/ref.json
@@ -763,7 +763,7 @@
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
             },
-            "$defs": {
+            "definitions": {
                 "bar": {
                     "$id": "#something",
                     "type": "string"

--- a/tests/draft7/ref.json
+++ b/tests/draft7/ref.json
@@ -799,7 +799,7 @@
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
             },
-            "$defs": {
+            "definitions": {
                 "bar": {
                     "$id": "#something",
                     "type": "string"


### PR DESCRIPTION
in draft 6 and 7, anchors are not looked up in `$defs`