### PR TITLE
Emit fully absolute URIs from `jsonschema_suite remotes`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,22 @@ If your implementation supports multiple versions, run the above procedure for e
 
 1. The suite, notably in its `refRemote.json` file in each draft, expects a number of remote references to be configured.
    These are JSON documents, identified by URI, which are used by the suite to test the behavior of the `$ref` keyword (and related keywords).
-   Depending on your implementation, you may configure how to "register" these either by retrieving them from the `remotes/` directory at the root of the repository, *or* you may execute `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined.
+   Depending on your implementation, you may configure how to "register" these either by retrieving them from the `remotes/` directory at the root of the repository, *or* you may execute `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined, e.g.:
+
+    ```
+
+    $  bin/jsonschema_suite remotes
+    ```
+    ```json
+    {
+        "http://localhost:1234/baseUriChange/folderInteger.json": {
+            "type": "integer"
+        },
+        "http://localhost:1234/baseUriChangeFolder/folderInteger.json": {
+            "type": "integer"
+        }
+    }
+    ```
 
 2. Test cases found within [special subdirectories](#subdirectories-within-each-draft) may require additional configuration to run.
    In particular, tests within the `optional/format` subdirectory may require implementations to change the way they treat the `"format"`keyword (particularly on older drafts which did not have a notion of vocabularies).

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ If your implementation supports multiple versions, run the above procedure for e
 
 1. The suite, notably in its `refRemote.json` file in each draft, expects a number of remote references to be configured.
    These are JSON documents, identified by URI, which are used by the suite to test the behavior of the `$ref` keyword (and related keywords).
-   Depending on your implementation, you may configure how to "register" these either by retrieving them from the `remotes/` directory at the root of the repository, *or* you may execute `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined, e.g.:
+   Depending on your implementation, you may configure how to "register" these *either*:
+
+    * by directly retrieving them off the filesystem from the `remotes/` directory, in which case you should resolve any `$ref` in the directory relative to a base URI of `http://localhost:1234` such that a `$ref` to `http://localhost:1234/foo/bar/baz.json` resolves to the file at `remotes/foo/bar/baz.json`
+
+    * or alternatively, by executing `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined, e.g.:
 
     ```
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If your implementation supports multiple versions, run the above procedure for e
    These are JSON documents, identified by URI, which are used by the suite to test the behavior of the `$ref` keyword (and related keywords).
    Depending on your implementation, you may configure how to "register" these *either*:
 
-    * by directly retrieving them off the filesystem from the `remotes/` directory, in which case you should resolve any `$ref` in the directory relative to a base URI of `http://localhost:1234` such that a `$ref` to `http://localhost:1234/foo/bar/baz.json` resolves to the file at `remotes/foo/bar/baz.json`
+    * by directly retrieving them off the filesystem from the `remotes/` directory, in which case you should load each schema with a retrieval URI of `http://localhost:1234` followed by the relative path from the remotes directory -- e.g. a `$ref` to `http://localhost:1234/foo/bar/baz.json` is expected to resolve to the contents of the file at `remotes/foo/bar/baz.json`
 
     * or alternatively, by executing `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined, e.g.:
 

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 from pathlib import Path
+from urllib.parse import urljoin
 import argparse
-import errno
 import json
 import os
 import random
@@ -30,7 +30,9 @@ else:
 
 ROOT_DIR = Path(__file__).parent.parent
 SUITE_ROOT_DIR = ROOT_DIR / "tests"
+
 REMOTES_DIR = ROOT_DIR / "remotes"
+REMOTES_BASE_URL = "http://localhost:1234/"
 
 TESTSUITE_SCHEMA = json.loads((ROOT_DIR / "test-schema.json").read_text())
 
@@ -66,6 +68,16 @@ def collect(root_dir):
     All of the test file paths within the given root directory, recursively.
     """
     return root_dir.glob("**/*.json")
+
+
+def url_for_path(path):
+    """
+    Return the assumed remote URL for a file in the remotes/ directory.
+
+    Tests in the refRemote.json file reference this URL, and assume the
+    corresponding contents are available at the URL.
+    """
+    return urljoin(REMOTES_BASE_URL, str(path.relative_to(REMOTES_DIR)))
 
 
 class SanityTests(unittest.TestCase):
@@ -243,10 +255,10 @@ def main(arguments):
 
         json.dump(selected_cases, sys.stdout, indent=4, sort_keys=True)
     elif arguments.command == "remotes":
-        remotes = {}
-        for path in collect(REMOTES_DIR):
-            relative_path = os.path.relpath(path, REMOTES_DIR)
-            remotes[relative_path] = json.loads(path.read_text())
+        remotes = {
+            url_for_path(path): json.loads(path.read_text())
+            for path in collect(REMOTES_DIR)
+        }
         json.dump(remotes, sys.stdout, indent=4, sort_keys=True)
     elif arguments.command == "dump_remotes":
         if arguments.update:


### PR DESCRIPTION
I.e. instead of

```
{
"foo.json": "..."
}
```

you get

```
{
"http://localhost:1234/foo.json": "..."
}
```
which are the URIs the `refRemote.json` files expect.

This was I believe just an oversight on my part (or I never noticed
it before) -- but there's no reason a user of this should need to
know the base URI is http://localhost:1234/, the whole point of the
command is to just give you the URIs + schemas to configure.

I don't know how many people use this command rather than reading
directly off the remotes/ directory, but I do, so it's at least 1
person.