### PR TITLE
Add $schema to 2019-09 and 2020-12, update README for draft configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The precise steps described do not need to be followed exactly, but the results 
 
 To test a specific version:
 
+* For 2019-09 and later published drafts, implementations that are able to detect the draft of each schema via `$schema` SHOULD be configured to do so
+* For draft-07 and earlier, draft-next, and implementations unable to detect via `$schema`, implementations MUST be configured to expect the draft matching the test directory name
 * Load any remote references [described below](additional-assumptions) and configure your implementation to retrieve them via their URIs
 * Walk the filesystem tree for that version's subdirectory and for each `.json` file found:
 

--- a/remotes/draft-next/baseUriChange/folderInteger.json
+++ b/remotes/draft-next/baseUriChange/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft-next/baseUriChange/folderInteger.json
+++ b/remotes/draft-next/baseUriChange/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "integer"
 }

--- a/remotes/draft-next/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft-next/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft-next/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft-next/baseUriChangeFolder/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "integer"
 }

--- a/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "integer"
 }

--- a/remotes/draft-next/extendible-dynamic-ref.json
+++ b/remotes/draft-next/extendible-dynamic-ref.json
@@ -1,0 +1,20 @@
+{
+    "description": "extendible array",
+    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/remotes/draft-next/extendible-dynamic-ref.json
+++ b/remotes/draft-next/extendible-dynamic-ref.json
@@ -1,6 +1,7 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "description": "extendible array",
-    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "$id": "http://localhost:1234/draft-next/extendible-dynamic-ref.json",
     "type": "object",
     "properties": {
         "elements": {

--- a/remotes/draft-next/integer.json
+++ b/remotes/draft-next/integer.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft-next/integer.json
+++ b/remotes/draft-next/integer.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "integer"
 }

--- a/remotes/draft-next/locationIndependentIdentifier.json
+++ b/remotes/draft-next/locationIndependentIdentifier.json
@@ -1,0 +1,11 @@
+{
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft-next/locationIndependentIdentifier.json
+++ b/remotes/draft-next/locationIndependentIdentifier.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "$defs": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft-next/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft-next/locationIndependentIdentifierDraft4.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft-next/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft-next/locationIndependentIdentifierDraft4.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft-next/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft-next/locationIndependentIdentifierPre2019.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft-next/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft-next/locationIndependentIdentifierPre2019.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft-next/metaschema-no-validation.json
+++ b/remotes/draft-next/metaschema-no-validation.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "$id": "http://localhost:1234/draft-next/metaschema-no-validation.json",
     "$vocabulary": {
         "https://json-schema.org/draft/next/vocab/applicator": true,

--- a/remotes/draft-next/name-defs.json
+++ b/remotes/draft-next/name-defs.json
@@ -1,0 +1,15 @@
+{
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft-next/name-defs.json
+++ b/remotes/draft-next/name-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "$defs": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft-next/name.json
+++ b/remotes/draft-next/name.json
@@ -1,0 +1,15 @@
+{
+    "definitions": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft-next/name.json
+++ b/remotes/draft-next/name.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "definitions": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft-next/nested/foo-ref-string.json
+++ b/remotes/draft-next/nested/foo-ref-string.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/remotes/draft-next/nested/foo-ref-string.json
+++ b/remotes/draft-next/nested/foo-ref-string.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "object",
     "properties": {
         "foo": {"$ref": "string.json"}

--- a/remotes/draft-next/nested/string.json
+++ b/remotes/draft-next/nested/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/remotes/draft-next/nested/string.json
+++ b/remotes/draft-next/nested/string.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "type": "string"
 }

--- a/remotes/draft-next/ref-and-definitions.json
+++ b/remotes/draft-next/ref-and-definitions.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "definitions": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "allOf": [ { "$ref": "#/definitions/inner" } ]
+}

--- a/remotes/draft-next/ref-and-definitions.json
+++ b/remotes/draft-next/ref-and-definitions.json
@@ -1,5 +1,6 @@
 {
-    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$id": "http://localhost:1234/draft-next/ref-and-definitions.json",
     "definitions": {
         "inner": {
             "properties": {

--- a/remotes/draft-next/ref-and-defs.json
+++ b/remotes/draft-next/ref-and-defs.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/remotes/draft-next/ref-and-defs.json
+++ b/remotes/draft-next/ref-and-defs.json
@@ -1,5 +1,6 @@
 {
-    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$id": "http://localhost:1234/draft-next/ref-and-defs.json",
     "$defs": {
         "inner": {
             "properties": {

--- a/remotes/draft-next/subSchemas-defs.json
+++ b/remotes/draft-next/subSchemas-defs.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/remotes/draft-next/subSchemas-defs.json
+++ b/remotes/draft-next/subSchemas-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "$defs": {
         "integer": {
             "type": "integer"

--- a/remotes/draft-next/subSchemas.json
+++ b/remotes/draft-next/subSchemas.json
@@ -1,0 +1,8 @@
+{
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/remotes/draft-next/subSchemas.json
+++ b/remotes/draft-next/subSchemas.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "integer": {
         "type": "integer"
     },

--- a/remotes/draft-next/tree.json
+++ b/remotes/draft-next/tree.json
@@ -1,0 +1,16 @@
+{
+    "description": "tree schema, extensible",
+    "$id": "http://localhost:1234/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/remotes/draft-next/tree.json
+++ b/remotes/draft-next/tree.json
@@ -1,6 +1,7 @@
 {
+    "$schema": "https://json-schema.org/draft/next/schema",
     "description": "tree schema, extensible",
-    "$id": "http://localhost:1234/tree.json",
+    "$id": "http://localhost:1234/draft-next/tree.json",
     "$dynamicAnchor": "node",
 
     "type": "object",

--- a/remotes/draft2019-09/baseUriChange/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChange/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2019-09/baseUriChange/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChange/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "integer"
 }

--- a/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "integer"
 }

--- a/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "integer"
 }

--- a/remotes/draft2019-09/extendible-dynamic-ref.json
+++ b/remotes/draft2019-09/extendible-dynamic-ref.json
@@ -1,0 +1,20 @@
+{
+    "description": "extendible array",
+    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/remotes/draft2019-09/extendible-dynamic-ref.json
+++ b/remotes/draft2019-09/extendible-dynamic-ref.json
@@ -1,7 +1,7 @@
 {
     "description": "extendible array",
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "$id": "http://localhost:1234/draft2019-09/extendible-dynamic-ref.json",
     "type": "object",
     "properties": {
         "elements": {

--- a/remotes/draft2019-09/extendible-dynamic-ref.json
+++ b/remotes/draft2019-09/extendible-dynamic-ref.json
@@ -1,5 +1,6 @@
 {
     "description": "extendible array",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "http://localhost:1234/extendible-dynamic-ref.json",
     "type": "object",
     "properties": {

--- a/remotes/draft2019-09/integer.json
+++ b/remotes/draft2019-09/integer.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2019-09/integer.json
+++ b/remotes/draft2019-09/integer.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "integer"
 }

--- a/remotes/draft2019-09/locationIndependentIdentifier.json
+++ b/remotes/draft2019-09/locationIndependentIdentifier.json
@@ -1,0 +1,11 @@
+{
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2019-09/locationIndependentIdentifier.json
+++ b/remotes/draft2019-09/locationIndependentIdentifier.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$defs": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2019-09/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft2019-09/locationIndependentIdentifierDraft4.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2019-09/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft2019-09/locationIndependentIdentifierDraft4.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2019-09/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft2019-09/locationIndependentIdentifierPre2019.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2019-09/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft2019-09/locationIndependentIdentifierPre2019.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2019-09/metaschema-no-validation.json
+++ b/remotes/draft2019-09/metaschema-no-validation.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
     "$vocabulary": {
         "https://json-schema.org/draft/2019-09/vocab/applicator": true,

--- a/remotes/draft2019-09/name-defs.json
+++ b/remotes/draft2019-09/name-defs.json
@@ -1,0 +1,15 @@
+{
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft2019-09/name-defs.json
+++ b/remotes/draft2019-09/name-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$defs": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft2019-09/name.json
+++ b/remotes/draft2019-09/name.json
@@ -1,0 +1,15 @@
+{
+    "definitions": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft2019-09/name.json
+++ b/remotes/draft2019-09/name.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "definitions": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft2019-09/nested/foo-ref-string.json
+++ b/remotes/draft2019-09/nested/foo-ref-string.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/remotes/draft2019-09/nested/foo-ref-string.json
+++ b/remotes/draft2019-09/nested/foo-ref-string.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "object",
     "properties": {
         "foo": {"$ref": "string.json"}

--- a/remotes/draft2019-09/nested/string.json
+++ b/remotes/draft2019-09/nested/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/remotes/draft2019-09/nested/string.json
+++ b/remotes/draft2019-09/nested/string.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string"
 }

--- a/remotes/draft2019-09/ref-and-definitions.json
+++ b/remotes/draft2019-09/ref-and-definitions.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "definitions": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "allOf": [ { "$ref": "#/definitions/inner" } ]
+}

--- a/remotes/draft2019-09/ref-and-definitions.json
+++ b/remotes/draft2019-09/ref-and-definitions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "$id": "http://localhost:1234/draft2019-09/ref-and-definitions.json",
     "definitions": {
         "inner": {
             "properties": {

--- a/remotes/draft2019-09/ref-and-definitions.json
+++ b/remotes/draft2019-09/ref-and-definitions.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "http://localhost:1234/ref-and-definitions.json",
     "definitions": {
         "inner": {

--- a/remotes/draft2019-09/ref-and-defs.json
+++ b/remotes/draft2019-09/ref-and-defs.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/remotes/draft2019-09/ref-and-defs.json
+++ b/remotes/draft2019-09/ref-and-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "http://localhost:1234/ref-and-defs.json",
     "$defs": {
         "inner": {

--- a/remotes/draft2019-09/ref-and-defs.json
+++ b/remotes/draft2019-09/ref-and-defs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$id": "http://localhost:1234/draft2019-09/ref-and-defs.json",
     "$defs": {
         "inner": {
             "properties": {

--- a/remotes/draft2019-09/subSchemas-defs.json
+++ b/remotes/draft2019-09/subSchemas-defs.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/remotes/draft2019-09/subSchemas-defs.json
+++ b/remotes/draft2019-09/subSchemas-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$defs": {
         "integer": {
             "type": "integer"

--- a/remotes/draft2019-09/subSchemas.json
+++ b/remotes/draft2019-09/subSchemas.json
@@ -1,0 +1,8 @@
+{
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/remotes/draft2019-09/subSchemas.json
+++ b/remotes/draft2019-09/subSchemas.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "integer": {
         "type": "integer"
     },

--- a/remotes/draft2019-09/tree.json
+++ b/remotes/draft2019-09/tree.json
@@ -1,0 +1,16 @@
+{
+    "description": "tree schema, extensible",
+    "$id": "http://localhost:1234/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/remotes/draft2019-09/tree.json
+++ b/remotes/draft2019-09/tree.json
@@ -1,5 +1,6 @@
 {
     "description": "tree schema, extensible",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "http://localhost:1234/tree.json",
     "$dynamicAnchor": "node",
 

--- a/remotes/draft2019-09/tree.json
+++ b/remotes/draft2019-09/tree.json
@@ -1,7 +1,7 @@
 {
     "description": "tree schema, extensible",
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://localhost:1234/tree.json",
+    "$id": "http://localhost:1234/draft2019-09/tree.json",
     "$dynamicAnchor": "node",
 
     "type": "object",

--- a/remotes/draft2020-12/baseUriChange/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChange/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2020-12/baseUriChange/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChange/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "integer"
 }

--- a/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "integer"
 }

--- a/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "integer"
 }

--- a/remotes/draft2020-12/extendible-dynamic-ref.json
+++ b/remotes/draft2020-12/extendible-dynamic-ref.json
@@ -1,0 +1,20 @@
+{
+    "description": "extendible array",
+    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/remotes/draft2020-12/extendible-dynamic-ref.json
+++ b/remotes/draft2020-12/extendible-dynamic-ref.json
@@ -1,5 +1,6 @@
 {
     "description": "extendible array",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://localhost:1234/extendible-dynamic-ref.json",
     "type": "object",
     "properties": {

--- a/remotes/draft2020-12/extendible-dynamic-ref.json
+++ b/remotes/draft2020-12/extendible-dynamic-ref.json
@@ -1,7 +1,7 @@
 {
     "description": "extendible array",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "$id": "http://localhost:1234/draft2020-12/extendible-dynamic-ref.json",
     "type": "object",
     "properties": {
         "elements": {

--- a/remotes/draft2020-12/integer.json
+++ b/remotes/draft2020-12/integer.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/remotes/draft2020-12/integer.json
+++ b/remotes/draft2020-12/integer.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "integer"
 }

--- a/remotes/draft2020-12/locationIndependentIdentifier.json
+++ b/remotes/draft2020-12/locationIndependentIdentifier.json
@@ -1,0 +1,11 @@
+{
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2020-12/locationIndependentIdentifier.json
+++ b/remotes/draft2020-12/locationIndependentIdentifier.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2020-12/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft2020-12/locationIndependentIdentifierDraft4.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2020-12/locationIndependentIdentifierDraft4.json
+++ b/remotes/draft2020-12/locationIndependentIdentifierDraft4.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2020-12/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft2020-12/locationIndependentIdentifierPre2019.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/remotes/draft2020-12/locationIndependentIdentifierPre2019.json
+++ b/remotes/draft2020-12/locationIndependentIdentifierPre2019.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "definitions": {
         "refToInteger": {
             "$ref": "#foo"

--- a/remotes/draft2020-12/metaschema-no-validation.json
+++ b/remotes/draft2020-12/metaschema-no-validation.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
     "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,

--- a/remotes/draft2020-12/name-defs.json
+++ b/remotes/draft2020-12/name-defs.json
@@ -1,0 +1,15 @@
+{
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft2020-12/name-defs.json
+++ b/remotes/draft2020-12/name-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft2020-12/name.json
+++ b/remotes/draft2020-12/name.json
@@ -1,0 +1,15 @@
+{
+    "definitions": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/remotes/draft2020-12/name.json
+++ b/remotes/draft2020-12/name.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "definitions": {
         "orNull": {
             "anyOf": [

--- a/remotes/draft2020-12/nested/foo-ref-string.json
+++ b/remotes/draft2020-12/nested/foo-ref-string.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/remotes/draft2020-12/nested/foo-ref-string.json
+++ b/remotes/draft2020-12/nested/foo-ref-string.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "foo": {"$ref": "string.json"}

--- a/remotes/draft2020-12/nested/string.json
+++ b/remotes/draft2020-12/nested/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/remotes/draft2020-12/nested/string.json
+++ b/remotes/draft2020-12/nested/string.json
@@ -1,3 +1,4 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string"
 }

--- a/remotes/draft2020-12/ref-and-definitions.json
+++ b/remotes/draft2020-12/ref-and-definitions.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "definitions": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "allOf": [ { "$ref": "#/definitions/inner" } ]
+}

--- a/remotes/draft2020-12/ref-and-definitions.json
+++ b/remotes/draft2020-12/ref-and-definitions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "$id": "http://localhost:1234/draft2020-12/ref-and-definitions.json",
     "definitions": {
         "inner": {
             "properties": {

--- a/remotes/draft2020-12/ref-and-definitions.json
+++ b/remotes/draft2020-12/ref-and-definitions.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://localhost:1234/ref-and-definitions.json",
     "definitions": {
         "inner": {

--- a/remotes/draft2020-12/ref-and-defs.json
+++ b/remotes/draft2020-12/ref-and-defs.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/remotes/draft2020-12/ref-and-defs.json
+++ b/remotes/draft2020-12/ref-and-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://localhost:1234/ref-and-defs.json",
     "$defs": {
         "inner": {

--- a/remotes/draft2020-12/ref-and-defs.json
+++ b/remotes/draft2020-12/ref-and-defs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$id": "http://localhost:1234/draft2020-12/ref-and-defs.json",
     "$defs": {
         "inner": {
             "properties": {

--- a/remotes/draft2020-12/subSchemas-defs.json
+++ b/remotes/draft2020-12/subSchemas-defs.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/remotes/draft2020-12/subSchemas-defs.json
+++ b/remotes/draft2020-12/subSchemas-defs.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "integer": {
             "type": "integer"

--- a/remotes/draft2020-12/subSchemas.json
+++ b/remotes/draft2020-12/subSchemas.json
@@ -1,0 +1,8 @@
+{
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/remotes/draft2020-12/subSchemas.json
+++ b/remotes/draft2020-12/subSchemas.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "integer": {
         "type": "integer"
     },

--- a/remotes/draft2020-12/tree.json
+++ b/remotes/draft2020-12/tree.json
@@ -1,0 +1,16 @@
+{
+    "description": "tree schema, extensible",
+    "$id": "http://localhost:1234/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/remotes/draft2020-12/tree.json
+++ b/remotes/draft2020-12/tree.json
@@ -1,7 +1,7 @@
 {
     "description": "tree schema, extensible",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://localhost:1234/tree.json",
+    "$id": "http://localhost:1234/draft2020-12/tree.json",
     "$dynamicAnchor": "node",
 
     "type": "object",

--- a/remotes/draft2020-12/tree.json
+++ b/remotes/draft2020-12/tree.json
@@ -1,5 +1,6 @@
 {
     "description": "tree schema, extensible",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://localhost:1234/tree.json",
     "$dynamicAnchor": "node",
 

--- a/tests/draft-next/additionalProperties.json
+++ b/tests/draft-next/additionalProperties.json
@@ -3,6 +3,7 @@
         "description":
             "additionalProperties being false does not allow other properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {"foo": {}, "bar": {}},
             "patternProperties": { "^v": {} },
             "additionalProperties": false
@@ -43,6 +44,7 @@
     {
         "description": "non-ASCII pattern with additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {"^á": {}},
             "additionalProperties": false
         },
@@ -62,6 +64,7 @@
     {
         "description": "additionalProperties with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {"foo": {}, "bar": {}},
             "additionalProperties": {"type": "boolean"}
         },
@@ -87,6 +90,7 @@
         "description":
             "additionalProperties can exist by itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "additionalProperties": {"type": "boolean"}
         },
         "tests": [
@@ -104,7 +108,10 @@
     },
     {
         "description": "additionalProperties are allowed by default",
-        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
         "tests": [
             {
                 "description": "additional properties are allowed",
@@ -116,6 +123,7 @@
     {
         "description": "additionalProperties does not look in applicators",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {"properties": {"foo": {}}}
             ],
@@ -132,6 +140,7 @@
     {
         "description": "additionalProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "additionalProperties": {
                 "type": "null"
             }

--- a/tests/draft-next/allOf.json
+++ b/tests/draft-next/allOf.json
@@ -2,6 +2,7 @@
     {
         "description": "allOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "properties": {
@@ -43,6 +44,7 @@
     {
         "description": "allOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {"bar": {"type": "integer"}},
             "required": ["bar"],
             "allOf" : [
@@ -91,6 +93,7 @@
     {
         "description": "allOf simple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {"maximum": 30},
                 {"minimum": 20}
@@ -111,7 +114,10 @@
     },
     {
         "description": "allOf with boolean schemas, all true",
-        "schema": {"allOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -122,7 +128,10 @@
     },
     {
         "description": "allOf with boolean schemas, some false",
-        "schema": {"allOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -133,7 +142,10 @@
     },
     {
         "description": "allOf with boolean schemas, all false",
-        "schema": {"allOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -145,6 +157,7 @@
     {
         "description": "allOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {}
             ]
@@ -160,6 +173,7 @@
     {
         "description": "allOf with two empty schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {},
                 {}
@@ -176,6 +190,7 @@
     {
         "description": "allOf with the first empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {},
                 { "type": "number" }
@@ -197,6 +212,7 @@
     {
         "description": "allOf with the last empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 { "type": "number" },
                 {}
@@ -218,6 +234,7 @@
     {
         "description": "nested allOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "allOf": [
@@ -244,6 +261,7 @@
     {
         "description": "allOf combined with anyOf, oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [ { "multipleOf": 2 } ],
             "anyOf": [ { "multipleOf": 3 } ],
             "oneOf": [ { "multipleOf": 5 } ]

--- a/tests/draft-next/anchor.json
+++ b/tests/draft-next/anchor.json
@@ -2,6 +2,7 @@
     {
         "description": "Location-independent identifier",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "#foo",
             "$defs": {
                 "A": {
@@ -26,10 +27,11 @@
     {
         "description": "Location-independent identifier with absolute URI",
         "schema": {
-            "$ref": "http://localhost:1234/bar#foo",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/bar#foo",
             "$defs": {
                 "A": {
-                    "$id": "http://localhost:1234/bar",
+                    "$id": "http://localhost:1234/draft-next/bar",
                     "$anchor": "foo",
                     "type": "integer"
                 }
@@ -51,8 +53,9 @@
     {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
-            "$id": "http://localhost:1234/root",
-            "$ref": "http://localhost:1234/nested.json#foo",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/root",
+            "$ref": "http://localhost:1234/draft-next/nested.json#foo",
             "$defs": {
                 "A": {
                     "$id": "nested.json",
@@ -82,6 +85,7 @@
         "description": "$anchor inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $anchor buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "anchor_in_enum": {
                     "enum": [
@@ -138,7 +142,8 @@
     {
         "description": "same $anchor with different base uri",
         "schema": {
-            "$id": "http://localhost:1234/foobar",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/foobar",
             "$defs": {
                 "A": {
                     "$id": "child1",
@@ -173,6 +178,7 @@
     {
         "description": "non-schema object containing an $anchor property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "const_not_anchor": {
                     "const": {
@@ -203,7 +209,10 @@
     },
     {
         "description": "invalid anchors",
-        "schema": { "$ref": "https://json-schema.org/draft/next/schema" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
         "tests": [
             {
                 "description": "MUST start with a letter (and not #)",

--- a/tests/draft-next/anyOf.json
+++ b/tests/draft-next/anyOf.json
@@ -2,6 +2,7 @@
     {
         "description": "anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "anyOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "anyOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "anyOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all true",
-        "schema": {"anyOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "anyOf with boolean schemas, some true",
-        "schema": {"anyOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all false",
-        "schema": {"anyOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -101,6 +112,7 @@
     {
         "description": "anyOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "anyOf": [
                 {
                     "properties": {
@@ -142,6 +154,7 @@
     {
         "description": "anyOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "anyOf": [
                 { "type": "number" },
                 {}
@@ -163,6 +176,7 @@
     {
         "description": "nested anyOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "anyOf": [
                 {
                     "anyOf": [

--- a/tests/draft-next/const.json
+++ b/tests/draft-next/const.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "const validation",
-        "schema": {"const": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 2
+        },
         "tests": [
             {
                 "description": "same value is valid",
@@ -22,7 +25,10 @@
     },
     {
         "description": "const with object",
-        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
         "tests": [
             {
                 "description": "same object is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "const with array",
-        "schema": {"const": [{ "foo": "bar" }]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [{ "foo": "bar" }]
+        },
         "tests": [
             {
                 "description": "same array is valid",
@@ -69,7 +78,10 @@
     },
     {
         "description": "const with null",
-        "schema": {"const": null},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": null
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -85,7 +97,10 @@
     },
     {
         "description": "const with false does not match 0",
-        "schema": {"const": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": false
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -106,7 +121,10 @@
     },
     {
         "description": "const with true does not match 1",
-        "schema": {"const": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": true
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -127,7 +145,10 @@
     },
     {
         "description": "const with [false] does not match [0]",
-        "schema": {"const": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [false]
+        },
         "tests": [
             {
                 "description": "[false] is valid",
@@ -148,7 +169,10 @@
     },
     {
         "description": "const with [true] does not match [1]",
-        "schema": {"const": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [true]
+        },
         "tests": [
             {
                 "description": "[true] is valid",
@@ -169,7 +193,10 @@
     },
     {
         "description": "const with {\"a\": false} does not match {\"a\": 0}",
-        "schema": {"const": {"a": false}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"a": false}
+        },
         "tests": [
             {
                 "description": "{\"a\": false} is valid",
@@ -190,7 +217,10 @@
     },
     {
         "description": "const with {\"a\": true} does not match {\"a\": 1}",
-        "schema": {"const": {"a": true}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"a": true}
+        },
         "tests": [
             {
                 "description": "{\"a\": true} is valid",
@@ -211,7 +241,10 @@
     },
     {
         "description": "const with 0 does not match other zero-like types",
-        "schema": {"const": 0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 0
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -247,7 +280,10 @@
     },
     {
         "description": "const with 1 does not match true",
-        "schema": {"const": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 1
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -268,7 +304,10 @@
     },
     {
         "description": "const with -2.0 matches integer and float types",
-        "schema": {"const": -2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": -2.0
+        },
         "tests": [
             {
                 "description": "integer -2 is valid",
@@ -299,7 +338,10 @@
     },
     {
         "description": "float and integers are equal up to 64-bit representation limits",
-        "schema": {"const": 9007199254740992},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 9007199254740992
+        },
         "tests": [
             {
                 "description": "integer is valid",
@@ -325,7 +367,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "const": "hello\u0000there" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": "hello\u0000there"
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft-next/contains.json
+++ b/tests/draft-next/contains.json
@@ -2,6 +2,7 @@
     {
         "description": "contains keyword validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "minimum": 5 }
         },
         "tests": [
@@ -65,6 +66,7 @@
     {
         "description": "contains keyword with const keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 5 }
         },
         "tests": [
@@ -102,7 +104,10 @@
     },
     {
         "description": "contains keyword with boolean schema true",
-        "schema": { "contains": true },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": true
+        },
         "tests": [
             {
                 "description": "any non-empty array is valid",
@@ -128,7 +133,10 @@
     },
     {
         "description": "contains keyword with boolean schema false",
-        "schema": { "contains": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -160,6 +168,7 @@
     {
         "description": "items + contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "additionalProperties": { "multipleOf": 2 },
             "items": { "multipleOf": 2 },
             "contains": { "multipleOf": 3 }
@@ -210,6 +219,7 @@
     {
         "description": "contains with false if subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": {
                 "if": false,
                 "else": true
@@ -241,6 +251,7 @@
     {
         "description": "contains with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": {
                 "type": "null"
             }

--- a/tests/draft-next/content.json
+++ b/tests/draft-next/content.json
@@ -2,6 +2,7 @@
     {
         "description": "validation of string-encoded content based on media type",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contentMediaType": "application/json"
         },
         "tests": [
@@ -25,6 +26,7 @@
     {
         "description": "validation of binary string-encoding",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contentEncoding": "base64"
         },
         "tests": [
@@ -48,6 +50,7 @@
     {
         "description": "validation of binary-encoded media type documents",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64"
         },
@@ -77,6 +80,7 @@
     {
         "description": "validation of binary-encoded media type documents with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
             "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }

--- a/tests/draft-next/default.json
+++ b/tests/draft-next/default.json
@@ -2,6 +2,7 @@
     {
         "description": "invalid type for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {
                     "type": "integer",
@@ -25,6 +26,7 @@
     {
         "description": "invalid string value for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "bar": {
                     "type": "string",
@@ -49,6 +51,7 @@
     {
         "description": "the default keyword does not do anything if the property is missing",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "alpha": {

--- a/tests/draft-next/defs.json
+++ b/tests/draft-next/defs.json
@@ -2,6 +2,7 @@
     {
         "description": "validate definition against metaschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
         "tests": [

--- a/tests/draft-next/dependentRequired.json
+++ b/tests/draft-next/dependentRequired.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependentRequired": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependentRequired": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependentRequired": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependentRequired": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]

--- a/tests/draft-next/dependentSchemas.json
+++ b/tests/draft-next/dependentSchemas.json
@@ -2,6 +2,7 @@
     {
         "description": "single dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependentSchemas": {
                 "bar": {
                     "properties": {
@@ -57,6 +58,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependentSchemas": {
                 "foo": true,
                 "bar": false
@@ -88,6 +90,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependentSchemas": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -2,6 +2,7 @@
     {
         "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
             "type": "array",
             "items": { "$dynamicRef": "#items" },
@@ -28,6 +29,7 @@
     {
         "description": "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/ref-dynamicAnchor-same-schema/root",
             "type": "array",
             "items": { "$ref": "#items" },
@@ -54,6 +56,7 @@
     {
         "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
             "$ref": "list",
             "$defs": {
@@ -84,6 +87,7 @@
     {
         "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
             "$ref": "intermediate-scope",
             "$defs": {
@@ -118,6 +122,7 @@
     {
         "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
             "$ref": "list",
             "$defs": {
@@ -148,6 +153,7 @@
     {
         "description": "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/relative-dynamic-reference/root",
             "$dynamicAnchor": "meta",
             "type": "object",
@@ -199,6 +205,7 @@
     {
         "description": "multiple dynamic paths to the $dynamicRef keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
             "$defs": {
                 "inner": {
@@ -245,6 +252,7 @@
     {
         "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
             "if": {
                 "$id": "first_scope",
@@ -302,7 +310,8 @@
     {
         "description": "strict-tree schema, guards against misspelled properties",
         "schema": {
-            "$id": "http://localhost:1234/strict-tree.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-tree.json",
             "$dynamicAnchor": "node",
 
             "$ref": "tree.json",
@@ -332,7 +341,8 @@
     {
         "description": "tests for implementation dynamic anchor and reference link",
         "schema": {
-            "$id": "http://localhost:1234/strict-extendible.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible.json",
             "$ref": "extendible-dynamic-ref.json",
             "$defs": {
                 "elements": {
@@ -376,7 +386,8 @@
     {
         "description": "$ref and $dynamicAnchor are independent of order - $defs first",
         "schema": {
-            "$id": "http://localhost:1234/strict-extendible-allof-defs-first.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible-allof-defs-first.json",
             "allOf": [
                 {
                     "$ref": "extendible-dynamic-ref.json"
@@ -426,7 +437,8 @@
     {
         "description": "$ref and $dynamicAnchor are independent of order - $ref first",
         "schema": {
-            "$id": "http://localhost:1234/strict-extendible-allof-ref-first.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible-allof-ref-first.json",
             "allOf": [
                 {
                     "$defs": {

--- a/tests/draft-next/enum.json
+++ b/tests/draft-next/enum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "simple enum validation",
-        "schema": {"enum": [1, 2, 3]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [1, 2, 3]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "heterogeneous enum validation",
-        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "heterogeneous enum-with-null validation",
-        "schema": { "enum": [6, null] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [6, null]
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -70,6 +79,7 @@
     {
         "description": "enums in properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type":"object",
             "properties": {
                 "foo": {"enum":["foo"]},
@@ -113,6 +123,7 @@
     {
         "description": "enum with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "enum": ["foo\nbar", "foo\rbar"]
         },
         "tests": [
@@ -135,7 +146,10 @@
     },
     {
         "description": "enum with false does not match 0",
-        "schema": {"enum": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [false]
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -156,7 +170,10 @@
     },
     {
         "description": "enum with true does not match 1",
-        "schema": {"enum": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [true]
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -177,7 +194,10 @@
     },
     {
         "description": "enum with 0 does not match false",
-        "schema": {"enum": [0]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [0]
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -198,7 +218,10 @@
     },
     {
         "description": "enum with 1 does not match true",
-        "schema": {"enum": [1]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [1]
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -219,7 +242,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "enum": [ "hello\u0000there" ] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [ "hello\u0000there" ]
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft-next/exclusiveMaximum.json
+++ b/tests/draft-next/exclusiveMaximum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMaximum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "exclusiveMaximum": 3.0
         },
         "tests": [

--- a/tests/draft-next/exclusiveMinimum.json
+++ b/tests/draft-next/exclusiveMinimum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMinimum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "exclusiveMinimum": 1.1
         },
         "tests": [

--- a/tests/draft-next/format.json
+++ b/tests/draft-next/format.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "email format",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -37,7 +40,10 @@
     },
     {
         "description": "idn-email format",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -73,7 +79,10 @@
     },
     {
         "description": "regex format",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -109,7 +118,10 @@
     },
     {
         "description": "ipv4 format",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -145,7 +157,10 @@
     },
     {
         "description": "ipv6 format",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -181,7 +196,10 @@
     },
     {
         "description": "idn-hostname format",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -217,7 +235,10 @@
     },
     {
         "description": "hostname format",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -253,7 +274,10 @@
     },
     {
         "description": "date format",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -289,7 +313,10 @@
     },
     {
         "description": "date-time format",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -325,7 +352,10 @@
     },
     {
         "description": "time format",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -361,7 +391,10 @@
     },
     {
         "description": "json-pointer format",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -397,7 +430,10 @@
     },
     {
         "description": "relative-json-pointer format",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -433,7 +469,10 @@
     },
     {
         "description": "iri format",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -469,7 +508,10 @@
     },
     {
         "description": "iri-reference format",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -505,7 +547,10 @@
     },
     {
         "description": "uri format",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -541,7 +586,10 @@
     },
     {
         "description": "uri-reference format",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -577,7 +625,10 @@
     },
     {
         "description": "uri-template format",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -613,7 +664,10 @@
     },
     {
         "description": "uuid format",
-        "schema": { "format": "uuid" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uuid"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -649,7 +703,10 @@
     },
     {
         "description": "duration format",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/id.json
+++ b/tests/draft-next/id.json
@@ -2,6 +2,7 @@
     {
         "description": "Invalid use of fragments in location-independent $id",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
         "tests": [
@@ -43,10 +44,10 @@
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#foo",
+                    "$ref": "http://localhost:1234/draft-next/bar#foo",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#foo",
+                            "$id": "http://localhost:1234/draft-next/bar#foo",
                             "type": "integer"
                         }
                     }
@@ -56,10 +57,10 @@
             {
                 "description": "Identifier path with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#/a/b",
+                    "$ref": "http://localhost:1234/draft-next/bar#/a/b",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#/a/b",
+                            "$id": "http://localhost:1234/draft-next/bar#/a/b",
                             "type": "integer"
                         }
                     }
@@ -69,8 +70,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#foo",
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#foo",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -88,8 +89,8 @@
             {
                 "description": "Identifier path with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/a/b",
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#/a/b",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -110,16 +111,17 @@
         "description": "Valid use of empty fragments in location-independent $id",
         "comment": "These are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
         "tests": [
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar",
+                    "$ref": "http://localhost:1234/draft-next/bar",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#",
+                            "$id": "http://localhost:1234/draft-next/bar#",
                             "type": "integer"
                         }
                     }
@@ -129,8 +131,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/$defs/B",
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#/$defs/B",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -150,16 +152,17 @@
     {
         "description": "Unnormalized $ids are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
         "tests": [
             {
                 "description": "Unnormalized identifier",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft-next/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -171,7 +174,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -181,10 +184,10 @@
             {
                 "description": "Unnormalized identifier with empty fragment",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft-next/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -196,7 +199,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -209,36 +212,37 @@
         "description": "$id inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $id buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "id_in_enum": {
                     "enum": [
                         {
-                          "$id": "https://localhost:1234/id/my_identifier.json",
+                          "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
                           "type": "null"
                         }
                     ]
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
                     "type": "string"
                 },
                 "zzz_id_in_const": {
                     "const": {
-                        "$id": "https://localhost:1234/id/my_identifier.json",
+                        "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
                         "type": "null"
                     }
                 }
             },
             "anyOf": [
                 { "$ref": "#/$defs/id_in_enum" },
-                { "$ref": "https://localhost:1234/id/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft-next/id/my_identifier.json" }
             ]
         },
         "tests": [
             {
                 "description": "exact match to enum, and type matches",
                 "data": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
                     "type": "null"
                 },
                 "valid": true
@@ -258,6 +262,7 @@
     {
         "description": "non-schema object containing an $id property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "const_not_id": {
                     "const": {

--- a/tests/draft-next/if-then-else.json
+++ b/tests/draft-next/if-then-else.json
@@ -2,6 +2,7 @@
     {
         "description": "ignore if without then or else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": {
                 "const": 0
             }
@@ -22,6 +23,7 @@
     {
         "description": "ignore then without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "then": {
                 "const": 0
             }
@@ -42,6 +44,7 @@
     {
         "description": "ignore else without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "else": {
                 "const": 0
             }
@@ -62,6 +65,7 @@
     {
         "description": "if and then without else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -90,6 +94,7 @@
     {
         "description": "if and else without then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -118,6 +123,7 @@
     {
         "description": "validate against correct branch, then vs else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -154,6 +160,7 @@
     {
         "description": "non-interference across combined schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "if": {
@@ -188,6 +195,7 @@
     {
         "description": "if with boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": true,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -208,6 +216,7 @@
     {
         "description": "if with boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": false,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -228,6 +237,7 @@
     {
         "description": "if appears at the end when serialized (keyword processing sequence)",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "then": { "const": "yes" },
             "else": { "const": "other" },
             "if": { "maxLength": 4 }

--- a/tests/draft-next/infinite-loop-detection.json
+++ b/tests/draft-next/infinite-loop-detection.json
@@ -2,6 +2,7 @@
     {
         "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "int": { "type": "integer" }
             },

--- a/tests/draft-next/items.json
+++ b/tests/draft-next/items.json
@@ -2,6 +2,7 @@
     {
         "description": "a schema given for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "items": {"type": "integer"}
         },
         "tests": [
@@ -32,7 +33,10 @@
     },
     {
         "description": "items with boolean schema (true)",
-        "schema": {"items": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": true
+        },
         "tests": [
             {
                 "description": "any array is valid",
@@ -48,7 +52,10 @@
     },
     {
         "description": "items with boolean schema (false)",
-        "schema": {"items": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -65,6 +72,7 @@
     {
         "description": "items and subitems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "item": {
                     "type": "array",
@@ -147,6 +155,7 @@
     {
         "description": "nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "array",
             "items": {
                 "type": "array",
@@ -182,6 +191,7 @@
     {
         "description": "prefixItems with no additional items allowed",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [{}, {}, {}],
             "items": false
         },
@@ -216,6 +226,7 @@
     {
         "description": "items does not look in applicators, valid case",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 { "prefixItems": [ { "minimum": 3 } ] }
             ],
@@ -237,6 +248,7 @@
     {
         "description": "prefixItems validation adjusts the starting index for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [ { "type": "string" } ],
             "items": { "type": "integer" }
         },
@@ -256,6 +268,7 @@
     {
         "description": "items with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "items": {
                 "type": "null"
             }

--- a/tests/draft-next/maxContains.json
+++ b/tests/draft-next/maxContains.json
@@ -2,6 +2,7 @@
     {
         "description": "maxContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "maxContains": 1
         },
         "tests": [
@@ -30,6 +31,7 @@
     {
         "description": "maxContains with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "maxContains": 1
         },
@@ -89,6 +91,7 @@
     {
         "description": "maxContains with contains, value with a decimal",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": {"const": 1},
             "maxContains": 1.0
         },
@@ -108,6 +111,7 @@
     {
         "description": "minContains < maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "minContains": 1,
             "maxContains": 3

--- a/tests/draft-next/maxItems.json
+++ b/tests/draft-next/maxItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxItems validation",
-        "schema": {"maxItems": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxItems": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maxItems validation with a decimal",
-        "schema": {"maxItems": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxItems": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft-next/maxLength.json
+++ b/tests/draft-next/maxLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxLength validation",
-        "schema": {"maxLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxLength": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "maxLength validation with a decimal",
-        "schema": {"maxLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxLength": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft-next/maxProperties.json
+++ b/tests/draft-next/maxProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxProperties validation",
-        "schema": {"maxProperties": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "maxProperties validation with a decimal",
-        "schema": {"maxProperties": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -53,7 +59,10 @@
     },
     {
         "description": "maxProperties = 0 means the object is empty",
-        "schema": { "maxProperties": 0 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 0
+        },
         "tests": [
             {
                 "description": "no properties is valid",

--- a/tests/draft-next/maximum.json
+++ b/tests/draft-next/maximum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maximum validation",
-        "schema": {"maximum": 3.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 3.0
+        },
         "tests": [
             {
                 "description": "below the maximum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maximum validation with unsigned integer",
-        "schema": {"maximum": 300},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 300
+        },
         "tests":  [
             {
                 "description": "below the maximum is invalid",

--- a/tests/draft-next/minContains.json
+++ b/tests/draft-next/minContains.json
@@ -2,6 +2,7 @@
     {
         "description": "minContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "minContains": 1
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "minContains=1 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "minContains": 1
         },
@@ -54,6 +56,7 @@
     {
         "description": "minContains=2 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "minContains": 2
         },
@@ -93,6 +96,7 @@
     {
         "description": "minContains=2 with contains with a decimal value",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": {"const": 1},
             "minContains": 2.0
         },
@@ -112,6 +116,7 @@
     {
         "description": "maxContains = minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "maxContains": 2,
             "minContains": 2
@@ -142,6 +147,7 @@
     {
         "description": "maxContains < minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "maxContains": 1,
             "minContains": 3
@@ -172,6 +178,7 @@
     {
         "description": "minContains = 0",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": { "const": 1 },
             "minContains": 0
         },
@@ -191,6 +198,7 @@
     {
         "description": "minContains = 0 with maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "contains": {"const": 1},
             "minContains": 0,
             "maxContains": 1

--- a/tests/draft-next/minItems.json
+++ b/tests/draft-next/minItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minItems validation",
-        "schema": {"minItems": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minItems": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minItems validation with a decimal",
-        "schema": {"minItems": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minItems": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft-next/minLength.json
+++ b/tests/draft-next/minLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minLength validation",
-        "schema": {"minLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minLength": 2
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "minLength validation with a decimal",
-        "schema": {"minLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minLength": 2.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft-next/minProperties.json
+++ b/tests/draft-next/minProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minProperties validation",
-        "schema": {"minProperties": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minProperties": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "minProperties validation with a decimal",
-        "schema": {"minProperties": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minProperties": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft-next/minimum.json
+++ b/tests/draft-next/minimum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minimum validation",
-        "schema": {"minimum": 1.1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": 1.1
+        },
         "tests": [
             {
                 "description": "above the minimum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minimum validation with signed integer",
-        "schema": {"minimum": -2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": -2
+        },
         "tests": [
             {
                 "description": "negative above the minimum is valid",

--- a/tests/draft-next/multipleOf.json
+++ b/tests/draft-next/multipleOf.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "by int",
-        "schema": {"multipleOf": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 2
+        },
         "tests": [
             {
                 "description": "int by int",
@@ -22,7 +25,10 @@
     },
     {
         "description": "by number",
-        "schema": {"multipleOf": 1.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 1.5
+        },
         "tests": [
             {
                 "description": "zero is multiple of anything",
@@ -43,7 +49,10 @@
     },
     {
         "description": "by small number",
-        "schema": {"multipleOf": 0.0001},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 0.0001
+        },
         "tests": [
             {
                 "description": "0.0075 is multiple of 0.0001",
@@ -59,7 +68,11 @@
     },
     {
         "description": "float division = inf",
-        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer",
+            "multipleOf": 0.123456789
+        },
         "tests": [
             {
                 "description": "always invalid, but naive implementations may raise an overflow error",

--- a/tests/draft-next/not.json
+++ b/tests/draft-next/not.json
@@ -2,6 +2,7 @@
     {
         "description": "not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "not": {"type": "integer"}
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "not multiple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "not": {"type": ["integer", "boolean"]}
         },
         "tests": [
@@ -43,6 +45,7 @@
     {
         "description": "not more complex schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "not": {
                 "type": "object",
                 "properties": {
@@ -73,6 +76,7 @@
     {
         "description": "forbidden property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": { 
                     "not": {}
@@ -94,7 +98,10 @@
     },
     {
         "description": "not with boolean schema true",
-        "schema": {"not": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": true
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -105,7 +112,10 @@
     },
     {
         "description": "not with boolean schema false",
-        "schema": {"not": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": false
+        },
         "tests": [
             {
                 "description": "any value is valid",

--- a/tests/draft-next/oneOf.json
+++ b/tests/draft-next/oneOf.json
@@ -2,6 +2,7 @@
     {
         "description": "oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "oneOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "oneOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "oneOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all true",
-        "schema": {"oneOf": [true, true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, true, true]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "oneOf with boolean schemas, one true",
-        "schema": {"oneOf": [true, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, false, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "oneOf with boolean schemas, more than one true",
-        "schema": {"oneOf": [true, true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -100,7 +111,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all false",
-        "schema": {"oneOf": [false, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [false, false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -112,6 +126,7 @@
     {
         "description": "oneOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -153,6 +168,7 @@
     {
         "description": "oneOf with empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "oneOf": [
                 { "type": "number" },
                 {}
@@ -174,6 +190,7 @@
     {
         "description": "oneOf with required",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "oneOf": [
                 { "required": ["foo", "bar"] },
@@ -206,6 +223,7 @@
 	{
         "description": "oneOf with missing optional property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -248,6 +266,7 @@
     {
         "description": "nested oneOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "oneOf": [
                 {
                     "oneOf": [

--- a/tests/draft-next/optional/bignum.json
+++ b/tests/draft-next/optional/bignum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer",
-        "schema": { "type": "integer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "a bignum is an integer",
@@ -17,7 +20,10 @@
     },
     {
         "description": "number",
-        "schema": { "type": "number" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "a bignum is a number",
@@ -33,7 +39,10 @@
     },
     {
         "description": "string",
-        "schema": { "type": "string" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "a bignum is not a string",
@@ -44,7 +53,10 @@
     },
     {
         "description": "maximum integer comparison",
-        "schema": { "maximum": 18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for high numbers",
@@ -56,6 +68,7 @@
     {
         "description": "float comparison with high precision",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "exclusiveMaximum": 972783798187987123879878123.18878137
         },
         "tests": [
@@ -68,7 +81,10 @@
     },
     {
         "description": "minimum integer comparison",
-        "schema": { "minimum": -18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": -18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for very negative numbers",
@@ -80,6 +96,7 @@
     {
         "description": "float comparison with high precision on negative numbers",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "exclusiveMinimum": -972783798187987123879878123.18878137
         },
         "tests": [

--- a/tests/draft-next/optional/dependencies-compatibility.json
+++ b/tests/draft-next/optional/dependencies-compatibility.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependencies": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependencies": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependencies": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependencies": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]
@@ -142,6 +152,7 @@
     {
         "description": "single schema dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependencies": {
                 "bar": {
                     "properties": {
@@ -197,6 +208,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependencies": {
                 "foo": true,
                 "bar": false
@@ -228,6 +240,7 @@
     {
         "description": "schema dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "dependencies": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft-next/optional/ecmascript-regex.json
+++ b/tests/draft-next/optional/ecmascript-regex.json
@@ -2,6 +2,7 @@
     {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^abc$"
         },
@@ -21,6 +22,7 @@
     {
         "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\t$"
         },
@@ -40,6 +42,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\cC$"
         },
@@ -59,6 +62,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\cc$"
         },
@@ -78,6 +82,7 @@
     {
         "description": "ECMA 262 \\d matches ascii digits only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\d$"
         },
@@ -102,6 +107,7 @@
     {
         "description": "ECMA 262 \\D matches everything but ascii digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\D$"
         },
@@ -126,6 +132,7 @@
     {
         "description": "ECMA 262 \\w matches ascii letters only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\w$"
         },
@@ -145,6 +152,7 @@
     {
         "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\W$"
         },
@@ -164,6 +172,7 @@
     {
         "description": "ECMA 262 \\s matches whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\s$"
         },
@@ -228,6 +237,7 @@
     {
         "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "string",
             "pattern": "^\\S$"
         },
@@ -291,7 +301,10 @@
     },
     {
         "description": "patterns always use unicode semantics with pattern",
-        "schema": { "pattern": "\\p{Letter}cole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "\\p{Letter}cole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -317,7 +330,10 @@
     },
     {
         "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
-        "schema": { "pattern": "\\wcole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "\\wcole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -343,7 +359,10 @@
     },
     {
         "description": "pattern with ASCII ranges",
-        "schema": { "pattern": "[a-z]cole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "[a-z]cole"
+        },
         "tests": [
             {
                 "description": "literal unicode character in json string",
@@ -364,7 +383,10 @@
     },
     {
         "description": "\\d in pattern matches [0-9], not unicode digits",
-        "schema": { "pattern": "^\\d+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^\\d+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -385,7 +407,10 @@
     },
     {
         "description": "\\a is not an ECMA 262 control escape",
-        "schema": { "$ref": "https://json-schema.org/draft/next/schema" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
         "tests": [
             {
                 "description": "when used as a pattern",
@@ -396,7 +421,10 @@
     },
     {
         "description": "pattern with non-ASCII digits",
-        "schema": { "pattern": "^\\p{digit}+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^\\p{digit}+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -418,6 +446,7 @@
     {
         "description": "patterns always use unicode semantics with patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "\\p{Letter}cole": true
@@ -450,6 +479,7 @@
     {
         "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "\\wcole": true
@@ -482,6 +512,7 @@
     {
         "description": "patternProperties with ASCII ranges",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "[a-z]cole": true
@@ -509,6 +540,7 @@
     {
         "description": "\\d in patternProperties matches [0-9], not unicode digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "^\\d+$": true
@@ -536,6 +568,7 @@
     {
         "description": "patternProperties with non-ASCII digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "^\\p{digit}+$": true

--- a/tests/draft-next/optional/float-overflow.json
+++ b/tests/draft-next/optional/float-overflow.json
@@ -1,7 +1,11 @@
 [
     {
         "description": "all integers are multiples of 0.5, if overflow is handled",
-        "schema": {"type": "integer", "multipleOf": 0.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer",
+            "multipleOf": 0.5
+        },
         "tests": [
             {
                 "description": "valid if optional overflow handling is implemented",

--- a/tests/draft-next/optional/format/date-time.json
+++ b/tests/draft-next/optional/format/date-time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date-time strings",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/date.json
+++ b/tests/draft-next/optional/format/date.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date strings",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/duration.json
+++ b/tests/draft-next/optional/format/duration.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of duration strings",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/email.json
+++ b/tests/draft-next/optional/format/email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of e-mail addresses",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of host names",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/idn-email.json
+++ b/tests/draft-next/optional/format/idn-email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of an internationalized e-mail addresses",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of internationalized host names",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/ipv4.json
+++ b/tests/draft-next/optional/format/ipv4.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IP addresses",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/ipv6.json
+++ b/tests/draft-next/optional/format/ipv6.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IPv6 addresses",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/iri-reference.json
+++ b/tests/draft-next/optional/format/iri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRI References",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/iri.json
+++ b/tests/draft-next/optional/format/iri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRIs",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/json-pointer.json
+++ b/tests/draft-next/optional/format/json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of JSON-pointers (JSON String Representation)",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/regex.json
+++ b/tests/draft-next/optional/format/regex.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of regular expressions",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/relative-json-pointer.json
+++ b/tests/draft-next/optional/format/relative-json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of Relative JSON Pointers (RJP)",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/time.json
+++ b/tests/draft-next/optional/format/time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of time strings",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/uri-reference.json
+++ b/tests/draft-next/optional/format/uri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URI References",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/uri-template.json
+++ b/tests/draft-next/optional/format/uri-template.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "format: uri-template",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft-next/optional/format/uri.json
+++ b/tests/draft-next/optional/format/uri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URIs",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "a valid URL with anchor tag",

--- a/tests/draft-next/optional/format/uuid.json
+++ b/tests/draft-next/optional/format/uuid.json
@@ -2,6 +2,7 @@
     {
         "description": "uuid format",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "format": "uuid"
         },
         "tests": [

--- a/tests/draft-next/optional/non-bmp-regex.json
+++ b/tests/draft-next/optional/non-bmp-regex.json
@@ -2,7 +2,10 @@
     {
         "description": "Proper UTF-16 surrogate pair handling: pattern",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
-        "schema": { "pattern": "^🐲*$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^🐲*$"
+        },
         "tests": [
             {
                 "description": "matches empty",
@@ -45,6 +48,7 @@
         "description": "Proper UTF-16 surrogate pair handling: patternProperties",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "^🐲*$": {
                     "type": "integer"

--- a/tests/draft-next/optional/refOfUnknownKeyword.json
+++ b/tests/draft-next/optional/refOfUnknownKeyword.json
@@ -2,6 +2,7 @@
     {
         "description": "reference of a root arbitrary keyword ",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "unknown-keyword": {"type": "integer"},
             "properties": {
                 "bar": {"$ref": "#/unknown-keyword"}
@@ -23,6 +24,7 @@
     {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}

--- a/tests/draft-next/pattern.json
+++ b/tests/draft-next/pattern.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "pattern validation",
-        "schema": {"pattern": "^a*$"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^a*$"
+        },
         "tests": [
             {
                 "description": "a matching pattern is valid",
@@ -47,7 +50,10 @@
     },
     {
         "description": "pattern is not anchored",
-        "schema": {"pattern": "a+"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "a+"
+        },
         "tests": [
             {
                 "description": "matches a substring",

--- a/tests/draft-next/patternProperties.json
+++ b/tests/draft-next/patternProperties.json
@@ -3,6 +3,7 @@
         "description":
             "patternProperties validates properties matching a regex",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "f.*o": {"type": "integer"}
             }
@@ -48,6 +49,7 @@
     {
         "description": "multiple simultaneous patternProperties are validated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "a*": {"type": "integer"},
                 "aaa*": {"maximum": 20}
@@ -89,6 +91,7 @@
     {
         "description": "regexes are not anchored by default and are case sensitive",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "[0-9]{2,}": { "type": "boolean" },
                 "X_": { "type": "string" }
@@ -120,6 +123,7 @@
     {
         "description": "patternProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "f.*": true,
                 "b.*": false
@@ -156,6 +160,7 @@
     {
         "description": "patternProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "patternProperties": {
                 "^.*bar$": {"type": "null"}
             }

--- a/tests/draft-next/prefixItems.json
+++ b/tests/draft-next/prefixItems.json
@@ -2,6 +2,7 @@
     {
         "description": "a schema given for prefixItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 {"type": "integer"},
                 {"type": "string"}
@@ -47,6 +48,7 @@
     {
         "description": "prefixItems with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [true, false]
         },
         "tests": [
@@ -69,7 +71,10 @@
     },
     {
         "description": "additional items are allowed by default",
-        "schema": {"prefixItems": [{"type": "integer"}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "integer"}]
+        },
         "tests": [
             {
                 "description": "only the first item is validated",
@@ -81,6 +86,7 @@
     {
         "description": "prefixItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 {
                     "type": "null"

--- a/tests/draft-next/properties.json
+++ b/tests/draft-next/properties.json
@@ -2,6 +2,7 @@
     {
         "description": "object properties validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"type": "string"}
@@ -44,6 +45,7 @@
         "description":
             "properties, patternProperties, additionalProperties interaction",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"type": "array", "maxItems": 3},
                 "bar": {"type": "array"}
@@ -97,6 +99,7 @@
     {
         "description": "properties with boolean schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": true,
                 "bar": false
@@ -128,6 +131,7 @@
     {
         "description": "properties with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo\nbar": {"type": "number"},
                 "foo\"bar": {"type": "number"},
@@ -167,6 +171,7 @@
     {
         "description": "properties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"type": "null"}
             }
@@ -183,6 +188,7 @@
         "description": "properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "__proto__": {"type": "number"},
                 "toString": {

--- a/tests/draft-next/propertyNames.json
+++ b/tests/draft-next/propertyNames.json
@@ -2,6 +2,7 @@
     {
         "description": "propertyNames validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "propertyNames": {"maxLength": 3}
         },
         "tests": [
@@ -45,7 +46,10 @@
     },
     {
         "description": "propertyNames with boolean schema true",
-        "schema": {"propertyNames": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyNames": true
+        },
         "tests": [
             {
                 "description": "object with any properties is valid",
@@ -61,7 +65,10 @@
     },
     {
         "description": "propertyNames with boolean schema false",
-        "schema": {"propertyNames": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyNames": false
+        },
         "tests": [
             {
                 "description": "object with any properties is invalid",

--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -2,6 +2,7 @@
     {
         "description": "root pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"$ref": "#"}
             },
@@ -33,6 +34,7 @@
     {
         "description": "relative pointer ref to object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"$ref": "#/properties/foo"}
@@ -54,6 +56,7 @@
     {
         "description": "relative pointer ref to array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 {"type": "integer"},
                 {"$ref": "#/prefixItems/0"}
@@ -75,6 +78,7 @@
     {
         "description": "escaped pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "tilde~field": {"type": "integer"},
                 "slash/field": {"type": "integer"},
@@ -122,6 +126,7 @@
     {
         "description": "nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "a": {"type": "integer"},
                 "b": {"$ref": "#/$defs/a"},
@@ -145,6 +150,7 @@
     {
         "description": "ref applies alongside sibling keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "reffed": {
                     "type": "array"
@@ -178,6 +184,7 @@
     {
         "description": "remote ref, containing refs itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
         "tests": [
@@ -196,6 +203,7 @@
     {
         "description": "property named $ref that is not a reference",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "$ref": {"type": "string"}
             }
@@ -216,6 +224,7 @@
     {
         "description": "property named $ref, containing an actual $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "$ref": {"$ref": "#/$defs/is-string"}
             },
@@ -241,6 +250,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": true
@@ -257,6 +267,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": false
@@ -273,7 +284,8 @@
     {
         "description": "Recursive references between schemas",
         "schema": {
-            "$id": "http://localhost:1234/tree",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/tree",
             "description": "tree of nodes",
             "type": "object",
             "properties": {
@@ -286,7 +298,7 @@
             "required": ["meta", "nodes"],
             "$defs": {
                 "node": {
-                    "$id": "http://localhost:1234/node",
+                    "$id": "http://localhost:1234/draft-next/node",
                     "description": "node",
                     "type": "object",
                     "properties": {
@@ -361,6 +373,7 @@
     {
         "description": "refs with quote",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
             },
@@ -388,6 +401,7 @@
     {
         "description": "ref creates new scope when adjacent to keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "A": {
                     "unevaluatedProperties": false
@@ -413,6 +427,7 @@
     {
         "description": "naive replacement of $ref with its destination is not correct",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "a_string": { "type": "string" }
             },
@@ -441,6 +456,7 @@
     {
         "description": "refs with relative uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "http://example.com/schema-relative-uri-defs1.json",
             "properties": {
                 "foo": {
@@ -493,6 +509,7 @@
     {
         "description": "relative refs with absolute uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
             "properties": {
                 "foo": {
@@ -545,6 +562,7 @@
     {
         "description": "$id must be resolved against nearest parent, not just immediate parent",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "http://example.com/a.json",
             "$defs": {
                 "x": {
@@ -581,8 +599,9 @@
     {
         "description": "order of evaluation: $id and $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/ref-and-id1/base.json",
+            "$id": "/draft/next/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
@@ -592,7 +611,7 @@
                 },
                 "smallint": {
                     "$comment": "canonical uri: /ref-and-id1-int.json",
-                    "$id": "/ref-and-id1-int.json",
+                    "$id": "/draft/next/ref-and-id1-int.json",
                     "maximum": 2
                 }
             }
@@ -613,8 +632,9 @@
     {
         "description": "order of evaluation: $id and $anchor and $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/ref-and-id2/base.json",
+            "$id": "/draft/next/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
@@ -624,7 +644,7 @@
                 },
                 "smallint": {
                     "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
-                    "$id": "/ref-and-id2/",
+                    "$id": "/draft/next/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2
                 }
@@ -646,6 +666,7 @@
     {
         "description": "simple URN base URI with $ref via the URN",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
             "minimum": 30,
@@ -669,6 +690,7 @@
     {
         "description": "simple URN base URI with JSON pointer",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
             "properties": {
@@ -694,6 +716,7 @@
     {
         "description": "URN base URI with NSS",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "RFC 8141 §2.2",
             "$id": "urn:example:1/406/47452/2",
             "properties": {
@@ -719,6 +742,7 @@
     {
         "description": "URN base URI with r-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "RFC 8141 §2.3.1",
             "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
             "properties": {
@@ -744,6 +768,7 @@
     {
         "description": "URN base URI with q-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "RFC 8141 §2.3.2",
             "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
             "properties": {
@@ -769,6 +794,7 @@
     {
         "description": "URN base URI with f-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
             "$ref": "https://json-schema.org/draft/next/schema"
         },
@@ -783,6 +809,7 @@
     {
         "description": "URN base URI with URN and JSON pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
@@ -807,6 +834,7 @@
     {
         "description": "URN base URI with URN and anchor ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}

--- a/tests/draft-next/refRemote.json
+++ b/tests/draft-next/refRemote.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "remote ref",
-        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/integer.json"
+        },
         "tests": [
             {
                 "description": "remote ref valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/subSchemas-defs.json#/$defs/integer"
+        },
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -34,7 +40,8 @@
     {
         "description": "ref within remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -52,7 +59,8 @@
     {
         "description": "base URI change",
         "schema": {
-            "$id": "http://localhost:1234/",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/",
             "items": {
                 "$id": "baseUriChange/",
                 "items": {"$ref": "folderInteger.json"}
@@ -74,7 +82,8 @@
     {
         "description": "base URI change - change folder",
         "schema": {
-            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/scope_change_defs1.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
             "$defs": {
@@ -101,7 +110,8 @@
     {
         "description": "base URI change - change folder in subschema",
         "schema": {
-            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/scope_change_defs2.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
             "$defs": {
@@ -132,7 +142,8 @@
     {
         "description": "root ref in remote ref",
         "schema": {
-            "$id": "http://localhost:1234/object",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/object",
             "type": "object",
             "properties": {
                 "name": {"$ref": "name-defs.json#/$defs/orNull"}
@@ -167,7 +178,8 @@
     {
         "description": "remote ref with ref to defs",
         "schema": {
-            "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/schema-remote-ref-ref-defs1.json",
             "$ref": "ref-and-defs.json"
         },
         "tests": [
@@ -190,7 +202,8 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -208,7 +221,8 @@
     {
         "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
-            "$id": "http://localhost:1234/some-id",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/some-id",
             "properties": {
                 "name": {"$ref": "nested/foo-ref-string.json"}
             }

--- a/tests/draft-next/required.json
+++ b/tests/draft-next/required.json
@@ -2,6 +2,7 @@
     {
         "description": "required validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {},
                 "bar": {}
@@ -39,6 +40,7 @@
     {
         "description": "required default validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {}
             }
@@ -54,6 +56,7 @@
     {
         "description": "required with empty array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {}
             },
@@ -70,6 +73,7 @@
     {
         "description": "required with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "required": [
                 "foo\nbar",
                 "foo\"bar",
@@ -105,7 +109,10 @@
     {
         "description": "required properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
-        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
         "tests": [
             {
                 "description": "ignores arrays",

--- a/tests/draft-next/type.json
+++ b/tests/draft-next/type.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer type matches integers",
-        "schema": {"type": "integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "an integer is an integer",
@@ -52,7 +55,10 @@
     },
     {
         "description": "number type matches numbers",
-        "schema": {"type": "number"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "an integer is a number",
@@ -103,7 +109,10 @@
     },
     {
         "description": "string type matches strings",
-        "schema": {"type": "string"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "1 is not a string",
@@ -154,7 +163,10 @@
     },
     {
         "description": "object type matches objects",
-        "schema": {"type": "object"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object"
+        },
         "tests": [
             {
                 "description": "an integer is not an object",
@@ -195,7 +207,10 @@
     },
     {
         "description": "array type matches arrays",
-        "schema": {"type": "array"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "array"
+        },
         "tests": [
             {
                 "description": "an integer is not an array",
@@ -236,7 +251,10 @@
     },
     {
         "description": "boolean type matches booleans",
-        "schema": {"type": "boolean"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "boolean"
+        },
         "tests": [
             {
                 "description": "an integer is not a boolean",
@@ -292,7 +310,10 @@
     },
     {
         "description": "null type matches only the null object",
-        "schema": {"type": "null"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "null"
+        },
         "tests": [
             {
                 "description": "an integer is not null",
@@ -348,7 +369,10 @@
     },
     {
         "description": "multiple types can be specified in an array",
-        "schema": {"type": ["integer", "string"]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": ["integer", "string"]
+        },
         "tests": [
             {
                 "description": "an integer is valid",
@@ -390,6 +414,7 @@
     {
         "description": "type as array with one item",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": ["string"]
         },
         "tests": [
@@ -408,6 +433,7 @@
     {
         "description": "type: array or object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": ["array", "object"]
         },
         "tests": [
@@ -441,6 +467,7 @@
     {
         "description": "type: array, object or null",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": ["array", "object", "null"]
         },
         "tests": [

--- a/tests/draft-next/unevaluatedItems.json
+++ b/tests/draft-next/unevaluatedItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "unevaluatedItems true",
-        "schema": { "unevaluatedItems": true },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": true
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -17,7 +20,10 @@
     },
     {
         "description": "unevaluatedItems false",
-        "schema": { "unevaluatedItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -33,7 +39,10 @@
     },
     {
         "description": "unevaluatedItems as schema",
-        "schema": { "unevaluatedItems": { "type": "string" } },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -55,6 +64,7 @@
     {
         "description": "unevaluatedItems with uniform items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "items": { "type": "string" },
             "unevaluatedItems": false
         },
@@ -69,6 +79,7 @@
     {
         "description": "unevaluatedItems with tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -90,6 +101,7 @@
     {
         "description": "unevaluatedItems with items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -107,6 +119,7 @@
     {
         "description": "unevaluatedItems with nested tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -136,6 +149,7 @@
     {
         "description": "unevaluatedItems with nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "unevaluatedItems": {"type": "boolean"},
             "anyOf": [
                 { "items": {"type": "string"} },
@@ -163,6 +177,7 @@
     {
         "description": "unevaluatedItems with nested prefixItems and items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "prefixItems": [
@@ -189,6 +204,7 @@
     {
         "description": "unevaluatedItems with nested unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "prefixItems": [
@@ -215,6 +231,7 @@
     {
         "description": "unevaluatedItems with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -261,6 +278,7 @@
     {
         "description": "unevaluatedItems with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -296,6 +314,7 @@
     {
         "description": "unevaluatedItems with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -320,6 +339,7 @@
     {
         "description": "unevaluatedItems with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -372,6 +392,7 @@
     {
         "description": "unevaluatedItems with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [true],
             "unevaluatedItems": false
         },
@@ -391,6 +412,7 @@
     {
         "description": "unevaluatedItems with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "#/$defs/bar",
             "prefixItems": [
                 { "type": "string" }
@@ -421,6 +443,7 @@
     {
         "description": "unevaluatedItems can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "prefixItems": [ true ]
@@ -439,6 +462,7 @@
     {
         "description": "item is evaluated in an uncle schema to unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {
                     "prefixItems": [
@@ -485,6 +509,7 @@
     {
         "description": "unevaluatedItems depends on adjacent contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [true],
             "contains": {"type": "string"},
             "unevaluatedItems": false
@@ -510,6 +535,7 @@
     {
         "description": "unevaluatedItems depends on multiple nested contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 { "contains": { "multipleOf": 2 } },
                 { "contains": { "multipleOf": 3 } }
@@ -532,6 +558,7 @@
     {
         "description": "unevaluatedItems and contains interact to control item dependency relationship",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "if": {
                 "contains": {"const": "a"}
             },
@@ -592,7 +619,10 @@
     },
     {
         "description": "non-array instances are valid",
-        "schema": {"unevaluatedItems": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -629,6 +659,7 @@
     {
         "description": "unevaluatedItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "unevaluatedItems": {
                 "type": "null"
             }

--- a/tests/draft-next/unevaluatedProperties.json
+++ b/tests/draft-next/unevaluatedProperties.json
@@ -2,6 +2,7 @@
     {
         "description": "unevaluatedProperties true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "unevaluatedProperties": true
         },
@@ -23,6 +24,7 @@
     {
         "description": "unevaluatedProperties schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "unevaluatedProperties": {
                 "type": "string",
@@ -54,6 +56,7 @@
     {
         "description": "unevaluatedProperties false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -75,6 +78,7 @@
     {
         "description": "unevaluatedProperties with adjacent properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -102,6 +106,7 @@
     {
         "description": "unevaluatedProperties with adjacent patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "patternProperties": {
                 "^foo": { "type": "string" }
@@ -129,6 +134,7 @@
     {
         "description": "unevaluatedProperties with adjacent additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -157,6 +163,7 @@
     {
         "description": "unevaluatedProperties with nested properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -193,6 +200,7 @@
     {
         "description": "unevaluatedProperties with nested patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -229,6 +237,7 @@
     {
         "description": "unevaluatedProperties with nested additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -261,6 +270,7 @@
     {
         "description": "unevaluatedProperties with nested unevaluatedProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -296,6 +306,7 @@
     {
         "description": "unevaluatedProperties with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -364,6 +375,7 @@
     {
         "description": "unevaluatedProperties with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -407,6 +419,7 @@
     {
         "description": "unevaluatedProperties with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -435,6 +448,7 @@
     {
         "description": "unevaluatedProperties with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -494,6 +508,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, then not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -547,6 +562,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, else not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -600,6 +616,7 @@
     {
         "description": "unevaluatedProperties with dependentSchemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -635,6 +652,7 @@
     {
         "description": "unevaluatedProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -662,6 +680,7 @@
     {
         "description": "unevaluatedProperties with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "$ref": "#/$defs/bar",
             "properties": {
@@ -699,6 +718,7 @@
     {
         "description": "unevaluatedProperties can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 {
                     "properties": {
@@ -723,6 +743,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -755,6 +776,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -787,6 +809,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -819,6 +842,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -851,6 +875,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, true with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -885,6 +910,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, false with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -920,6 +946,7 @@
         "description": "property is evaluated in an uncle schema to unevaluatedProperties",
         "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "foo": {
@@ -971,6 +998,7 @@
     {
         "description": "in-place applicator siblings, allOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1016,6 +1044,7 @@
     {
         "description": "in-place applicator siblings, anyOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1061,6 +1090,7 @@
     {
         "description": "unevaluatedProperties + single cyclic ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "type": "object",
             "properties": {
                 "x": { "$ref": "#" }
@@ -1108,6 +1138,7 @@
     {
         "description": "unevaluatedProperties + ref inside allOf / oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "one": {
                     "properties": { "a": true }
@@ -1178,6 +1209,7 @@
     {
         "description": "dynamic evalation inside nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "one": {
                     "oneOf": [
@@ -1311,6 +1343,7 @@
     {
         "description": "unevaluatedProperties depends on adjacent contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
               "foo": { "type": "number" }
             },
@@ -1338,6 +1371,7 @@
     {
         "description": "unevaluatedProperties depends on multiple nested contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "allOf": [
                 { "contains": { "multipleOf": 2 } },
                 { "contains": { "multipleOf": 3 } }
@@ -1359,7 +1393,10 @@
     },
     {
         "description": "non-object instances are valid",
-        "schema": {"unevaluatedProperties": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedProperties": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -1396,6 +1433,7 @@
     {
         "description": "unevaluatedProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "unevaluatedProperties": {
                 "type": "null"
             }

--- a/tests/draft-next/uniqueItems.json
+++ b/tests/draft-next/uniqueItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "uniqueItems validation",
-        "schema": {"uniqueItems": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "uniqueItems": true
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -149,6 +152,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
@@ -198,6 +202,7 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true,
             "items": false
@@ -232,7 +237,10 @@
     },
     {
         "description": "uniqueItems=false validation",
-        "schema": { "uniqueItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "uniqueItems": false
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -320,6 +328,7 @@
     {
         "description": "uniqueItems=false with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false
         },
@@ -369,6 +378,7 @@
     {
         "description": "uniqueItems=false with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false,
             "items": false

--- a/tests/draft-next/unknownKeyword.json
+++ b/tests/draft-next/unknownKeyword.json
@@ -3,26 +3,27 @@
         "description": "$id inside an unknown keyword is not a real identifier",
         "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "id_in_unknown0": {
                     "not": {
                         "array_of_schemas": [
                             {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
                               "type": "null"
                             }
                         ]
                     }
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                    "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
                     "type": "string"
                 },
                 "id_in_unknown1": {
                     "not": {
                         "object_of_schemas": {
                             "foo": {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
                               "type": "integer"
                             }
                         }
@@ -32,7 +33,7 @@
             "anyOf": [
                 { "$ref": "#/$defs/id_in_unknown0" },
                 { "$ref": "#/$defs/id_in_unknown1" },
-                { "$ref": "https://localhost:1234/unknownKeyword/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json" }
             ]
         },
         "tests": [

--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -2,6 +2,7 @@
     {
         "description": "additionalItems as schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{}],
             "additionalItems": {"type": "integer"}
         },
@@ -21,6 +22,7 @@
     {
         "description": "when items is schema, additionalItems does nothing",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": {},
             "additionalItems": false
         },
@@ -35,6 +37,7 @@
     {
         "description": "array of items with no additionalItems permitted",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{}, {}, {}],
             "additionalItems": false
         },
@@ -68,7 +71,10 @@
     },
     {
         "description": "additionalItems as false without items",
-        "schema": {"additionalItems": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalItems": false
+        },
         "tests": [
             {
                 "description":
@@ -85,7 +91,10 @@
     },
     {
         "description": "additionalItems are allowed by default",
-        "schema": {"items": [{"type": "integer"}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "integer"}]
+        },
         "tests": [
             {
                 "description": "only the first item is validated",
@@ -97,6 +106,7 @@
     {
         "description": "additionalItems does not look in applicators, valid case",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 { "items": [ { "type": "integer" } ] }
             ],
@@ -113,6 +123,7 @@
     {
         "description": "additionalItems does not look in applicators, invalid case",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 { "items": [ { "type": "integer" }, { "type": "string" } ] }
             ],
@@ -130,6 +141,7 @@
     {
         "description": "items validation adjusts the starting index for additionalItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [ { "type": "string" } ],
             "additionalItems": { "type": "integer" }
         },
@@ -149,6 +161,7 @@
     {
         "description": "additionalItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "additionalItems": {
                 "type": "null"
             }

--- a/tests/draft2019-09/additionalProperties.json
+++ b/tests/draft2019-09/additionalProperties.json
@@ -3,6 +3,7 @@
         "description":
             "additionalProperties being false does not allow other properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {"foo": {}, "bar": {}},
             "patternProperties": { "^v": {} },
             "additionalProperties": false
@@ -43,6 +44,7 @@
     {
         "description": "non-ASCII pattern with additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {"^á": {}},
             "additionalProperties": false
         },
@@ -62,6 +64,7 @@
     {
         "description": "additionalProperties with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {"foo": {}, "bar": {}},
             "additionalProperties": {"type": "boolean"}
         },
@@ -87,6 +90,7 @@
         "description":
             "additionalProperties can exist by itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "additionalProperties": {"type": "boolean"}
         },
         "tests": [
@@ -104,7 +108,10 @@
     },
     {
         "description": "additionalProperties are allowed by default",
-        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
         "tests": [
             {
                 "description": "additional properties are allowed",
@@ -116,6 +123,7 @@
     {
         "description": "additionalProperties does not look in applicators",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {"properties": {"foo": {}}}
             ],
@@ -132,6 +140,7 @@
     {
         "description": "additionalProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "additionalProperties": {
                 "type": "null"
             }

--- a/tests/draft2019-09/allOf.json
+++ b/tests/draft2019-09/allOf.json
@@ -2,6 +2,7 @@
     {
         "description": "allOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "properties": {
@@ -43,6 +44,7 @@
     {
         "description": "allOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {"bar": {"type": "integer"}},
             "required": ["bar"],
             "allOf" : [
@@ -91,6 +93,7 @@
     {
         "description": "allOf simple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {"maximum": 30},
                 {"minimum": 20}
@@ -111,7 +114,10 @@
     },
     {
         "description": "allOf with boolean schemas, all true",
-        "schema": {"allOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -122,7 +128,10 @@
     },
     {
         "description": "allOf with boolean schemas, some false",
-        "schema": {"allOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -133,7 +142,10 @@
     },
     {
         "description": "allOf with boolean schemas, all false",
-        "schema": {"allOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -145,6 +157,7 @@
     {
         "description": "allOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {}
             ]
@@ -160,6 +173,7 @@
     {
         "description": "allOf with two empty schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {},
                 {}
@@ -176,6 +190,7 @@
     {
         "description": "allOf with the first empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {},
                 { "type": "number" }
@@ -197,6 +212,7 @@
     {
         "description": "allOf with the last empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 { "type": "number" },
                 {}
@@ -218,6 +234,7 @@
     {
         "description": "nested allOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "allOf": [
@@ -244,6 +261,7 @@
     {
         "description": "allOf combined with anyOf, oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [ { "multipleOf": 2 } ],
             "anyOf": [ { "multipleOf": 3 } ],
             "oneOf": [ { "multipleOf": 5 } ]

--- a/tests/draft2019-09/anchor.json
+++ b/tests/draft2019-09/anchor.json
@@ -28,10 +28,10 @@
         "description": "Location-independent identifier with absolute URI",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$ref": "http://localhost:1234/bar#foo",
+            "$ref": "http://localhost:1234/draft2019-09/bar#foo",
             "$defs": {
                 "A": {
-                    "$id": "http://localhost:1234/bar",
+                    "$id": "http://localhost:1234/draft2019-09/bar",
                     "$anchor": "foo",
                     "type": "integer"
                 }
@@ -54,8 +54,8 @@
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/root",
-            "$ref": "http://localhost:1234/nested.json#foo",
+            "$id": "http://localhost:1234/draft2019-09/root",
+            "$ref": "http://localhost:1234/draft2019-09/nested.json#foo",
             "$defs": {
                 "A": {
                     "$id": "nested.json",
@@ -143,7 +143,7 @@
         "description": "same $anchor with different base uri",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/foobar",
+            "$id": "http://localhost:1234/draft2019-09/foobar",
             "$defs": {
                 "A": {
                     "$id": "child1",

--- a/tests/draft2019-09/anchor.json
+++ b/tests/draft2019-09/anchor.json
@@ -2,6 +2,7 @@
     {
         "description": "Location-independent identifier",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "#foo",
             "$defs": {
                 "A": {
@@ -26,6 +27,7 @@
     {
         "description": "Location-independent identifier with absolute URI",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://localhost:1234/bar#foo",
             "$defs": {
                 "A": {
@@ -51,6 +53,7 @@
     {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/root",
             "$ref": "http://localhost:1234/nested.json#foo",
             "$defs": {
@@ -82,6 +85,7 @@
         "description": "$anchor inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $anchor buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "anchor_in_enum": {
                     "enum": [
@@ -138,6 +142,7 @@
     {
         "description": "same $anchor with different base uri",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/foobar",
             "$defs": {
                 "A": {
@@ -173,6 +178,7 @@
     {
         "description": "non-schema object containing an $anchor property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "const_not_anchor": {
                     "const": {
@@ -204,7 +210,10 @@
     {
         "description": "invalid anchors",
         "comment": "Section 8.2.3",
-        "schema": { "$ref": "https://json-schema.org/draft/2019-09/schema" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
         "tests": [
             {
                 "description": "MUST start with a letter (and not #)",

--- a/tests/draft2019-09/anyOf.json
+++ b/tests/draft2019-09/anyOf.json
@@ -2,6 +2,7 @@
     {
         "description": "anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "anyOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "anyOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "anyOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all true",
-        "schema": {"anyOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "anyOf with boolean schemas, some true",
-        "schema": {"anyOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all false",
-        "schema": {"anyOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -101,6 +112,7 @@
     {
         "description": "anyOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "anyOf": [
                 {
                     "properties": {
@@ -142,6 +154,7 @@
     {
         "description": "anyOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "anyOf": [
                 { "type": "number" },
                 {}
@@ -163,6 +176,7 @@
     {
         "description": "nested anyOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "anyOf": [
                 {
                     "anyOf": [

--- a/tests/draft2019-09/const.json
+++ b/tests/draft2019-09/const.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "const validation",
-        "schema": {"const": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 2
+        },
         "tests": [
             {
                 "description": "same value is valid",
@@ -22,7 +25,10 @@
     },
     {
         "description": "const with object",
-        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
         "tests": [
             {
                 "description": "same object is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "const with array",
-        "schema": {"const": [{ "foo": "bar" }]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [{ "foo": "bar" }]
+        },
         "tests": [
             {
                 "description": "same array is valid",
@@ -69,7 +78,10 @@
     },
     {
         "description": "const with null",
-        "schema": {"const": null},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": null
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -85,7 +97,10 @@
     },
     {
         "description": "const with false does not match 0",
-        "schema": {"const": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": false
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -106,7 +121,10 @@
     },
     {
         "description": "const with true does not match 1",
-        "schema": {"const": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": true
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -127,7 +145,10 @@
     },
     {
         "description": "const with [false] does not match [0]",
-        "schema": {"const": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [false]
+        },
         "tests": [
             {
                 "description": "[false] is valid",
@@ -148,7 +169,10 @@
     },
     {
         "description": "const with [true] does not match [1]",
-        "schema": {"const": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [true]
+        },
         "tests": [
             {
                 "description": "[true] is valid",
@@ -169,7 +193,10 @@
     },
     {
         "description": "const with {\"a\": false} does not match {\"a\": 0}",
-        "schema": {"const": {"a": false}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"a": false}
+        },
         "tests": [
             {
                 "description": "{\"a\": false} is valid",
@@ -190,7 +217,10 @@
     },
     {
         "description": "const with {\"a\": true} does not match {\"a\": 1}",
-        "schema": {"const": {"a": true}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"a": true}
+        },
         "tests": [
             {
                 "description": "{\"a\": true} is valid",
@@ -211,7 +241,10 @@
     },
     {
         "description": "const with 0 does not match other zero-like types",
-        "schema": {"const": 0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 0
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -247,7 +280,10 @@
     },
     {
         "description": "const with 1 does not match true",
-        "schema": {"const": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 1
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -268,7 +304,10 @@
     },
     {
         "description": "const with -2.0 matches integer and float types",
-        "schema": {"const": -2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": -2.0
+        },
         "tests": [
             {
                 "description": "integer -2 is valid",
@@ -299,7 +338,10 @@
     },
     {
         "description": "float and integers are equal up to 64-bit representation limits",
-        "schema": {"const": 9007199254740992},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 9007199254740992
+        },
         "tests": [
             {
                 "description": "integer is valid",
@@ -325,7 +367,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "const": "hello\u0000there" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": "hello\u0000there"
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft2019-09/contains.json
+++ b/tests/draft2019-09/contains.json
@@ -2,6 +2,7 @@
     {
         "description": "contains keyword validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"minimum": 5}
         },
         "tests": [
@@ -40,6 +41,7 @@
     {
         "description": "contains keyword with const keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": { "const": 5 }
         },
         "tests": [
@@ -62,7 +64,10 @@
     },
     {
         "description": "contains keyword with boolean schema true",
-        "schema": {"contains": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": true
+        },
         "tests": [
             {
                 "description": "any non-empty array is valid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "contains keyword with boolean schema false",
-        "schema": {"contains": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -100,6 +108,7 @@
     {
         "description": "items + contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": { "multipleOf": 2 },
             "contains": { "multipleOf": 3 }
         },
@@ -129,6 +138,7 @@
     {
         "description": "contains with false if subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {
                 "if": false,
                 "else": true
@@ -150,6 +160,7 @@
     {
         "description": "contains with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {
                 "type": "null"
             }

--- a/tests/draft2019-09/content.json
+++ b/tests/draft2019-09/content.json
@@ -2,6 +2,7 @@
     {
         "description": "validation of string-encoded content based on media type",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contentMediaType": "application/json"
         },
         "tests": [
@@ -25,6 +26,7 @@
     {
         "description": "validation of binary string-encoding",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contentEncoding": "base64"
         },
         "tests": [
@@ -48,6 +50,7 @@
     {
         "description": "validation of binary-encoded media type documents",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64"
         },
@@ -77,6 +80,7 @@
     {
         "description": "validation of binary-encoded media type documents with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
             "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }

--- a/tests/draft2019-09/default.json
+++ b/tests/draft2019-09/default.json
@@ -2,6 +2,7 @@
     {
         "description": "invalid type for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {
                     "type": "integer",
@@ -25,6 +26,7 @@
     {
         "description": "invalid string value for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "bar": {
                     "type": "string",
@@ -49,6 +51,7 @@
     {
         "description": "the default keyword does not do anything if the property is missing",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "alpha": {

--- a/tests/draft2019-09/defs.json
+++ b/tests/draft2019-09/defs.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validate definition against metaschema",
-        "schema": {"$ref": "https://json-schema.org/draft/2019-09/schema"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
         "tests": [
             {
                 "description": "valid definition schema",

--- a/tests/draft2019-09/dependentRequired.json
+++ b/tests/draft2019-09/dependentRequired.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependentRequired": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependentRequired": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependentRequired": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependentRequired": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]

--- a/tests/draft2019-09/dependentSchemas.json
+++ b/tests/draft2019-09/dependentSchemas.json
@@ -2,6 +2,7 @@
     {
         "description": "single dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependentSchemas": {
                 "bar": {
                     "properties": {
@@ -57,6 +58,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependentSchemas": {
                 "foo": true,
                 "bar": false
@@ -88,6 +90,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependentSchemas": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft2019-09/enum.json
+++ b/tests/draft2019-09/enum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "simple enum validation",
-        "schema": {"enum": [1, 2, 3]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [1, 2, 3]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "heterogeneous enum validation",
-        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "heterogeneous enum-with-null validation",
-        "schema": { "enum": [6, null] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [6, null]
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -70,6 +79,7 @@
     {
         "description": "enums in properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type":"object",
             "properties": {
                 "foo": {"enum":["foo"]},
@@ -113,6 +123,7 @@
     {
         "description": "enum with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "enum": ["foo\nbar", "foo\rbar"]
         },
         "tests": [
@@ -135,7 +146,10 @@
     },
     {
         "description": "enum with false does not match 0",
-        "schema": {"enum": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [false]
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -156,7 +170,10 @@
     },
     {
         "description": "enum with true does not match 1",
-        "schema": {"enum": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [true]
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -177,7 +194,10 @@
     },
     {
         "description": "enum with 0 does not match false",
-        "schema": {"enum": [0]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [0]
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -198,7 +218,10 @@
     },
     {
         "description": "enum with 1 does not match true",
-        "schema": {"enum": [1]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [1]
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -219,7 +242,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "enum": [ "hello\u0000there" ] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [ "hello\u0000there" ]
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft2019-09/exclusiveMaximum.json
+++ b/tests/draft2019-09/exclusiveMaximum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMaximum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "exclusiveMaximum": 3.0
         },
         "tests": [

--- a/tests/draft2019-09/exclusiveMinimum.json
+++ b/tests/draft2019-09/exclusiveMinimum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMinimum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "exclusiveMinimum": 1.1
         },
         "tests": [

--- a/tests/draft2019-09/format.json
+++ b/tests/draft2019-09/format.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "email format",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -37,7 +40,10 @@
     },
     {
         "description": "idn-email format",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -73,7 +79,10 @@
     },
     {
         "description": "regex format",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -109,7 +118,10 @@
     },
     {
         "description": "ipv4 format",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -145,7 +157,10 @@
     },
     {
         "description": "ipv6 format",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -181,7 +196,10 @@
     },
     {
         "description": "idn-hostname format",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -217,7 +235,10 @@
     },
     {
         "description": "hostname format",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -253,7 +274,10 @@
     },
     {
         "description": "date format",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -289,7 +313,10 @@
     },
     {
         "description": "date-time format",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -325,7 +352,10 @@
     },
     {
         "description": "time format",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -361,7 +391,10 @@
     },
     {
         "description": "json-pointer format",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -397,7 +430,10 @@
     },
     {
         "description": "relative-json-pointer format",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -433,7 +469,10 @@
     },
     {
         "description": "iri format",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -469,7 +508,10 @@
     },
     {
         "description": "iri-reference format",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -505,7 +547,10 @@
     },
     {
         "description": "uri format",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -541,7 +586,10 @@
     },
     {
         "description": "uri-reference format",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -577,7 +625,10 @@
     },
     {
         "description": "uri-template format",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -613,7 +664,10 @@
     },
     {
         "description": "uuid format",
-        "schema": { "format": "uuid" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uuid"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -649,7 +703,10 @@
     },
     {
         "description": "duration format",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/id.json
+++ b/tests/draft2019-09/id.json
@@ -2,6 +2,7 @@
     {
         "description": "Invalid use of fragments in location-independent $id",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "https://json-schema.org/draft/2019-09/schema"
         },
         "tests": [
@@ -110,6 +111,7 @@
         "description": "Valid use of empty fragments in location-independent $id",
         "comment": "These are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "https://json-schema.org/draft/2019-09/schema"
         },
         "tests": [
@@ -150,6 +152,7 @@
     {
         "description": "Unnormalized $ids are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "https://json-schema.org/draft/2019-09/schema"
         },
         "tests": [
@@ -209,6 +212,7 @@
         "description": "$id inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $id buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "id_in_enum": {
                     "enum": [
@@ -258,6 +262,7 @@
     {
         "description": "non-schema object containing an $id property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "const_not_id": {
                     "const": {

--- a/tests/draft2019-09/id.json
+++ b/tests/draft2019-09/id.json
@@ -44,10 +44,10 @@
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#foo",
+                    "$ref": "http://localhost:1234/draft2019-09/bar#foo",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#foo",
+                            "$id": "http://localhost:1234/draft2019-09/bar#foo",
                             "type": "integer"
                         }
                     }
@@ -57,10 +57,10 @@
             {
                 "description": "Identifier path with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#/a/b",
+                    "$ref": "http://localhost:1234/draft2019-09/bar#/a/b",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#/a/b",
+                            "$id": "http://localhost:1234/draft2019-09/bar#/a/b",
                             "type": "integer"
                         }
                     }
@@ -70,8 +70,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#foo",
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#foo",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -89,8 +89,8 @@
             {
                 "description": "Identifier path with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/a/b",
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#/a/b",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -118,10 +118,10 @@
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar",
+                    "$ref": "http://localhost:1234/draft2019-09/bar",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#",
+                            "$id": "http://localhost:1234/draft2019-09/bar#",
                             "type": "integer"
                         }
                     }
@@ -131,8 +131,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/$defs/B",
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#/$defs/B",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -159,10 +159,10 @@
             {
                 "description": "Unnormalized identifier",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft2019-09/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -174,7 +174,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -184,10 +184,10 @@
             {
                 "description": "Unnormalized identifier with empty fragment",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft2019-09/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -199,7 +199,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -217,32 +217,32 @@
                 "id_in_enum": {
                     "enum": [
                         {
-                          "$id": "https://localhost:1234/id/my_identifier.json",
+                          "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
                           "type": "null"
                         }
                     ]
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
                     "type": "string"
                 },
                 "zzz_id_in_const": {
                     "const": {
-                        "$id": "https://localhost:1234/id/my_identifier.json",
+                        "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
                         "type": "null"
                     }
                 }
             },
             "anyOf": [
                 { "$ref": "#/$defs/id_in_enum" },
-                { "$ref": "https://localhost:1234/id/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft2019-09/id/my_identifier.json" }
             ]
         },
         "tests": [
             {
                 "description": "exact match to enum, and type matches",
                 "data": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
                     "type": "null"
                 },
                 "valid": true

--- a/tests/draft2019-09/if-then-else.json
+++ b/tests/draft2019-09/if-then-else.json
@@ -2,6 +2,7 @@
     {
         "description": "ignore if without then or else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": {
                 "const": 0
             }
@@ -22,6 +23,7 @@
     {
         "description": "ignore then without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "then": {
                 "const": 0
             }
@@ -42,6 +44,7 @@
     {
         "description": "ignore else without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "else": {
                 "const": 0
             }
@@ -62,6 +65,7 @@
     {
         "description": "if and then without else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -90,6 +94,7 @@
     {
         "description": "if and else without then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -118,6 +123,7 @@
     {
         "description": "validate against correct branch, then vs else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -154,6 +160,7 @@
     {
         "description": "non-interference across combined schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "if": {
@@ -188,6 +195,7 @@
     {
         "description": "if with boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": true,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -208,6 +216,7 @@
     {
         "description": "if with boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "if": false,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -228,6 +237,7 @@
     {
         "description": "if appears at the end when serialized (keyword processing sequence)",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "then": { "const": "yes" },
             "else": { "const": "other" },
             "if": { "maxLength": 4 }

--- a/tests/draft2019-09/infinite-loop-detection.json
+++ b/tests/draft2019-09/infinite-loop-detection.json
@@ -2,6 +2,7 @@
     {
         "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "int": { "type": "integer" }
             },

--- a/tests/draft2019-09/items.json
+++ b/tests/draft2019-09/items.json
@@ -2,6 +2,7 @@
     {
         "description": "a schema given for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": {"type": "integer"}
         },
         "tests": [
@@ -33,6 +34,7 @@
     {
         "description": "an array of schemas for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 {"type": "integer"},
                 {"type": "string"}
@@ -77,7 +79,10 @@
     },
     {
         "description": "items with boolean schema (true)",
-        "schema": {"items": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": true
+        },
         "tests": [
             {
                 "description": "any array is valid",
@@ -93,7 +98,10 @@
     },
     {
         "description": "items with boolean schema (false)",
-        "schema": {"items": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -110,6 +118,7 @@
     {
         "description": "items with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [true, false]
         },
         "tests": [
@@ -133,6 +142,7 @@
     {
         "description": "items and subitems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "item": {
                     "type": "array",
@@ -215,6 +225,7 @@
     {
         "description": "nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "array",
             "items": {
                 "type": "array",
@@ -250,6 +261,7 @@
     {
         "description": "single-form items with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": {
                 "type": "null"
             }
@@ -265,6 +277,7 @@
     {
         "description": "array-form items with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 {
                     "type": "null"

--- a/tests/draft2019-09/maxContains.json
+++ b/tests/draft2019-09/maxContains.json
@@ -2,6 +2,7 @@
     {
         "description": "maxContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "maxContains": 1
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "maxContains with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "maxContains": 1
         },
@@ -54,6 +56,7 @@
     {
         "description": "maxContains with contains, value with a decimal",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "maxContains": 1.0
         },
@@ -73,6 +76,7 @@
     {
         "description": "minContains < maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 1,
             "maxContains": 3

--- a/tests/draft2019-09/maxItems.json
+++ b/tests/draft2019-09/maxItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxItems validation",
-        "schema": {"maxItems": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxItems": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maxItems validation with a decimal",
-        "schema": {"maxItems": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxItems": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft2019-09/maxLength.json
+++ b/tests/draft2019-09/maxLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxLength validation",
-        "schema": {"maxLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxLength": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "maxLength validation with a decimal",
-        "schema": {"maxLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxLength": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft2019-09/maxProperties.json
+++ b/tests/draft2019-09/maxProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxProperties validation",
-        "schema": {"maxProperties": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "maxProperties validation with a decimal",
-        "schema": {"maxProperties": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -53,7 +59,10 @@
     },
     {
         "description": "maxProperties = 0 means the object is empty",
-        "schema": { "maxProperties": 0 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 0
+        },
         "tests": [
             {
                 "description": "no properties is valid",

--- a/tests/draft2019-09/maximum.json
+++ b/tests/draft2019-09/maximum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maximum validation",
-        "schema": {"maximum": 3.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 3.0
+        },
         "tests": [
             {
                 "description": "below the maximum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maximum validation with unsigned integer",
-        "schema": {"maximum": 300},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 300
+        },
         "tests":  [
             {
                 "description": "below the maximum is invalid",

--- a/tests/draft2019-09/minContains.json
+++ b/tests/draft2019-09/minContains.json
@@ -2,6 +2,7 @@
     {
         "description": "minContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "minContains": 1
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "minContains=1 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 1
         },
@@ -54,6 +56,7 @@
     {
         "description": "minContains=2 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 2
         },
@@ -93,6 +96,7 @@
     {
         "description": "minContains=2 with contains with a decimal value",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 2.0
         },
@@ -112,6 +116,7 @@
     {
         "description": "maxContains = minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "maxContains": 2,
             "minContains": 2
@@ -142,6 +147,7 @@
     {
         "description": "maxContains < minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "maxContains": 1,
             "minContains": 3
@@ -172,6 +178,7 @@
     {
         "description": "minContains = 0 with no maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 0
         },
@@ -191,6 +198,7 @@
     {
         "description": "minContains = 0 with maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contains": {"const": 1},
             "minContains": 0,
             "maxContains": 1

--- a/tests/draft2019-09/minItems.json
+++ b/tests/draft2019-09/minItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minItems validation",
-        "schema": {"minItems": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minItems": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minItems validation with a decimal",
-        "schema": {"minItems": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minItems": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2019-09/minLength.json
+++ b/tests/draft2019-09/minLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minLength validation",
-        "schema": {"minLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minLength": 2
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "minLength validation with a decimal",
-        "schema": {"minLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minLength": 2.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2019-09/minProperties.json
+++ b/tests/draft2019-09/minProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minProperties validation",
-        "schema": {"minProperties": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minProperties": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "minProperties validation with a decimal",
-        "schema": {"minProperties": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minProperties": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2019-09/minimum.json
+++ b/tests/draft2019-09/minimum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minimum validation",
-        "schema": {"minimum": 1.1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": 1.1
+        },
         "tests": [
             {
                 "description": "above the minimum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minimum validation with signed integer",
-        "schema": {"minimum": -2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": -2
+        },
         "tests": [
             {
                 "description": "negative above the minimum is valid",

--- a/tests/draft2019-09/multipleOf.json
+++ b/tests/draft2019-09/multipleOf.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "by int",
-        "schema": {"multipleOf": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 2
+        },
         "tests": [
             {
                 "description": "int by int",
@@ -22,7 +25,10 @@
     },
     {
         "description": "by number",
-        "schema": {"multipleOf": 1.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 1.5
+        },
         "tests": [
             {
                 "description": "zero is multiple of anything",
@@ -43,7 +49,10 @@
     },
     {
         "description": "by small number",
-        "schema": {"multipleOf": 0.0001},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 0.0001
+        },
         "tests": [
             {
                 "description": "0.0075 is multiple of 0.0001",
@@ -59,7 +68,10 @@
     },
     {
         "description": "float division = inf",
-        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer", "multipleOf": 0.123456789
+        },
         "tests": [
             {
                 "description": "always invalid, but naive implementations may raise an overflow error",

--- a/tests/draft2019-09/not.json
+++ b/tests/draft2019-09/not.json
@@ -2,6 +2,7 @@
     {
         "description": "not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "not": {"type": "integer"}
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "not multiple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "not": {"type": ["integer", "boolean"]}
         },
         "tests": [
@@ -43,6 +45,7 @@
     {
         "description": "not more complex schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "not": {
                 "type": "object",
                 "properties": {
@@ -73,6 +76,7 @@
     {
         "description": "forbidden property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": { 
                     "not": {}
@@ -94,7 +98,10 @@
     },
     {
         "description": "not with boolean schema true",
-        "schema": {"not": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": true
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -105,7 +112,10 @@
     },
     {
         "description": "not with boolean schema false",
-        "schema": {"not": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": false
+        },
         "tests": [
             {
                 "description": "any value is valid",

--- a/tests/draft2019-09/oneOf.json
+++ b/tests/draft2019-09/oneOf.json
@@ -2,6 +2,7 @@
     {
         "description": "oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "oneOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "oneOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "oneOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all true",
-        "schema": {"oneOf": [true, true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, true, true]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "oneOf with boolean schemas, one true",
-        "schema": {"oneOf": [true, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, false, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "oneOf with boolean schemas, more than one true",
-        "schema": {"oneOf": [true, true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -100,7 +111,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all false",
-        "schema": {"oneOf": [false, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [false, false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -112,6 +126,7 @@
     {
         "description": "oneOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -153,6 +168,7 @@
     {
         "description": "oneOf with empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "oneOf": [
                 { "type": "number" },
                 {}
@@ -174,6 +190,7 @@
     {
         "description": "oneOf with required",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "oneOf": [
                 { "required": ["foo", "bar"] },
@@ -206,6 +223,7 @@
 	{
         "description": "oneOf with missing optional property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -248,6 +266,7 @@
     {
         "description": "nested oneOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "oneOf": [
                 {
                     "oneOf": [

--- a/tests/draft2019-09/optional/bignum.json
+++ b/tests/draft2019-09/optional/bignum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer",
-        "schema": { "type": "integer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "a bignum is an integer",
@@ -17,7 +20,10 @@
     },
     {
         "description": "number",
-        "schema": { "type": "number" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "a bignum is a number",
@@ -33,7 +39,10 @@
     },
     {
         "description": "string",
-        "schema": { "type": "string" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "a bignum is not a string",
@@ -44,7 +53,10 @@
     },
     {
         "description": "maximum integer comparison",
-        "schema": { "maximum": 18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for high numbers",
@@ -56,6 +68,7 @@
     {
         "description": "float comparison with high precision",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "exclusiveMaximum": 972783798187987123879878123.18878137
         },
         "tests": [
@@ -68,7 +81,10 @@
     },
     {
         "description": "minimum integer comparison",
-        "schema": { "minimum": -18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": -18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for very negative numbers",
@@ -80,6 +96,7 @@
     {
         "description": "float comparison with high precision on negative numbers",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "exclusiveMinimum": -972783798187987123879878123.18878137
         },
         "tests": [

--- a/tests/draft2019-09/optional/dependencies-compatibility.json
+++ b/tests/draft2019-09/optional/dependencies-compatibility.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependencies": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependencies": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependencies": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependencies": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]
@@ -142,6 +152,7 @@
     {
         "description": "single schema dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependencies": {
                 "bar": {
                     "properties": {
@@ -197,6 +208,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependencies": {
                 "foo": true,
                 "bar": false
@@ -228,6 +240,7 @@
     {
         "description": "schema dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "dependencies": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/ecmascript-regex.json
@@ -2,6 +2,7 @@
     {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^abc$"
         },
@@ -21,6 +22,7 @@
     {
         "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\t$"
         },
@@ -40,6 +42,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\cC$"
         },
@@ -59,6 +62,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\cc$"
         },
@@ -78,6 +82,7 @@
     {
         "description": "ECMA 262 \\d matches ascii digits only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\d$"
         },
@@ -102,6 +107,7 @@
     {
         "description": "ECMA 262 \\D matches everything but ascii digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\D$"
         },
@@ -126,6 +132,7 @@
     {
         "description": "ECMA 262 \\w matches ascii letters only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\w$"
         },
@@ -145,6 +152,7 @@
     {
         "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\W$"
         },
@@ -164,6 +172,7 @@
     {
         "description": "ECMA 262 \\s matches whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\s$"
         },
@@ -228,6 +237,7 @@
     {
         "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "string",
             "pattern": "^\\S$"
         },
@@ -291,7 +301,10 @@
     },
     {
         "description": "patterns always use unicode semantics with pattern",
-        "schema": { "pattern": "\\p{Letter}cole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "\\p{Letter}cole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -317,7 +330,10 @@
     },
     {
         "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
-        "schema": { "pattern": "\\wcole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "\\wcole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -343,7 +359,10 @@
     },
     {
         "description": "pattern with ASCII ranges",
-        "schema": { "pattern": "[a-z]cole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "[a-z]cole"
+        },
         "tests": [
             {
                 "description": "literal unicode character in json string",
@@ -364,7 +383,10 @@
     },
     {
         "description": "\\d in pattern matches [0-9], not unicode digits",
-        "schema": { "pattern": "^\\d+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^\\d+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -385,7 +407,10 @@
     },
     {
         "description": "pattern with non-ASCII digits",
-        "schema": { "pattern": "^\\p{digit}+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^\\p{digit}+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -407,6 +432,7 @@
     {
         "description": "patterns always use unicode semantics with patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "\\p{Letter}cole": true
@@ -439,6 +465,7 @@
     {
         "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "\\wcole": true
@@ -471,6 +498,7 @@
     {
         "description": "patternProperties with ASCII ranges",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "[a-z]cole": true
@@ -498,6 +526,7 @@
     {
         "description": "\\d in patternProperties matches [0-9], not unicode digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "^\\d+$": true
@@ -525,6 +554,7 @@
     {
         "description": "patternProperties with non-ASCII digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "^\\p{digit}+$": true

--- a/tests/draft2019-09/optional/float-overflow.json
+++ b/tests/draft2019-09/optional/float-overflow.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "all integers are multiples of 0.5, if overflow is handled",
-        "schema": {"type": "integer", "multipleOf": 0.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer", "multipleOf": 0.5
+        },
         "tests": [
             {
                 "description": "valid if optional overflow handling is implemented",

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date-time strings",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date strings",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of duration strings",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of e-mail addresses",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of host names",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of an internationalized e-mail addresses",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of internationalized host names",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IP addresses",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IPv6 addresses",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRI References",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRIs",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/json-pointer.json
+++ b/tests/draft2019-09/optional/format/json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of JSON-pointers (JSON String Representation)",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/regex.json
+++ b/tests/draft2019-09/optional/format/regex.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of regular expressions",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of Relative JSON Pointers (RJP)",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of time strings",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/unknown.json
+++ b/tests/draft2019-09/optional/format/unknown.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "unknown format",
-        "schema": { "format": "unknown" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "unknown"
+        },
         "tests": [
             {
                 "description": "unknown formats ignore integers",

--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URI References",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "format: uri-template",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URIs",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "a valid URL with anchor tag",

--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -2,6 +2,7 @@
     {
         "description": "uuid format",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "format": "uuid"
         },
         "tests": [

--- a/tests/draft2019-09/optional/no-schema.json
+++ b/tests/draft2019-09/optional/no-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validation without $schema",
+        "comment": "minLength is the same across all drafts",
+        "schema": {
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "a 3-character string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a 1-character string is not valid",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "a non-string is valid",
+                "data": 5,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/optional/non-bmp-regex.json
+++ b/tests/draft2019-09/optional/non-bmp-regex.json
@@ -2,7 +2,10 @@
     {
         "description": "Proper UTF-16 surrogate pair handling: pattern",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
-        "schema": { "pattern": "^🐲*$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^🐲*$"
+        },
         "tests": [
             {
                 "description": "matches empty",
@@ -45,6 +48,7 @@
         "description": "Proper UTF-16 surrogate pair handling: patternProperties",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "^🐲*$": {
                     "type": "integer"

--- a/tests/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/tests/draft2019-09/optional/refOfUnknownKeyword.json
@@ -2,6 +2,7 @@
     {
         "description": "reference of a root arbitrary keyword ",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "unknown-keyword": {"type": "integer"},
             "properties": {
                 "bar": {"$ref": "#/unknown-keyword"}
@@ -23,6 +24,7 @@
     {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}

--- a/tests/draft2019-09/pattern.json
+++ b/tests/draft2019-09/pattern.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "pattern validation",
-        "schema": {"pattern": "^a*$"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^a*$"
+        },
         "tests": [
             {
                 "description": "a matching pattern is valid",
@@ -47,7 +50,10 @@
     },
     {
         "description": "pattern is not anchored",
-        "schema": {"pattern": "a+"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "a+"
+        },
         "tests": [
             {
                 "description": "matches a substring",

--- a/tests/draft2019-09/patternProperties.json
+++ b/tests/draft2019-09/patternProperties.json
@@ -3,6 +3,7 @@
         "description":
             "patternProperties validates properties matching a regex",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "f.*o": {"type": "integer"}
             }
@@ -48,6 +49,7 @@
     {
         "description": "multiple simultaneous patternProperties are validated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "a*": {"type": "integer"},
                 "aaa*": {"maximum": 20}
@@ -89,6 +91,7 @@
     {
         "description": "regexes are not anchored by default and are case sensitive",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "[0-9]{2,}": { "type": "boolean" },
                 "X_": { "type": "string" }
@@ -120,6 +123,7 @@
     {
         "description": "patternProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "f.*": true,
                 "b.*": false
@@ -156,6 +160,7 @@
     {
         "description": "patternProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "patternProperties": {
                 "^.*bar$": {"type": "null"}
             }

--- a/tests/draft2019-09/properties.json
+++ b/tests/draft2019-09/properties.json
@@ -2,6 +2,7 @@
     {
         "description": "object properties validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"type": "string"}
@@ -44,6 +45,7 @@
         "description":
             "properties, patternProperties, additionalProperties interaction",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"type": "array", "maxItems": 3},
                 "bar": {"type": "array"}
@@ -97,6 +99,7 @@
     {
         "description": "properties with boolean schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": true,
                 "bar": false
@@ -128,6 +131,7 @@
     {
         "description": "properties with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo\nbar": {"type": "number"},
                 "foo\"bar": {"type": "number"},
@@ -167,6 +171,7 @@
     {
         "description": "properties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"type": "null"}
             }
@@ -183,6 +188,7 @@
         "description": "properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "__proto__": {"type": "number"},
                 "toString": {

--- a/tests/draft2019-09/propertyNames.json
+++ b/tests/draft2019-09/propertyNames.json
@@ -2,6 +2,7 @@
     {
         "description": "propertyNames validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "propertyNames": {"maxLength": 3}
         },
         "tests": [
@@ -46,6 +47,7 @@
     {
         "description": "propertyNames validation with pattern",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "propertyNames": { "pattern": "^a+$" }
         },
         "tests": [
@@ -74,7 +76,10 @@
     },
     {
         "description": "propertyNames with boolean schema true",
-        "schema": {"propertyNames": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": true
+        },
         "tests": [
             {
                 "description": "object with any properties is valid",
@@ -90,7 +95,10 @@
     },
     {
         "description": "propertyNames with boolean schema false",
-        "schema": {"propertyNames": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": false
+        },
         "tests": [
             {
                 "description": "object with any properties is invalid",

--- a/tests/draft2019-09/recursiveRef.json
+++ b/tests/draft2019-09/recursiveRef.json
@@ -2,6 +2,7 @@
     {
         "description": "$recursiveRef without $recursiveAnchor works like $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": { "$recursiveRef": "#" }
             },
@@ -33,6 +34,7 @@
     {
         "description": "$recursiveRef without using nesting",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef2/schema.json",
             "$defs": {
                 "myobject": {
@@ -83,6 +85,7 @@
     {
         "description": "$recursiveRef with nesting",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef3/schema.json",
             "$recursiveAnchor": true,
             "$defs": {
@@ -134,6 +137,7 @@
     {
         "description": "$recursiveRef with $recursiveAnchor: false works like $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef4/schema.json",
             "$recursiveAnchor": false,
             "$defs": {
@@ -185,6 +189,7 @@
     {
         "description": "$recursiveRef with no $recursiveAnchor works like $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef5/schema.json",
             "$defs": {
                 "myobject": {
@@ -235,6 +240,7 @@
     {
         "description": "$recursiveRef with no $recursiveAnchor in the initial target schema resource",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef6/base.json",
             "$recursiveAnchor": true,
             "anyOf": [
@@ -273,6 +279,7 @@
     {
         "description": "$recursiveRef with no $recursiveAnchor in the outer schema resource",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:4242/recursiveRef7/base.json",
             "anyOf": [
                 { "type": "boolean" },
@@ -310,6 +317,7 @@
     {
         "description": "multiple dynamic paths to the $recursiveRef keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "recursiveRef8_main.json",
             "$defs": {
                 "inner": {
@@ -356,6 +364,7 @@
     {
         "description": "dynamic $recursiveRef destination (not predictable at schema compile time)",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "main.json",
             "$defs": {
                 "inner": {

--- a/tests/draft2019-09/recursiveRef.json
+++ b/tests/draft2019-09/recursiveRef.json
@@ -35,7 +35,7 @@
         "description": "$recursiveRef without using nesting",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef2/schema.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef2/schema.json",
             "$defs": {
                 "myobject": {
                     "$id": "myobject.json",
@@ -86,7 +86,7 @@
         "description": "$recursiveRef with nesting",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef3/schema.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef3/schema.json",
             "$recursiveAnchor": true,
             "$defs": {
                 "myobject": {
@@ -138,7 +138,7 @@
         "description": "$recursiveRef with $recursiveAnchor: false works like $ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef4/schema.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef4/schema.json",
             "$recursiveAnchor": false,
             "$defs": {
                 "myobject": {
@@ -190,7 +190,7 @@
         "description": "$recursiveRef with no $recursiveAnchor works like $ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef5/schema.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef5/schema.json",
             "$defs": {
                 "myobject": {
                     "$id": "myobject.json",
@@ -241,14 +241,14 @@
         "description": "$recursiveRef with no $recursiveAnchor in the initial target schema resource",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef6/base.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef6/base.json",
             "$recursiveAnchor": true,
             "anyOf": [
                 { "type": "boolean" },
                 {
                     "type": "object",
                     "additionalProperties": {
-                        "$id": "http://localhost:4242/recursiveRef6/inner.json",
+                        "$id": "http://localhost:4242/draft2019-09/recursiveRef6/inner.json",
                         "$comment": "there is no $recursiveAnchor: true here, so we do NOT recurse to the base",
                         "anyOf": [
                             { "type": "integer" },
@@ -280,13 +280,13 @@
         "description": "$recursiveRef with no $recursiveAnchor in the outer schema resource",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:4242/recursiveRef7/base.json",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef7/base.json",
             "anyOf": [
                 { "type": "boolean" },
                 {
                     "type": "object",
                     "additionalProperties": {
-                        "$id": "http://localhost:4242/recursiveRef7/inner.json",
+                        "$id": "http://localhost:4242/draft2019-09/recursiveRef7/inner.json",
                         "$recursiveAnchor": true,
                         "anyOf": [
                             { "type": "integer" },

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -285,7 +285,7 @@
         "description": "Recursive references between schemas",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/tree",
+            "$id": "http://localhost:1234/draft2019-09/tree",
             "description": "tree of nodes",
             "type": "object",
             "properties": {
@@ -298,7 +298,7 @@
             "required": ["meta", "nodes"],
             "$defs": {
                 "node": {
-                    "$id": "http://localhost:1234/node",
+                    "$id": "http://localhost:1234/draft2019-09/node",
                     "description": "node",
                     "type": "object",
                     "properties": {
@@ -601,17 +601,17 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/ref-and-id1/base.json",
+            "$id": "/draft2019-09/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id1/int.json",
                     "$id": "int.json",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id1-int.json",
-                    "$id": "/ref-and-id1-int.json",
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id1-int.json",
+                    "$id": "/draft2019-09/ref-and-id1-int.json",
                     "maximum": 2
                 }
             }
@@ -634,17 +634,17 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/ref-and-id2/base.json",
+            "$id": "/draft2019-09/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /ref-and-id2/base.json/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id2/base.json/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
                     "$anchor": "bigint",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
-                    "$id": "/ref-and-id2/",
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2019-09/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2
                 }

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -2,6 +2,7 @@
     {
         "description": "root pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"$ref": "#"}
             },
@@ -33,6 +34,7 @@
     {
         "description": "relative pointer ref to object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"$ref": "#/properties/foo"}
@@ -54,6 +56,7 @@
     {
         "description": "relative pointer ref to array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 {"type": "integer"},
                 {"$ref": "#/items/0"}
@@ -75,6 +78,7 @@
     {
         "description": "escaped pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "tilde~field": {"type": "integer"},
                 "slash/field": {"type": "integer"},
@@ -122,6 +126,7 @@
     {
         "description": "nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "a": {"type": "integer"},
                 "b": {"$ref": "#/$defs/a"},
@@ -145,6 +150,7 @@
     {
         "description": "ref applies alongside sibling keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "reffed": {
                     "type": "array"
@@ -178,6 +184,7 @@
     {
         "description": "remote ref, containing refs itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "https://json-schema.org/draft/2019-09/schema"
         },
         "tests": [
@@ -196,6 +203,7 @@
     {
         "description": "property named $ref that is not a reference",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "$ref": {"type": "string"}
             }
@@ -216,6 +224,7 @@
     {
         "description": "property named $ref, containing an actual $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "$ref": {"$ref": "#/$defs/is-string"}
             },
@@ -241,6 +250,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": true
@@ -257,6 +267,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": false
@@ -273,6 +284,7 @@
     {
         "description": "Recursive references between schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/tree",
             "description": "tree of nodes",
             "type": "object",
@@ -361,6 +373,7 @@
     {
         "description": "refs with quote",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
             },
@@ -388,6 +401,7 @@
     {
         "description": "ref creates new scope when adjacent to keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "A": {
                     "unevaluatedProperties": false
@@ -413,6 +427,7 @@
     {
         "description": "naive replacement of $ref with its destination is not correct",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "a_string": { "type": "string" }
             },
@@ -441,6 +456,7 @@
     {
         "description": "refs with relative uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://example.com/schema-relative-uri-defs1.json",
             "properties": {
                 "foo": {
@@ -493,6 +509,7 @@
     {
         "description": "relative refs with absolute uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
             "properties": {
                 "foo": {
@@ -545,6 +562,7 @@
     {
         "description": "$id must be resolved against nearest parent, not just immediate parent",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://example.com/a.json",
             "$defs": {
                 "x": {
@@ -581,6 +599,7 @@
     {
         "description": "order of evaluation: $id and $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$id": "/ref-and-id1/base.json",
             "$ref": "int.json",
@@ -613,6 +632,7 @@
     {
         "description": "order of evaluation: $id and $anchor and $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$id": "/ref-and-id2/base.json",
             "$ref": "#bigint",
@@ -646,6 +666,7 @@
     {
         "description": "simple URN base URI with $ref via the URN",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
             "minimum": 30,
@@ -669,6 +690,7 @@
     {
         "description": "simple URN base URI with JSON pointer",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
             "properties": {
@@ -694,6 +716,7 @@
     {
         "description": "URN base URI with NSS",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "RFC 8141 §2.2",
             "$id": "urn:example:1/406/47452/2",
             "properties": {
@@ -719,6 +742,7 @@
     {
         "description": "URN base URI with r-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "RFC 8141 §2.3.1",
             "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
             "properties": {
@@ -744,6 +768,7 @@
     {
         "description": "URN base URI with q-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "RFC 8141 §2.3.2",
             "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
             "properties": {
@@ -769,6 +794,7 @@
     {
         "description": "URN base URI with f-component",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
             "$ref": "https://json-schema.org/draft/2019-09/schema"
         },
@@ -783,6 +809,7 @@
     {
         "description": "URN base URI with URN and JSON pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
@@ -807,6 +834,7 @@
     {
         "description": "URN base URI with URN and anchor ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -3,7 +3,7 @@
         "description": "remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$ref": "http://localhost:1234/integer.json"
+            "$ref": "http://localhost:1234/draft2019-09/integer.json"
         },
         "tests": [
             {
@@ -22,7 +22,7 @@
         "description": "fragment within remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"
+            "$ref": "http://localhost:1234/draft2019-09/subSchemas-defs.json#/$defs/integer"
         },
         "tests": [
             {
@@ -41,7 +41,7 @@
         "description": "ref within remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
+            "$ref": "http://localhost:1234/draft2019-09/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -60,7 +60,7 @@
         "description": "base URI change",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/",
+            "$id": "http://localhost:1234/draft2019-09/",
             "items": {
                 "$id": "baseUriChange/",
                 "items": {"$ref": "folderInteger.json"}
@@ -83,7 +83,7 @@
         "description": "base URI change - change folder",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "$id": "http://localhost:1234/draft2019-09/scope_change_defs1.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
             "$defs": {
@@ -111,7 +111,7 @@
         "description": "base URI change - change folder in subschema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "$id": "http://localhost:1234/draft2019-09/scope_change_defs2.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
             "$defs": {
@@ -143,7 +143,7 @@
         "description": "root ref in remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/object",
+            "$id": "http://localhost:1234/draft2019-09/object",
             "type": "object",
             "properties": {
                 "name": {"$ref": "name-defs.json#/$defs/orNull"}
@@ -179,7 +179,7 @@
         "description": "remote ref with ref to defs",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
+            "$id": "http://localhost:1234/draft2019-09/schema-remote-ref-ref-defs1.json",
             "$ref": "ref-and-defs.json"
         },
         "tests": [
@@ -203,7 +203,7 @@
         "description": "Location-independent identifier in remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
+            "$ref": "http://localhost:1234/draft2019-09/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -222,7 +222,7 @@
         "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://localhost:1234/some-id",
+            "$id": "http://localhost:1234/draft2019-09/some-id",
             "properties": {
                 "name": {"$ref": "nested/foo-ref-string.json"}
             }

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "remote ref",
-        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/integer.json"
+        },
         "tests": [
             {
                 "description": "remote ref valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"
+        },
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -34,6 +40,7 @@
     {
         "description": "ref within remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
@@ -52,6 +59,7 @@
     {
         "description": "base URI change",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/",
             "items": {
                 "$id": "baseUriChange/",
@@ -74,6 +82,7 @@
     {
         "description": "base URI change - change folder",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/scope_change_defs1.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
@@ -101,6 +110,7 @@
     {
         "description": "base URI change - change folder in subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
@@ -132,6 +142,7 @@
     {
         "description": "root ref in remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
@@ -167,6 +178,7 @@
     {
         "description": "remote ref with ref to defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
             "$ref": "ref-and-defs.json"
         },
@@ -190,6 +202,7 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
@@ -208,6 +221,7 @@
     {
         "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "http://localhost:1234/some-id",
             "properties": {
                 "name": {"$ref": "nested/foo-ref-string.json"}

--- a/tests/draft2019-09/required.json
+++ b/tests/draft2019-09/required.json
@@ -2,6 +2,7 @@
     {
         "description": "required validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {},
                 "bar": {}
@@ -39,6 +40,7 @@
     {
         "description": "required default validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {}
             }
@@ -54,6 +56,7 @@
     {
         "description": "required with empty array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {}
             },
@@ -70,6 +73,7 @@
     {
         "description": "required with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "required": [
                 "foo\nbar",
                 "foo\"bar",
@@ -105,7 +109,10 @@
     {
         "description": "required properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
-        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
         "tests": [
             {
                 "description": "ignores arrays",

--- a/tests/draft2019-09/type.json
+++ b/tests/draft2019-09/type.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer type matches integers",
-        "schema": {"type": "integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "an integer is an integer",
@@ -52,7 +55,10 @@
     },
     {
         "description": "number type matches numbers",
-        "schema": {"type": "number"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "an integer is a number",
@@ -103,7 +109,10 @@
     },
     {
         "description": "string type matches strings",
-        "schema": {"type": "string"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "1 is not a string",
@@ -154,7 +163,10 @@
     },
     {
         "description": "object type matches objects",
-        "schema": {"type": "object"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object"
+        },
         "tests": [
             {
                 "description": "an integer is not an object",
@@ -195,7 +207,10 @@
     },
     {
         "description": "array type matches arrays",
-        "schema": {"type": "array"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "array"
+        },
         "tests": [
             {
                 "description": "an integer is not an array",
@@ -236,7 +251,10 @@
     },
     {
         "description": "boolean type matches booleans",
-        "schema": {"type": "boolean"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "boolean"
+        },
         "tests": [
             {
                 "description": "an integer is not a boolean",
@@ -292,7 +310,10 @@
     },
     {
         "description": "null type matches only the null object",
-        "schema": {"type": "null"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "null"
+        },
         "tests": [
             {
                 "description": "an integer is not null",
@@ -348,7 +369,10 @@
     },
     {
         "description": "multiple types can be specified in an array",
-        "schema": {"type": ["integer", "string"]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": ["integer", "string"]
+        },
         "tests": [
             {
                 "description": "an integer is valid",
@@ -390,6 +414,7 @@
     {
         "description": "type as array with one item",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": ["string"]
         },
         "tests": [
@@ -408,6 +433,7 @@
     {
         "description": "type: array or object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": ["array", "object"]
         },
         "tests": [
@@ -441,6 +467,7 @@
     {
         "description": "type: array, object or null",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": ["array", "object", "null"]
         },
         "tests": [

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "unevaluatedItems true",
-        "schema": { "unevaluatedItems": true },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": true
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -17,7 +20,10 @@
     },
     {
         "description": "unevaluatedItems false",
-        "schema": { "unevaluatedItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -33,7 +39,10 @@
     },
     {
         "description": "unevaluatedItems as schema",
-        "schema": { "unevaluatedItems": { "type": "string" } },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -55,6 +64,7 @@
     {
         "description": "unevaluatedItems with uniform items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": { "type": "string" },
             "unevaluatedItems": false
         },
@@ -69,6 +79,7 @@
     {
         "description": "unevaluatedItems with tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "type": "string" }
             ],
@@ -90,6 +101,7 @@
     {
         "description": "unevaluatedItems with additionalItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "type": "string" }
             ],
@@ -107,6 +119,7 @@
     {
         "description": "unevaluatedItems with nested tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "type": "string" }
             ],
@@ -136,6 +149,7 @@
     {
         "description": "unevaluatedItems with nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "unevaluatedItems": {"type": "boolean"},
             "anyOf": [
                 { "items": {"type": "string"} },
@@ -163,6 +177,7 @@
     {
         "description": "unevaluatedItems with nested items and additionalItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "items": [
@@ -189,6 +204,7 @@
     {
         "description": "unevaluatedItems with nested unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "items": [
@@ -215,6 +231,7 @@
     {
         "description": "unevaluatedItems with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "const": "foo" }
             ],
@@ -261,6 +278,7 @@
     {
         "description": "unevaluatedItems with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "const": "foo" }
             ],
@@ -296,6 +314,7 @@
     {
         "description": "unevaluatedItems with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
                 { "const": "foo" }
             ],
@@ -320,6 +339,7 @@
     {
         "description": "unevaluatedItems with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [ { "const": "foo" } ],
             "if": {
                 "items": [
@@ -370,6 +390,7 @@
     {
         "description": "unevaluatedItems with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [true],
             "unevaluatedItems": false
         },
@@ -389,6 +410,7 @@
     {
         "description": "unevaluatedItems with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "#/$defs/bar",
             "items": [
                 { "type": "string" }
@@ -419,6 +441,7 @@
     {
         "description": "unevaluatedItems can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "items": [ true ]
@@ -437,6 +460,7 @@
     {
         "description": "item is evaluated in an uncle schema to unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {
                     "items": [
@@ -482,7 +506,10 @@
     },
     {
         "description": "non-array instances are valid",
-        "schema": {"unevaluatedItems": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -519,6 +546,7 @@
     {
         "description": "unevaluatedItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "unevaluatedItems": {
                 "type": "null"
             }

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -2,6 +2,7 @@
     {
         "description": "unevaluatedProperties true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "unevaluatedProperties": true
         },
@@ -23,6 +24,7 @@
     {
         "description": "unevaluatedProperties schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "unevaluatedProperties": {
                 "type": "string",
@@ -54,6 +56,7 @@
     {
         "description": "unevaluatedProperties false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -75,6 +78,7 @@
     {
         "description": "unevaluatedProperties with adjacent properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -102,6 +106,7 @@
     {
         "description": "unevaluatedProperties with adjacent patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "patternProperties": {
                 "^foo": { "type": "string" }
@@ -129,6 +134,7 @@
     {
         "description": "unevaluatedProperties with adjacent additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -157,6 +163,7 @@
     {
         "description": "unevaluatedProperties with nested properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -193,6 +200,7 @@
     {
         "description": "unevaluatedProperties with nested patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -229,6 +237,7 @@
     {
         "description": "unevaluatedProperties with nested additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -261,6 +270,7 @@
     {
         "description": "unevaluatedProperties with nested unevaluatedProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -296,6 +306,7 @@
     {
         "description": "unevaluatedProperties with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -364,6 +375,7 @@
     {
         "description": "unevaluatedProperties with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -407,6 +419,7 @@
     {
         "description": "unevaluatedProperties with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -435,6 +448,7 @@
     {
         "description": "unevaluatedProperties with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -494,6 +508,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, then not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -547,6 +562,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, else not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -600,6 +616,7 @@
     {
         "description": "unevaluatedProperties with dependentSchemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -635,6 +652,7 @@
     {
         "description": "unevaluatedProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -662,6 +680,7 @@
     {
         "description": "unevaluatedProperties with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "$ref": "#/$defs/bar",
             "properties": {
@@ -699,6 +718,7 @@
     {
         "description": "unevaluatedProperties can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "allOf": [
                 {
                     "properties": {
@@ -723,6 +743,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -755,6 +776,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -787,6 +809,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -819,6 +842,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -851,6 +875,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, true with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -885,6 +910,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, false with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -920,6 +946,7 @@
         "description": "property is evaluated in an uncle schema to unevaluatedProperties",
         "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "foo": {
@@ -971,6 +998,7 @@
     {
         "description": "in-place applicator siblings, allOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1016,6 +1044,7 @@
     {
         "description": "in-place applicator siblings, anyOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1061,6 +1090,7 @@
     {
         "description": "unevaluatedProperties + single cyclic ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
             "properties": {
                 "x": { "$ref": "#" }
@@ -1108,6 +1138,7 @@
     {
         "description": "unevaluatedProperties + ref inside allOf / oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "one": {
                     "properties": { "a": true }
@@ -1178,6 +1209,7 @@
     {
         "description": "dynamic evalation inside nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "one": {
                     "oneOf": [
@@ -1310,7 +1342,10 @@
     },
     {
         "description": "non-object instances are valid",
-        "schema": {"unevaluatedProperties": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedProperties": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -1347,6 +1382,7 @@
     {
         "description": "unevaluatedProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "unevaluatedProperties": {
                 "type": "null"
             }

--- a/tests/draft2019-09/uniqueItems.json
+++ b/tests/draft2019-09/uniqueItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "uniqueItems validation",
-        "schema": {"uniqueItems": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "uniqueItems": true
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -149,6 +152,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
@@ -198,6 +202,7 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true,
             "additionalItems": false
@@ -232,7 +237,10 @@
     },
     {
         "description": "uniqueItems=false validation",
-        "schema": { "uniqueItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "uniqueItems": false
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -320,6 +328,7 @@
     {
         "description": "uniqueItems=false with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false
         },
@@ -369,6 +378,7 @@
     {
         "description": "uniqueItems=false with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false,
             "additionalItems": false

--- a/tests/draft2019-09/unknownKeyword.json
+++ b/tests/draft2019-09/unknownKeyword.json
@@ -3,6 +3,7 @@
         "description": "$id inside an unknown keyword is not a real identifier",
         "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$defs": {
                 "id_in_unknown0": {
                     "not": {

--- a/tests/draft2019-09/unknownKeyword.json
+++ b/tests/draft2019-09/unknownKeyword.json
@@ -9,21 +9,21 @@
                     "not": {
                         "array_of_schemas": [
                             {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
                               "type": "null"
                             }
                         ]
                     }
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
                     "type": "string"
                 },
                 "id_in_unknown1": {
                     "not": {
                         "object_of_schemas": {
                             "foo": {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
                               "type": "integer"
                             }
                         }
@@ -33,7 +33,7 @@
             "anyOf": [
                 { "$ref": "#/$defs/id_in_unknown0" },
                 { "$ref": "#/$defs/id_in_unknown1" },
-                { "$ref": "https://localhost:1234/unknownKeyword/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json" }
             ]
         },
         "tests": [

--- a/tests/draft2019-09/vocabulary.json
+++ b/tests/draft2019-09/vocabulary.json
@@ -2,6 +2,7 @@
     {
         "description": "schema that uses custom metaschema with with no validation vocabulary",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "https://schema/using/no/validation",
             "$schema": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
             "properties": {

--- a/tests/draft2019-09/vocabulary.json
+++ b/tests/draft2019-09/vocabulary.json
@@ -2,7 +2,6 @@
     {
         "description": "schema that uses custom metaschema with with no validation vocabulary",
         "schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$id": "https://schema/using/no/validation",
             "$schema": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
             "properties": {

--- a/tests/draft2020-12/additionalProperties.json
+++ b/tests/draft2020-12/additionalProperties.json
@@ -3,6 +3,7 @@
         "description":
             "additionalProperties being false does not allow other properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {"foo": {}, "bar": {}},
             "patternProperties": { "^v": {} },
             "additionalProperties": false
@@ -43,6 +44,7 @@
     {
         "description": "non-ASCII pattern with additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {"^á": {}},
             "additionalProperties": false
         },
@@ -62,6 +64,7 @@
     {
         "description": "additionalProperties with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {"foo": {}, "bar": {}},
             "additionalProperties": {"type": "boolean"}
         },
@@ -87,6 +90,7 @@
         "description":
             "additionalProperties can exist by itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "additionalProperties": {"type": "boolean"}
         },
         "tests": [
@@ -104,7 +108,10 @@
     },
     {
         "description": "additionalProperties are allowed by default",
-        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
         "tests": [
             {
                 "description": "additional properties are allowed",
@@ -116,6 +123,7 @@
     {
         "description": "additionalProperties does not look in applicators",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {"properties": {"foo": {}}}
             ],
@@ -132,6 +140,7 @@
     {
         "description": "additionalProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "additionalProperties": {
                 "type": "null"
             }

--- a/tests/draft2020-12/allOf.json
+++ b/tests/draft2020-12/allOf.json
@@ -2,6 +2,7 @@
     {
         "description": "allOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "properties": {
@@ -43,6 +44,7 @@
     {
         "description": "allOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {"bar": {"type": "integer"}},
             "required": ["bar"],
             "allOf" : [
@@ -91,6 +93,7 @@
     {
         "description": "allOf simple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {"maximum": 30},
                 {"minimum": 20}
@@ -111,7 +114,10 @@
     },
     {
         "description": "allOf with boolean schemas, all true",
-        "schema": {"allOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -122,7 +128,10 @@
     },
     {
         "description": "allOf with boolean schemas, some false",
-        "schema": {"allOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -133,7 +142,10 @@
     },
     {
         "description": "allOf with boolean schemas, all false",
-        "schema": {"allOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -145,6 +157,7 @@
     {
         "description": "allOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {}
             ]
@@ -160,6 +173,7 @@
     {
         "description": "allOf with two empty schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {},
                 {}
@@ -176,6 +190,7 @@
     {
         "description": "allOf with the first empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {},
                 { "type": "number" }
@@ -197,6 +212,7 @@
     {
         "description": "allOf with the last empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 { "type": "number" },
                 {}
@@ -218,6 +234,7 @@
     {
         "description": "nested allOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "allOf": [
@@ -244,6 +261,7 @@
     {
         "description": "allOf combined with anyOf, oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [ { "multipleOf": 2 } ],
             "anyOf": [ { "multipleOf": 3 } ],
             "oneOf": [ { "multipleOf": 5 } ]

--- a/tests/draft2020-12/anchor.json
+++ b/tests/draft2020-12/anchor.json
@@ -28,10 +28,10 @@
         "description": "Location-independent identifier with absolute URI",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "http://localhost:1234/bar#foo",
+            "$ref": "http://localhost:1234/draft2020-12/bar#foo",
             "$defs": {
                 "A": {
-                    "$id": "http://localhost:1234/bar",
+                    "$id": "http://localhost:1234/draft2020-12/bar",
                     "$anchor": "foo",
                     "type": "integer"
                 }
@@ -54,8 +54,8 @@
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/root",
-            "$ref": "http://localhost:1234/nested.json#foo",
+            "$id": "http://localhost:1234/draft2020-12/root",
+            "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
             "$defs": {
                 "A": {
                     "$id": "nested.json",
@@ -143,7 +143,7 @@
         "description": "same $anchor with different base uri",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/foobar",
+            "$id": "http://localhost:1234/draft2020-12/foobar",
             "$defs": {
                 "A": {
                     "$id": "child1",

--- a/tests/draft2020-12/anchor.json
+++ b/tests/draft2020-12/anchor.json
@@ -2,6 +2,7 @@
     {
         "description": "Location-independent identifier",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "#foo",
             "$defs": {
                 "A": {
@@ -26,6 +27,7 @@
     {
         "description": "Location-independent identifier with absolute URI",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://localhost:1234/bar#foo",
             "$defs": {
                 "A": {
@@ -51,6 +53,7 @@
     {
         "description": "Location-independent identifier with base URI change in subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/root",
             "$ref": "http://localhost:1234/nested.json#foo",
             "$defs": {
@@ -82,6 +85,7 @@
         "description": "$anchor inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $anchor buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "anchor_in_enum": {
                     "enum": [
@@ -138,6 +142,7 @@
     {
         "description": "same $anchor with different base uri",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/foobar",
             "$defs": {
                 "A": {
@@ -173,6 +178,7 @@
     {
         "description": "non-schema object containing an $anchor property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "const_not_anchor": {
                     "const": {
@@ -204,7 +210,10 @@
     {
         "description": "invalid anchors",
         "comment": "Section 8.2.2",
-        "schema": { "$ref": "https://json-schema.org/draft/2020-12/schema" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
         "tests": [
             {
                 "description": "MUST start with a letter (and not #)",

--- a/tests/draft2020-12/anyOf.json
+++ b/tests/draft2020-12/anyOf.json
@@ -2,6 +2,7 @@
     {
         "description": "anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "anyOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "anyOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "anyOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all true",
-        "schema": {"anyOf": [true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, true]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "anyOf with boolean schemas, some true",
-        "schema": {"anyOf": [true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "anyOf with boolean schemas, all false",
-        "schema": {"anyOf": [false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -101,6 +112,7 @@
     {
         "description": "anyOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "anyOf": [
                 {
                     "properties": {
@@ -142,6 +154,7 @@
     {
         "description": "anyOf with one empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "anyOf": [
                 { "type": "number" },
                 {}
@@ -163,6 +176,7 @@
     {
         "description": "nested anyOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "anyOf": [
                 {
                     "anyOf": [

--- a/tests/draft2020-12/const.json
+++ b/tests/draft2020-12/const.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "const validation",
-        "schema": {"const": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 2
+        },
         "tests": [
             {
                 "description": "same value is valid",
@@ -22,7 +25,10 @@
     },
     {
         "description": "const with object",
-        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
         "tests": [
             {
                 "description": "same object is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "const with array",
-        "schema": {"const": [{ "foo": "bar" }]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [{ "foo": "bar" }]
+        },
         "tests": [
             {
                 "description": "same array is valid",
@@ -69,7 +78,10 @@
     },
     {
         "description": "const with null",
-        "schema": {"const": null},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": null
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -85,7 +97,10 @@
     },
     {
         "description": "const with false does not match 0",
-        "schema": {"const": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": false
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -106,7 +121,10 @@
     },
     {
         "description": "const with true does not match 1",
-        "schema": {"const": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": true
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -127,7 +145,10 @@
     },
     {
         "description": "const with [false] does not match [0]",
-        "schema": {"const": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [false]
+        },
         "tests": [
             {
                 "description": "[false] is valid",
@@ -148,7 +169,10 @@
     },
     {
         "description": "const with [true] does not match [1]",
-        "schema": {"const": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [true]
+        },
         "tests": [
             {
                 "description": "[true] is valid",
@@ -169,7 +193,10 @@
     },
     {
         "description": "const with {\"a\": false} does not match {\"a\": 0}",
-        "schema": {"const": {"a": false}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": false}
+        },
         "tests": [
             {
                 "description": "{\"a\": false} is valid",
@@ -190,7 +217,10 @@
     },
     {
         "description": "const with {\"a\": true} does not match {\"a\": 1}",
-        "schema": {"const": {"a": true}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": true}
+        },
         "tests": [
             {
                 "description": "{\"a\": true} is valid",
@@ -211,7 +241,10 @@
     },
     {
         "description": "const with 0 does not match other zero-like types",
-        "schema": {"const": 0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 0
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -247,7 +280,10 @@
     },
     {
         "description": "const with 1 does not match true",
-        "schema": {"const": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 1
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -268,7 +304,10 @@
     },
     {
         "description": "const with -2.0 matches integer and float types",
-        "schema": {"const": -2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": -2.0
+        },
         "tests": [
             {
                 "description": "integer -2 is valid",
@@ -299,7 +338,10 @@
     },
     {
         "description": "float and integers are equal up to 64-bit representation limits",
-        "schema": {"const": 9007199254740992},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 9007199254740992
+        },
         "tests": [
             {
                 "description": "integer is valid",
@@ -325,7 +367,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "const": "hello\u0000there" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": "hello\u0000there"
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft2020-12/contains.json
+++ b/tests/draft2020-12/contains.json
@@ -2,6 +2,7 @@
     {
         "description": "contains keyword validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"minimum": 5}
         },
         "tests": [
@@ -40,6 +41,7 @@
     {
         "description": "contains keyword with const keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": { "const": 5 }
         },
         "tests": [
@@ -62,7 +64,10 @@
     },
     {
         "description": "contains keyword with boolean schema true",
-        "schema": {"contains": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": true
+        },
         "tests": [
             {
                 "description": "any non-empty array is valid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "contains keyword with boolean schema false",
-        "schema": {"contains": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -100,6 +108,7 @@
     {
         "description": "items + contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "items": { "multipleOf": 2 },
             "contains": { "multipleOf": 3 }
         },
@@ -129,6 +138,7 @@
     {
         "description": "contains with false if subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {
                 "if": false,
                 "else": true
@@ -150,6 +160,7 @@
     {
         "description": "contains with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {
                 "type": "null"
             }

--- a/tests/draft2020-12/content.json
+++ b/tests/draft2020-12/content.json
@@ -2,6 +2,7 @@
     {
         "description": "validation of string-encoded content based on media type",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contentMediaType": "application/json"
         },
         "tests": [
@@ -25,6 +26,7 @@
     {
         "description": "validation of binary string-encoding",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contentEncoding": "base64"
         },
         "tests": [
@@ -48,6 +50,7 @@
     {
         "description": "validation of binary-encoded media type documents",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64"
         },
@@ -77,6 +80,7 @@
     {
         "description": "validation of binary-encoded media type documents with schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
             "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }

--- a/tests/draft2020-12/default.json
+++ b/tests/draft2020-12/default.json
@@ -2,6 +2,7 @@
     {
         "description": "invalid type for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {
                     "type": "integer",
@@ -25,6 +26,7 @@
     {
         "description": "invalid string value for default",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "bar": {
                     "type": "string",
@@ -49,6 +51,7 @@
     {
         "description": "the default keyword does not do anything if the property is missing",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "alpha": {

--- a/tests/draft2020-12/defs.json
+++ b/tests/draft2020-12/defs.json
@@ -2,6 +2,7 @@
     {
         "description": "validate definition against metaschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [

--- a/tests/draft2020-12/dependentRequired.json
+++ b/tests/draft2020-12/dependentRequired.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependentRequired": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependentRequired": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependentRequired": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependentRequired": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]

--- a/tests/draft2020-12/dependentSchemas.json
+++ b/tests/draft2020-12/dependentSchemas.json
@@ -2,6 +2,7 @@
     {
         "description": "single dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependentSchemas": {
                 "bar": {
                     "properties": {
@@ -57,6 +58,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependentSchemas": {
                 "foo": true,
                 "bar": false
@@ -88,6 +90,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependentSchemas": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -2,6 +2,7 @@
     {
         "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
             "type": "array",
             "items": { "$dynamicRef": "#items" },
@@ -28,6 +29,7 @@
     {
         "description": "A $dynamicRef to an $anchor in the same schema resource behaves like a normal $ref to an $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamicRef-anchor-same-schema/root",
             "type": "array",
             "items": { "$dynamicRef": "#items" },
@@ -54,6 +56,7 @@
     {
         "description": "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/ref-dynamicAnchor-same-schema/root",
             "type": "array",
             "items": { "$ref": "#items" },
@@ -80,6 +83,7 @@
     {
         "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
             "$ref": "list",
             "$defs": {
@@ -116,6 +120,7 @@
     {
         "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
             "$ref": "intermediate-scope",
             "$defs": {
@@ -156,6 +161,7 @@
     {
         "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
             "$ref": "list",
             "$defs": {
@@ -187,6 +193,7 @@
     {
         "description": "A $dynamicRef without a matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-resolution-without-bookend/root",
             "$ref": "list",
             "$defs": {
@@ -218,6 +225,7 @@
     {
         "description": "A $dynamicRef with a non-matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/unmatched-dynamic-anchor/root",
             "$ref": "list",
             "$defs": {
@@ -250,6 +258,7 @@
     {
         "description": "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/relative-dynamic-reference/root",
             "$dynamicAnchor": "meta",
             "type": "object",
@@ -301,6 +310,7 @@
     {
         "description": "A $dynamicRef that initially resolves to a schema without a matching $dynamicAnchor behaves like a normal $ref to $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/relative-dynamic-reference-without-bookend/root",
             "$dynamicAnchor": "meta",
             "type": "object",
@@ -342,6 +352,7 @@
     {
         "description": "multiple dynamic paths to the $dynamicRef keyword",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
             "$defs": {
                 "inner": {
@@ -388,6 +399,7 @@
     {
         "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
             "if": {
                 "$id": "first_scope",
@@ -445,6 +457,7 @@
     {
         "description": "strict-tree schema, guards against misspelled properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/strict-tree.json",
             "$dynamicAnchor": "node",
 
@@ -475,6 +488,7 @@
     {
         "description": "tests for implementation dynamic anchor and reference link",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/strict-extendible.json",
             "$ref": "extendible-dynamic-ref.json",
             "$defs": {
@@ -519,6 +533,7 @@
     {
         "description": "$ref and $dynamicAnchor are independent of order - $defs first",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/strict-extendible-allof-defs-first.json",
             "allOf": [
                 {
@@ -569,6 +584,7 @@
     {
         "description": "$ref and $dynamicAnchor are independent of order - $ref first",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/strict-extendible-allof-ref-first.json",
             "allOf": [
                 {

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -458,7 +458,7 @@
         "description": "strict-tree schema, guards against misspelled properties",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/strict-tree.json",
+            "$id": "http://localhost:1234/draft2020-12/strict-tree.json",
             "$dynamicAnchor": "node",
 
             "$ref": "tree.json",
@@ -489,7 +489,7 @@
         "description": "tests for implementation dynamic anchor and reference link",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/strict-extendible.json",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible.json",
             "$ref": "extendible-dynamic-ref.json",
             "$defs": {
                 "elements": {
@@ -534,7 +534,7 @@
         "description": "$ref and $dynamicAnchor are independent of order - $defs first",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/strict-extendible-allof-defs-first.json",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-defs-first.json",
             "allOf": [
                 {
                     "$ref": "extendible-dynamic-ref.json"
@@ -585,7 +585,7 @@
         "description": "$ref and $dynamicAnchor are independent of order - $ref first",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/strict-extendible-allof-ref-first.json",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-ref-first.json",
             "allOf": [
                 {
                     "$defs": {

--- a/tests/draft2020-12/enum.json
+++ b/tests/draft2020-12/enum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "simple enum validation",
-        "schema": {"enum": [1, 2, 3]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1, 2, 3]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "heterogeneous enum validation",
-        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
         "tests": [
             {
                 "description": "one of the enum is valid",
@@ -48,7 +54,10 @@
     },
     {
         "description": "heterogeneous enum-with-null validation",
-        "schema": { "enum": [6, null] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, null]
+        },
         "tests": [
             {
                 "description": "null is valid",
@@ -70,6 +79,7 @@
     {
         "description": "enums in properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type":"object",
             "properties": {
                 "foo": {"enum":["foo"]},
@@ -113,6 +123,7 @@
     {
         "description": "enum with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "enum": ["foo\nbar", "foo\rbar"]
         },
         "tests": [
@@ -135,7 +146,10 @@
     },
     {
         "description": "enum with false does not match 0",
-        "schema": {"enum": [false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [false]
+        },
         "tests": [
             {
                 "description": "false is valid",
@@ -156,7 +170,10 @@
     },
     {
         "description": "enum with true does not match 1",
-        "schema": {"enum": [true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [true]
+        },
         "tests": [
             {
                 "description": "true is valid",
@@ -177,7 +194,10 @@
     },
     {
         "description": "enum with 0 does not match false",
-        "schema": {"enum": [0]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [0]
+        },
         "tests": [
             {
                 "description": "false is invalid",
@@ -198,7 +218,10 @@
     },
     {
         "description": "enum with 1 does not match true",
-        "schema": {"enum": [1]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1]
+        },
         "tests": [
             {
                 "description": "true is invalid",
@@ -219,7 +242,10 @@
     },
     {
         "description": "nul characters in strings",
-        "schema": { "enum": [ "hello\u0000there" ] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [ "hello\u0000there" ]
+        },
         "tests": [
             {
                 "description": "match string with nul",

--- a/tests/draft2020-12/exclusiveMaximum.json
+++ b/tests/draft2020-12/exclusiveMaximum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMaximum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "exclusiveMaximum": 3.0
         },
         "tests": [

--- a/tests/draft2020-12/exclusiveMinimum.json
+++ b/tests/draft2020-12/exclusiveMinimum.json
@@ -2,6 +2,7 @@
     {
         "description": "exclusiveMinimum validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "exclusiveMinimum": 1.1
         },
         "tests": [

--- a/tests/draft2020-12/format.json
+++ b/tests/draft2020-12/format.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "email format",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -37,7 +40,10 @@
     },
     {
         "description": "idn-email format",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -73,7 +79,10 @@
     },
     {
         "description": "regex format",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -109,7 +118,10 @@
     },
     {
         "description": "ipv4 format",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -145,7 +157,10 @@
     },
     {
         "description": "ipv6 format",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -181,7 +196,10 @@
     },
     {
         "description": "idn-hostname format",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -217,7 +235,10 @@
     },
     {
         "description": "hostname format",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -253,7 +274,10 @@
     },
     {
         "description": "date format",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -289,7 +313,10 @@
     },
     {
         "description": "date-time format",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -325,7 +352,10 @@
     },
     {
         "description": "time format",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -361,7 +391,10 @@
     },
     {
         "description": "json-pointer format",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -397,7 +430,10 @@
     },
     {
         "description": "relative-json-pointer format",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -433,7 +469,10 @@
     },
     {
         "description": "iri format",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -469,7 +508,10 @@
     },
     {
         "description": "iri-reference format",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -505,7 +547,10 @@
     },
     {
         "description": "uri format",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -541,7 +586,10 @@
     },
     {
         "description": "uri-reference format",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -577,7 +625,10 @@
     },
     {
         "description": "uri-template format",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -613,7 +664,10 @@
     },
     {
         "description": "uuid format",
-        "schema": { "format": "uuid" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uuid"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",
@@ -649,7 +703,10 @@
     },
     {
         "description": "duration format",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/id.json
+++ b/tests/draft2020-12/id.json
@@ -2,6 +2,7 @@
     {
         "description": "Invalid use of fragments in location-independent $id",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [
@@ -110,6 +111,7 @@
         "description": "Valid use of empty fragments in location-independent $id",
         "comment": "These are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [
@@ -150,6 +152,7 @@
     {
         "description": "Unnormalized $ids are allowed but discouraged",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [
@@ -209,6 +212,7 @@
         "description": "$id inside an enum is not a real identifier",
         "comment": "the implementation must not be confused by an $id buried in the enum",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "id_in_enum": {
                     "enum": [
@@ -258,6 +262,7 @@
     {
         "description": "non-schema object containing an $id property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "const_not_id": {
                     "const": {

--- a/tests/draft2020-12/id.json
+++ b/tests/draft2020-12/id.json
@@ -44,10 +44,10 @@
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#foo",
+                    "$ref": "http://localhost:1234/draft2020-12/bar#foo",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#foo",
+                            "$id": "http://localhost:1234/draft2020-12/bar#foo",
                             "type": "integer"
                         }
                     }
@@ -57,10 +57,10 @@
             {
                 "description": "Identifier path with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar#/a/b",
+                    "$ref": "http://localhost:1234/draft2020-12/bar#/a/b",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#/a/b",
+                            "$id": "http://localhost:1234/draft2020-12/bar#/a/b",
                             "type": "integer"
                         }
                     }
@@ -70,8 +70,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#foo",
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -89,8 +89,8 @@
             {
                 "description": "Identifier path with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/a/b",
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/a/b",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -118,10 +118,10 @@
             {
                 "description": "Identifier name with absolute URI",
                 "data": {
-                    "$ref": "http://localhost:1234/bar",
+                    "$ref": "http://localhost:1234/draft2020-12/bar",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/bar#",
+                            "$id": "http://localhost:1234/draft2020-12/bar#",
                             "type": "integer"
                         }
                     }
@@ -131,8 +131,8 @@
             {
                 "description": "Identifier name with base URI change in subschema",
                 "data": {
-                    "$id": "http://localhost:1234/root",
-                    "$ref": "http://localhost:1234/nested.json#/$defs/B",
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/$defs/B",
                     "$defs": {
                         "A": {
                             "$id": "nested.json",
@@ -159,10 +159,10 @@
             {
                 "description": "Unnormalized identifier",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -174,7 +174,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz",
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
                             "type": "integer"
                         }
                     }
@@ -184,10 +184,10 @@
             {
                 "description": "Unnormalized identifier with empty fragment",
                 "data": {
-                    "$ref": "http://localhost:1234/foo/baz",
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -199,7 +199,7 @@
                 "data": {
                     "$defs": {
                         "A": {
-                            "$id": "http://localhost:1234/foo/bar/../baz#",
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
                             "type": "integer"
                         }
                     }
@@ -217,32 +217,32 @@
                 "id_in_enum": {
                     "enum": [
                         {
-                          "$id": "https://localhost:1234/id/my_identifier.json",
+                          "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
                           "type": "null"
                         }
                     ]
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
                     "type": "string"
                 },
                 "zzz_id_in_const": {
                     "const": {
-                        "$id": "https://localhost:1234/id/my_identifier.json",
+                        "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
                         "type": "null"
                     }
                 }
             },
             "anyOf": [
                 { "$ref": "#/$defs/id_in_enum" },
-                { "$ref": "https://localhost:1234/id/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft2020-12/id/my_identifier.json" }
             ]
         },
         "tests": [
             {
                 "description": "exact match to enum, and type matches",
                 "data": {
-                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
                     "type": "null"
                 },
                 "valid": true

--- a/tests/draft2020-12/if-then-else.json
+++ b/tests/draft2020-12/if-then-else.json
@@ -2,6 +2,7 @@
     {
         "description": "ignore if without then or else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": {
                 "const": 0
             }
@@ -22,6 +23,7 @@
     {
         "description": "ignore then without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "then": {
                 "const": 0
             }
@@ -42,6 +44,7 @@
     {
         "description": "ignore else without if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "else": {
                 "const": 0
             }
@@ -62,6 +65,7 @@
     {
         "description": "if and then without else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -90,6 +94,7 @@
     {
         "description": "if and else without then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -118,6 +123,7 @@
     {
         "description": "validate against correct branch, then vs else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": {
                 "exclusiveMaximum": 0
             },
@@ -154,6 +160,7 @@
     {
         "description": "non-interference across combined schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "if": {
@@ -188,6 +195,7 @@
     {
         "description": "if with boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": true,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -208,6 +216,7 @@
     {
         "description": "if with boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": false,
             "then": { "const": "then" },
             "else": { "const": "else" }
@@ -228,6 +237,7 @@
     {
         "description": "if appears at the end when serialized (keyword processing sequence)",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "then": { "const": "yes" },
             "else": { "const": "other" },
             "if": { "maxLength": 4 }

--- a/tests/draft2020-12/infinite-loop-detection.json
+++ b/tests/draft2020-12/infinite-loop-detection.json
@@ -2,6 +2,7 @@
     {
         "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "int": { "type": "integer" }
             },

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -2,6 +2,7 @@
     {
         "description": "a schema given for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "items": {"type": "integer"}
         },
         "tests": [
@@ -32,7 +33,10 @@
     },
     {
         "description": "items with boolean schema (true)",
-        "schema": {"items": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": true
+        },
         "tests": [
             {
                 "description": "any array is valid",
@@ -48,7 +52,10 @@
     },
     {
         "description": "items with boolean schema (false)",
-        "schema": {"items": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": false
+        },
         "tests": [
             {
                 "description": "any non-empty array is invalid",
@@ -65,6 +72,7 @@
     {
         "description": "items and subitems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "item": {
                     "type": "array",
@@ -147,6 +155,7 @@
     {
         "description": "nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "array",
             "items": {
                 "type": "array",
@@ -182,6 +191,7 @@
     {
         "description": "prefixItems with no additional items allowed",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [{}, {}, {}],
             "items": false
         },
@@ -216,6 +226,7 @@
     {
         "description": "items does not look in applicators, valid case",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 { "prefixItems": [ { "minimum": 3 } ] }
             ],
@@ -237,6 +248,7 @@
     {
         "description": "prefixItems validation adjusts the starting index for items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [ { "type": "string" } ],
             "items": { "type": "integer" }
         },
@@ -256,6 +268,7 @@
     {
         "description": "items with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "items": {
                 "type": "null"
             }

--- a/tests/draft2020-12/maxContains.json
+++ b/tests/draft2020-12/maxContains.json
@@ -2,6 +2,7 @@
     {
         "description": "maxContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxContains": 1
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "maxContains with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "maxContains": 1
         },
@@ -54,6 +56,7 @@
     {
         "description": "maxContains with contains, value with a decimal",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "maxContains": 1.0
         },
@@ -73,6 +76,7 @@
     {
         "description": "minContains < maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 1,
             "maxContains": 3

--- a/tests/draft2020-12/maxItems.json
+++ b/tests/draft2020-12/maxItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxItems validation",
-        "schema": {"maxItems": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maxItems validation with a decimal",
-        "schema": {"maxItems": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft2020-12/maxLength.json
+++ b/tests/draft2020-12/maxLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxLength validation",
-        "schema": {"maxLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "maxLength validation with a decimal",
-        "schema": {"maxLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",

--- a/tests/draft2020-12/maxProperties.json
+++ b/tests/draft2020-12/maxProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maxProperties validation",
-        "schema": {"maxProperties": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "maxProperties validation with a decimal",
-        "schema": {"maxProperties": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2.0
+        },
         "tests": [
             {
                 "description": "shorter is valid",
@@ -53,7 +59,10 @@
     },
     {
         "description": "maxProperties = 0 means the object is empty",
-        "schema": { "maxProperties": 0 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 0
+        },
         "tests": [
             {
                 "description": "no properties is valid",

--- a/tests/draft2020-12/maximum.json
+++ b/tests/draft2020-12/maximum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "maximum validation",
-        "schema": {"maximum": 3.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 3.0
+        },
         "tests": [
             {
                 "description": "below the maximum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "maximum validation with unsigned integer",
-        "schema": {"maximum": 300},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 300
+        },
         "tests":  [
             {
                 "description": "below the maximum is invalid",

--- a/tests/draft2020-12/minContains.json
+++ b/tests/draft2020-12/minContains.json
@@ -2,6 +2,7 @@
     {
         "description": "minContains without contains is ignored",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "minContains": 1
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "minContains=1 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 1
         },
@@ -54,6 +56,7 @@
     {
         "description": "minContains=2 with contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 2
         },
@@ -93,6 +96,7 @@
     {
         "description": "minContains=2 with contains with a decimal value",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 2.0
         },
@@ -112,6 +116,7 @@
     {
         "description": "maxContains = minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "maxContains": 2,
             "minContains": 2
@@ -142,6 +147,7 @@
     {
         "description": "maxContains < minContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "maxContains": 1,
             "minContains": 3
@@ -172,6 +178,7 @@
     {
         "description": "minContains = 0",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 0
         },
@@ -191,6 +198,7 @@
     {
         "description": "minContains = 0 with maxContains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contains": {"const": 1},
             "minContains": 0,
             "maxContains": 1

--- a/tests/draft2020-12/minItems.json
+++ b/tests/draft2020-12/minItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minItems validation",
-        "schema": {"minItems": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minItems validation with a decimal",
-        "schema": {"minItems": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2020-12/minLength.json
+++ b/tests/draft2020-12/minLength.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minLength validation",
-        "schema": {"minLength": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -32,7 +35,10 @@
     },
     {
         "description": "minLength validation with a decimal",
-        "schema": {"minLength": 2.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2020-12/minProperties.json
+++ b/tests/draft2020-12/minProperties.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minProperties validation",
-        "schema": {"minProperties": 1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1
+        },
         "tests": [
             {
                 "description": "longer is valid",
@@ -37,7 +40,10 @@
     },
     {
         "description": "minProperties validation with a decimal",
-        "schema": {"minProperties": 1.0},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1.0
+        },
         "tests": [
             {
                 "description": "longer is valid",

--- a/tests/draft2020-12/minimum.json
+++ b/tests/draft2020-12/minimum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "minimum validation",
-        "schema": {"minimum": 1.1},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": 1.1
+        },
         "tests": [
             {
                 "description": "above the minimum is valid",
@@ -27,7 +30,10 @@
     },
     {
         "description": "minimum validation with signed integer",
-        "schema": {"minimum": -2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -2
+        },
         "tests": [
             {
                 "description": "negative above the minimum is valid",

--- a/tests/draft2020-12/multipleOf.json
+++ b/tests/draft2020-12/multipleOf.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "by int",
-        "schema": {"multipleOf": 2},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 2
+        },
         "tests": [
             {
                 "description": "int by int",
@@ -22,7 +25,10 @@
     },
     {
         "description": "by number",
-        "schema": {"multipleOf": 1.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 1.5
+        },
         "tests": [
             {
                 "description": "zero is multiple of anything",
@@ -43,7 +49,10 @@
     },
     {
         "description": "by small number",
-        "schema": {"multipleOf": 0.0001},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 0.0001
+        },
         "tests": [
             {
                 "description": "0.0075 is multiple of 0.0001",
@@ -59,7 +68,10 @@
     },
     {
         "description": "float division = inf",
-        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer", "multipleOf": 0.123456789
+        },
         "tests": [
             {
                 "description": "always invalid, but naive implementations may raise an overflow error",

--- a/tests/draft2020-12/not.json
+++ b/tests/draft2020-12/not.json
@@ -2,6 +2,7 @@
     {
         "description": "not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "not": {"type": "integer"}
         },
         "tests": [
@@ -20,6 +21,7 @@
     {
         "description": "not multiple types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "not": {"type": ["integer", "boolean"]}
         },
         "tests": [
@@ -43,6 +45,7 @@
     {
         "description": "not more complex schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "not": {
                 "type": "object",
                 "properties": {
@@ -73,6 +76,7 @@
     {
         "description": "forbidden property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": { 
                     "not": {}
@@ -94,7 +98,10 @@
     },
     {
         "description": "not with boolean schema true",
-        "schema": {"not": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": true
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -105,7 +112,10 @@
     },
     {
         "description": "not with boolean schema false",
-        "schema": {"not": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": false
+        },
         "tests": [
             {
                 "description": "any value is valid",

--- a/tests/draft2020-12/oneOf.json
+++ b/tests/draft2020-12/oneOf.json
@@ -2,6 +2,7 @@
     {
         "description": "oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "oneOf": [
                 {
                     "type": "integer"
@@ -37,6 +38,7 @@
     {
         "description": "oneOf with base schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "oneOf" : [
                 {
@@ -67,7 +69,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all true",
-        "schema": {"oneOf": [true, true, true]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, true]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -78,7 +83,10 @@
     },
     {
         "description": "oneOf with boolean schemas, one true",
-        "schema": {"oneOf": [true, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, false, false]
+        },
         "tests": [
             {
                 "description": "any value is valid",
@@ -89,7 +97,10 @@
     },
     {
         "description": "oneOf with boolean schemas, more than one true",
-        "schema": {"oneOf": [true, true, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -100,7 +111,10 @@
     },
     {
         "description": "oneOf with boolean schemas, all false",
-        "schema": {"oneOf": [false, false, false]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [false, false, false]
+        },
         "tests": [
             {
                 "description": "any value is invalid",
@@ -112,6 +126,7 @@
     {
         "description": "oneOf complex types",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -153,6 +168,7 @@
     {
         "description": "oneOf with empty schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "oneOf": [
                 { "type": "number" },
                 {}
@@ -174,6 +190,7 @@
     {
         "description": "oneOf with required",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "oneOf": [
                 { "required": ["foo", "bar"] },
@@ -206,6 +223,7 @@
 	{
         "description": "oneOf with missing optional property",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "oneOf": [
                 {
                     "properties": {
@@ -248,6 +266,7 @@
     {
         "description": "nested oneOf, to check validation semantics",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "oneOf": [
                 {
                     "oneOf": [

--- a/tests/draft2020-12/optional/bignum.json
+++ b/tests/draft2020-12/optional/bignum.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer",
-        "schema": { "type": "integer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "a bignum is an integer",
@@ -17,7 +20,10 @@
     },
     {
         "description": "number",
-        "schema": { "type": "number" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "a bignum is a number",
@@ -33,7 +39,10 @@
     },
     {
         "description": "string",
-        "schema": { "type": "string" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "a bignum is not a string",
@@ -44,7 +53,10 @@
     },
     {
         "description": "maximum integer comparison",
-        "schema": { "maximum": 18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for high numbers",
@@ -56,6 +68,7 @@
     {
         "description": "float comparison with high precision",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "exclusiveMaximum": 972783798187987123879878123.18878137
         },
         "tests": [
@@ -68,7 +81,10 @@
     },
     {
         "description": "minimum integer comparison",
-        "schema": { "minimum": -18446744073709551615 },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -18446744073709551615
+        },
         "tests": [
             {
                 "description": "comparison works for very negative numbers",
@@ -80,6 +96,7 @@
     {
         "description": "float comparison with high precision on negative numbers",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "exclusiveMinimum": -972783798187987123879878123.18878137
         },
         "tests": [

--- a/tests/draft2020-12/optional/dependencies-compatibility.json
+++ b/tests/draft2020-12/optional/dependencies-compatibility.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "single dependency",
-        "schema": {"dependencies": {"bar": ["foo"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -42,7 +45,10 @@
     },
     {
         "description": "empty dependents",
-        "schema": {"dependencies": {"bar": []}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": []}
+        },
         "tests": [
             {
                 "description": "empty object",
@@ -63,7 +69,10 @@
     },
     {
         "description": "multiple dependents required",
-        "schema": {"dependencies": {"quux": ["foo", "bar"]}},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
         "tests": [
             {
                 "description": "neither",
@@ -100,6 +109,7 @@
     {
         "description": "dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependencies": {
                 "foo\nbar": ["foo\rbar"],
                 "foo\"bar": ["foo'bar"]
@@ -142,6 +152,7 @@
     {
         "description": "single schema dependency",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependencies": {
                 "bar": {
                     "properties": {
@@ -197,6 +208,7 @@
     {
         "description": "boolean subschemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependencies": {
                 "foo": true,
                 "bar": false
@@ -228,6 +240,7 @@
     {
         "description": "schema dependencies with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "dependencies": {
                 "foo\tbar": {"minProperties": 4},
                 "foo'bar": {"required": ["foo\"bar"]}

--- a/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/ecmascript-regex.json
@@ -2,6 +2,7 @@
     {
         "description": "ECMA 262 regex $ does not match trailing newline",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^abc$"
         },
@@ -21,6 +22,7 @@
     {
         "description": "ECMA 262 regex converts \\t to horizontal tab",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\t$"
         },
@@ -40,6 +42,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\cC$"
         },
@@ -59,6 +62,7 @@
     {
         "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\cc$"
         },
@@ -78,6 +82,7 @@
     {
         "description": "ECMA 262 \\d matches ascii digits only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\d$"
         },
@@ -102,6 +107,7 @@
     {
         "description": "ECMA 262 \\D matches everything but ascii digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\D$"
         },
@@ -126,6 +132,7 @@
     {
         "description": "ECMA 262 \\w matches ascii letters only",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\w$"
         },
@@ -145,6 +152,7 @@
     {
         "description": "ECMA 262 \\W matches everything but ascii letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\W$"
         },
@@ -164,6 +172,7 @@
     {
         "description": "ECMA 262 \\s matches whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\s$"
         },
@@ -228,6 +237,7 @@
     {
         "description": "ECMA 262 \\S matches everything but whitespace",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string",
             "pattern": "^\\S$"
         },
@@ -291,7 +301,10 @@
     },
     {
         "description": "patterns always use unicode semantics with pattern",
-        "schema": { "pattern": "\\p{Letter}cole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\p{Letter}cole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -317,7 +330,10 @@
     },
     {
         "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
-        "schema": { "pattern": "\\wcole" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\wcole"
+        },
         "tests": [
             {
                 "description": "ascii character in json string",
@@ -343,7 +359,11 @@
     },
     {
         "description": "pattern with ASCII ranges",
-        "schema": { "pattern": "[a-z]cole" },
+        "description": "unicode characters do not match ascii ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "[a-z]cole"
+        },
         "tests": [
             {
                 "description": "literal unicode character in json string",
@@ -364,7 +384,10 @@
     },
     {
         "description": "\\d in pattern matches [0-9], not unicode digits",
-        "schema": { "pattern": "^\\d+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\d+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -385,7 +408,10 @@
     },
     {
         "description": "\\a is not an ECMA 262 control escape",
-        "schema": { "$ref": "https://json-schema.org/draft/2020-12/schema" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
         "tests": [
             {
                 "description": "when used as a pattern",
@@ -396,7 +422,10 @@
     },
     {
         "description": "pattern with non-ASCII digits",
-        "schema": { "pattern": "^\\p{digit}+$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\p{digit}+$"
+        },
         "tests": [
             {
                 "description": "ascii digits",
@@ -418,6 +447,7 @@
     {
         "description": "patterns always use unicode semantics with patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "\\p{Letter}cole": true
@@ -450,6 +480,7 @@
     {
         "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "\\wcole": true
@@ -482,6 +513,7 @@
     {
         "description": "patternProperties with ASCII ranges",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "[a-z]cole": true
@@ -509,6 +541,7 @@
     {
         "description": "\\d in patternProperties matches [0-9], not unicode digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "^\\d+$": true
@@ -536,6 +569,7 @@
     {
         "description": "patternProperties with non-ASCII digits",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "^\\p{digit}+$": true

--- a/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/ecmascript-regex.json
@@ -359,7 +359,6 @@
     },
     {
         "description": "pattern with ASCII ranges",
-        "description": "unicode characters do not match ascii ranges",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "pattern": "[a-z]cole"

--- a/tests/draft2020-12/optional/float-overflow.json
+++ b/tests/draft2020-12/optional/float-overflow.json
@@ -1,7 +1,11 @@
 [
     {
         "description": "all integers are multiples of 0.5, if overflow is handled",
-        "schema": {"type": "integer", "multipleOf": 0.5},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer",
+            "multipleOf": 0.5
+        },
         "tests": [
             {
                 "description": "valid if optional overflow handling is implemented",

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date-time strings",
-        "schema": { "format": "date-time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of date strings",
-        "schema": { "format": "date" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of duration strings",
-        "schema": { "format": "duration" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of e-mail addresses",
-        "schema": { "format": "email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of host names",
-        "schema": { "format": "hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of an internationalized e-mail addresses",
-        "schema": { "format": "idn-email" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of internationalized host names",
-        "schema": { "format": "idn-hostname" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IP addresses",
-        "schema": { "format": "ipv4" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IPv6 addresses",
-        "schema": { "format": "ipv6" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRI References",
-        "schema": { "format": "iri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of IRIs",
-        "schema": { "format": "iri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/json-pointer.json
+++ b/tests/draft2020-12/optional/format/json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of JSON-pointers (JSON String Representation)",
-        "schema": { "format": "json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/regex.json
+++ b/tests/draft2020-12/optional/format/regex.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of regular expressions",
-        "schema": { "format": "regex" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of Relative JSON Pointers (RJP)",
-        "schema": { "format": "relative-json-pointer" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of time strings",
-        "schema": { "format": "time" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/unknown.json
+++ b/tests/draft2020-12/optional/format/unknown.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "unknown format",
-        "schema": { "format": "unknown" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "unknown"
+        },
         "tests": [
             {
                 "description": "unknown formats ignore integers",

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URI References",
-        "schema": { "format": "uri-reference" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "format: uri-template",
-        "schema": { "format": "uri-template" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
         "tests": [
             {
                 "description": "all string formats ignore integers",

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "validation of URIs",
-        "schema": { "format": "uri" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
         "tests": [
             {
                 "description": "a valid URL with anchor tag",

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -2,6 +2,7 @@
     {
         "description": "uuid format",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "format": "uuid"
         },
         "tests": [

--- a/tests/draft2020-12/optional/no-schema.json
+++ b/tests/draft2020-12/optional/no-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validation without $schema",
+        "comment": "minLength is the same across all drafts",
+        "schema": {
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "a 3-character string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a 1-character string is not valid",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "a non-string is valid",
+                "data": 5,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2020-12/optional/non-bmp-regex.json
+++ b/tests/draft2020-12/optional/non-bmp-regex.json
@@ -2,7 +2,10 @@
     {
         "description": "Proper UTF-16 surrogate pair handling: pattern",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
-        "schema": { "pattern": "^🐲*$" },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^🐲*$"
+        },
         "tests": [
             {
                 "description": "matches empty",
@@ -45,6 +48,7 @@
         "description": "Proper UTF-16 surrogate pair handling: patternProperties",
         "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "^🐲*$": {
                     "type": "integer"

--- a/tests/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/tests/draft2020-12/optional/refOfUnknownKeyword.json
@@ -2,6 +2,7 @@
     {
         "description": "reference of a root arbitrary keyword ",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unknown-keyword": {"type": "integer"},
             "properties": {
                 "bar": {"$ref": "#/unknown-keyword"}
@@ -23,6 +24,7 @@
     {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}

--- a/tests/draft2020-12/pattern.json
+++ b/tests/draft2020-12/pattern.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "pattern validation",
-        "schema": {"pattern": "^a*$"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^a*$"
+        },
         "tests": [
             {
                 "description": "a matching pattern is valid",
@@ -47,7 +50,10 @@
     },
     {
         "description": "pattern is not anchored",
-        "schema": {"pattern": "a+"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "a+"
+        },
         "tests": [
             {
                 "description": "matches a substring",

--- a/tests/draft2020-12/patternProperties.json
+++ b/tests/draft2020-12/patternProperties.json
@@ -3,6 +3,7 @@
         "description":
             "patternProperties validates properties matching a regex",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "f.*o": {"type": "integer"}
             }
@@ -48,6 +49,7 @@
     {
         "description": "multiple simultaneous patternProperties are validated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "a*": {"type": "integer"},
                 "aaa*": {"maximum": 20}
@@ -89,6 +91,7 @@
     {
         "description": "regexes are not anchored by default and are case sensitive",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "[0-9]{2,}": { "type": "boolean" },
                 "X_": { "type": "string" }
@@ -120,6 +123,7 @@
     {
         "description": "patternProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "f.*": true,
                 "b.*": false
@@ -156,6 +160,7 @@
     {
         "description": "patternProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "patternProperties": {
                 "^.*bar$": {"type": "null"}
             }

--- a/tests/draft2020-12/prefixItems.json
+++ b/tests/draft2020-12/prefixItems.json
@@ -2,6 +2,7 @@
     {
         "description": "a schema given for prefixItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 {"type": "integer"},
                 {"type": "string"}
@@ -47,6 +48,7 @@
     {
         "description": "prefixItems with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [true, false]
         },
         "tests": [
@@ -69,7 +71,10 @@
     },
     {
         "description": "additional items are allowed by default",
-        "schema": {"prefixItems": [{"type": "integer"}]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "integer"}]
+        },
         "tests": [
             {
                 "description": "only the first item is validated",
@@ -81,6 +86,7 @@
     {
         "description": "prefixItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 {
                     "type": "null"

--- a/tests/draft2020-12/properties.json
+++ b/tests/draft2020-12/properties.json
@@ -2,6 +2,7 @@
     {
         "description": "object properties validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"type": "string"}
@@ -44,6 +45,7 @@
         "description":
             "properties, patternProperties, additionalProperties interaction",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"type": "array", "maxItems": 3},
                 "bar": {"type": "array"}
@@ -97,6 +99,7 @@
     {
         "description": "properties with boolean schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": true,
                 "bar": false
@@ -128,6 +131,7 @@
     {
         "description": "properties with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo\nbar": {"type": "number"},
                 "foo\"bar": {"type": "number"},
@@ -167,6 +171,7 @@
     {
         "description": "properties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"type": "null"}
             }
@@ -183,6 +188,7 @@
         "description": "properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "__proto__": {"type": "number"},
                 "toString": {

--- a/tests/draft2020-12/propertyNames.json
+++ b/tests/draft2020-12/propertyNames.json
@@ -2,6 +2,7 @@
     {
         "description": "propertyNames validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "propertyNames": {"maxLength": 3}
         },
         "tests": [
@@ -45,7 +46,10 @@
     },
     {
         "description": "propertyNames with boolean schema true",
-        "schema": {"propertyNames": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": true
+        },
         "tests": [
             {
                 "description": "object with any properties is valid",
@@ -61,7 +65,10 @@
     },
     {
         "description": "propertyNames with boolean schema false",
-        "schema": {"propertyNames": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": false
+        },
         "tests": [
             {
                 "description": "object with any properties is invalid",

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -285,7 +285,7 @@
         "description": "Recursive references between schemas",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/tree",
+            "$id": "http://localhost:1234/draft2020-12/tree",
             "description": "tree of nodes",
             "type": "object",
             "properties": {
@@ -298,7 +298,7 @@
             "required": ["meta", "nodes"],
             "$defs": {
                 "node": {
-                    "$id": "http://localhost:1234/node",
+                    "$id": "http://localhost:1234/draft2020-12/node",
                     "description": "node",
                     "type": "object",
                     "properties": {
@@ -601,7 +601,7 @@
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "/ref-and-id1/base.json",
+            "$id": "/draft2020-12/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
@@ -611,7 +611,7 @@
                 },
                 "smallint": {
                     "$comment": "canonical uri: /ref-and-id1-int.json",
-                    "$id": "/ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
                     "maximum": 2
                 }
             }
@@ -634,7 +634,7 @@
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "/ref-and-id2/base.json",
+            "$id": "/draft2020-12/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
@@ -644,7 +644,7 @@
                 },
                 "smallint": {
                     "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
-                    "$id": "/ref-and-id2/",
+                    "$id": "/draft2020-12/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2
                 }

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -2,6 +2,7 @@
     {
         "description": "root pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"$ref": "#"}
             },
@@ -33,6 +34,7 @@
     {
         "description": "relative pointer ref to object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"type": "integer"},
                 "bar": {"$ref": "#/properties/foo"}
@@ -54,6 +56,7 @@
     {
         "description": "relative pointer ref to array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 {"type": "integer"},
                 {"$ref": "#/prefixItems/0"}
@@ -75,6 +78,7 @@
     {
         "description": "escaped pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "tilde~field": {"type": "integer"},
                 "slash/field": {"type": "integer"},
@@ -122,6 +126,7 @@
     {
         "description": "nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "a": {"type": "integer"},
                 "b": {"$ref": "#/$defs/a"},
@@ -145,6 +150,7 @@
     {
         "description": "ref applies alongside sibling keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "reffed": {
                     "type": "array"
@@ -178,6 +184,7 @@
     {
         "description": "remote ref, containing refs itself",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [
@@ -196,6 +203,7 @@
     {
         "description": "property named $ref that is not a reference",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "$ref": {"type": "string"}
             }
@@ -216,6 +224,7 @@
     {
         "description": "property named $ref, containing an actual $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "$ref": {"$ref": "#/$defs/is-string"}
             },
@@ -241,6 +250,7 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": true
@@ -257,6 +267,7 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "#/$defs/bool",
             "$defs": {
                 "bool": false
@@ -273,6 +284,7 @@
     {
         "description": "Recursive references between schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/tree",
             "description": "tree of nodes",
             "type": "object",
@@ -361,6 +373,7 @@
     {
         "description": "refs with quote",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
             },
@@ -388,6 +401,7 @@
     {
         "description": "ref creates new scope when adjacent to keywords",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "A": {
                     "unevaluatedProperties": false
@@ -413,6 +427,7 @@
     {
         "description": "naive replacement of $ref with its destination is not correct",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "a_string": { "type": "string" }
             },
@@ -441,6 +456,7 @@
     {
         "description": "refs with relative uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://example.com/schema-relative-uri-defs1.json",
             "properties": {
                 "foo": {
@@ -493,6 +509,7 @@
     {
         "description": "relative refs with absolute uris and defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
             "properties": {
                 "foo": {
@@ -545,6 +562,7 @@
     {
         "description": "$id must be resolved against nearest parent, not just immediate parent",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://example.com/a.json",
             "$defs": {
                 "x": {
@@ -582,6 +600,7 @@
         "description": "order of evaluation: $id and $ref",
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
@@ -614,6 +633,7 @@
         "description": "order of evaluation: $id and $anchor and $ref",
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
@@ -647,6 +667,7 @@
         "description": "simple URN base URI with $ref via the URN",
         "schema": {
             "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
             "minimum": 30,
             "properties": {
@@ -670,6 +691,7 @@
         "description": "simple URN base URI with JSON pointer",
         "schema": {
             "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "#/$defs/bar"}
@@ -695,6 +717,7 @@
         "description": "URN base URI with NSS",
         "schema": {
             "$comment": "RFC 8141 §2.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:example:1/406/47452/2",
             "properties": {
                 "foo": {"$ref": "#/$defs/bar"}
@@ -720,6 +743,7 @@
         "description": "URN base URI with r-component",
         "schema": {
             "$comment": "RFC 8141 §2.3.1",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
             "properties": {
                 "foo": {"$ref": "#/$defs/bar"}
@@ -745,6 +769,7 @@
         "description": "URN base URI with q-component",
         "schema": {
             "$comment": "RFC 8141 §2.3.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
             "properties": {
                 "foo": {"$ref": "#/$defs/bar"}
@@ -770,6 +795,7 @@
         "description": "URN base URI with f-component",
         "schema": {
             "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "https://json-schema.org/draft/2020-12/schema"
         },
         "tests": [
@@ -783,6 +809,7 @@
     {
         "description": "URN base URI with URN and JSON pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
@@ -807,6 +834,7 @@
     {
         "description": "URN base URI with URN and anchor ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
             "properties": {
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -3,7 +3,7 @@
         "description": "remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "http://localhost:1234/integer.json"
+            "$ref": "http://localhost:1234/draft2020-12/integer.json"
         },
         "tests": [
             {
@@ -22,7 +22,7 @@
         "description": "fragment within remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/integer"
         },
         "tests": [
             {
@@ -41,7 +41,7 @@
         "description": "ref within remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -60,7 +60,7 @@
         "description": "base URI change",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/",
+            "$id": "http://localhost:1234/draft2020-12/",
             "items": {
                 "$id": "baseUriChange/",
                 "items": {"$ref": "folderInteger.json"}
@@ -83,7 +83,7 @@
         "description": "base URI change - change folder",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs1.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
             "$defs": {
@@ -111,7 +111,7 @@
         "description": "base URI change - change folder in subschema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs2.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
             "$defs": {
@@ -143,7 +143,7 @@
         "description": "root ref in remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/object",
+            "$id": "http://localhost:1234/draft2020-12/object",
             "type": "object",
             "properties": {
                 "name": {"$ref": "name-defs.json#/$defs/orNull"}
@@ -179,7 +179,7 @@
         "description": "remote ref with ref to defs",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
+            "$id": "http://localhost:1234/draft2020-12/schema-remote-ref-ref-defs1.json",
             "$ref": "ref-and-defs.json"
         },
         "tests": [
@@ -203,7 +203,7 @@
         "description": "Location-independent identifier in remote ref",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
+            "$ref": "http://localhost:1234/draft2020-12/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
             {
@@ -222,7 +222,7 @@
         "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/some-id",
+            "$id": "http://localhost:1234/draft2020-12/some-id",
             "properties": {
                 "name": {"$ref": "nested/foo-ref-string.json"}
             }

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "remote ref",
-        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/integer.json"
+        },
         "tests": [
             {
                 "description": "remote ref valid",
@@ -17,7 +20,10 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/integer"
+        },
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -34,6 +40,7 @@
     {
         "description": "ref within remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://localhost:1234/subSchemas-defs.json#/$defs/refToInteger"
         },
         "tests": [
@@ -52,6 +59,7 @@
     {
         "description": "base URI change",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/",
             "items": {
                 "$id": "baseUriChange/",
@@ -74,6 +82,7 @@
     {
         "description": "base URI change - change folder",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/scope_change_defs1.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
@@ -101,6 +110,7 @@
     {
         "description": "base URI change - change folder in subschema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/scope_change_defs2.json",
             "type" : "object",
             "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
@@ -132,6 +142,7 @@
     {
         "description": "root ref in remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
@@ -167,6 +178,7 @@
     {
         "description": "remote ref with ref to defs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
             "$ref": "ref-and-defs.json"
         },
@@ -190,6 +202,7 @@
     {
         "description": "Location-independent identifier in remote ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://localhost:1234/locationIndependentIdentifier.json#/$defs/refToInteger"
         },
         "tests": [
@@ -208,6 +221,7 @@
     {
         "description": "retrieved nested refs resolve relative to their URI not $id",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://localhost:1234/some-id",
             "properties": {
                 "name": {"$ref": "nested/foo-ref-string.json"}

--- a/tests/draft2020-12/required.json
+++ b/tests/draft2020-12/required.json
@@ -2,6 +2,7 @@
     {
         "description": "required validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {},
                 "bar": {}
@@ -39,6 +40,7 @@
     {
         "description": "required default validation",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {}
             }
@@ -54,6 +56,7 @@
     {
         "description": "required with empty array",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {}
             },
@@ -70,6 +73,7 @@
     {
         "description": "required with escaped characters",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "required": [
                 "foo\nbar",
                 "foo\"bar",
@@ -105,7 +109,10 @@
     {
         "description": "required properties whose names are Javascript object property names",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
-        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
         "tests": [
             {
                 "description": "ignores arrays",

--- a/tests/draft2020-12/type.json
+++ b/tests/draft2020-12/type.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "integer type matches integers",
-        "schema": {"type": "integer"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
         "tests": [
             {
                 "description": "an integer is an integer",
@@ -52,7 +55,10 @@
     },
     {
         "description": "number type matches numbers",
-        "schema": {"type": "number"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
         "tests": [
             {
                 "description": "an integer is a number",
@@ -103,7 +109,10 @@
     },
     {
         "description": "string type matches strings",
-        "schema": {"type": "string"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
         "tests": [
             {
                 "description": "1 is not a string",
@@ -154,7 +163,10 @@
     },
     {
         "description": "object type matches objects",
-        "schema": {"type": "object"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object"
+        },
         "tests": [
             {
                 "description": "an integer is not an object",
@@ -195,7 +207,10 @@
     },
     {
         "description": "array type matches arrays",
-        "schema": {"type": "array"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array"
+        },
         "tests": [
             {
                 "description": "an integer is not an array",
@@ -236,7 +251,10 @@
     },
     {
         "description": "boolean type matches booleans",
-        "schema": {"type": "boolean"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "boolean"
+        },
         "tests": [
             {
                 "description": "an integer is not a boolean",
@@ -292,7 +310,10 @@
     },
     {
         "description": "null type matches only the null object",
-        "schema": {"type": "null"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "null"
+        },
         "tests": [
             {
                 "description": "an integer is not null",
@@ -348,7 +369,10 @@
     },
     {
         "description": "multiple types can be specified in an array",
-        "schema": {"type": ["integer", "string"]},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["integer", "string"]
+        },
         "tests": [
             {
                 "description": "an integer is valid",
@@ -390,6 +414,7 @@
     {
         "description": "type as array with one item",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["string"]
         },
         "tests": [
@@ -408,6 +433,7 @@
     {
         "description": "type: array or object",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["array", "object"]
         },
         "tests": [
@@ -441,6 +467,7 @@
     {
         "description": "type: array, object or null",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["array", "object", "null"]
         },
         "tests": [

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "unevaluatedItems true",
-        "schema": { "unevaluatedItems": true },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": true
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -17,7 +20,10 @@
     },
     {
         "description": "unevaluatedItems false",
-        "schema": { "unevaluatedItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -33,7 +39,10 @@
     },
     {
         "description": "unevaluatedItems as schema",
-        "schema": { "unevaluatedItems": { "type": "string" } },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
         "tests": [
             {
                 "description": "with no unevaluated items",
@@ -55,6 +64,7 @@
     {
         "description": "unevaluatedItems with uniform items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "items": { "type": "string" },
             "unevaluatedItems": false
         },
@@ -69,6 +79,7 @@
     {
         "description": "unevaluatedItems with tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -90,6 +101,7 @@
     {
         "description": "unevaluatedItems with items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -107,6 +119,7 @@
     {
         "description": "unevaluatedItems with nested tuple",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "type": "string" }
             ],
@@ -136,6 +149,7 @@
     {
         "description": "unevaluatedItems with nested items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unevaluatedItems": {"type": "boolean"},
             "anyOf": [
                 { "items": {"type": "string"} },
@@ -163,6 +177,7 @@
     {
         "description": "unevaluatedItems with nested prefixItems and items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "prefixItems": [
@@ -189,6 +204,7 @@
     {
         "description": "unevaluatedItems with nested unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "prefixItems": [
@@ -215,6 +231,7 @@
     {
         "description": "unevaluatedItems with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -261,6 +278,7 @@
     {
         "description": "unevaluatedItems with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -296,6 +314,7 @@
     {
         "description": "unevaluatedItems with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -320,6 +339,7 @@
     {
         "description": "unevaluatedItems with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
                 { "const": "foo" }
             ],
@@ -372,6 +392,7 @@
     {
         "description": "unevaluatedItems with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [true],
             "unevaluatedItems": false
         },
@@ -391,6 +412,7 @@
     {
         "description": "unevaluatedItems with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "#/$defs/bar",
             "prefixItems": [
                 { "type": "string" }
@@ -421,6 +443,7 @@
     {
         "description": "unevaluatedItems can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "prefixItems": [ true ]
@@ -439,6 +462,7 @@
     {
         "description": "item is evaluated in an uncle schema to unevaluatedItems",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {
                     "prefixItems": [
@@ -485,6 +509,7 @@
     {
         "description": "unevaluatedItems depends on adjacent contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [true],
             "contains": {"type": "string"},
             "unevaluatedItems": false
@@ -510,6 +535,7 @@
     {
         "description": "unevaluatedItems depends on multiple nested contains",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 { "contains": { "multipleOf": 2 } },
                 { "contains": { "multipleOf": 3 } }
@@ -532,6 +558,7 @@
     {
         "description": "unevaluatedItems and contains interact to control item dependency relationship",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "if": {
                 "contains": {"const": "a"}
             },
@@ -592,7 +619,10 @@
     },
     {
         "description": "non-array instances are valid",
-        "schema": {"unevaluatedItems": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -629,6 +659,7 @@
     {
         "description": "unevaluatedItems with null instance elements",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unevaluatedItems": {
                 "type": "null"
             }

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -2,6 +2,7 @@
     {
         "description": "unevaluatedProperties true",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "unevaluatedProperties": true
         },
@@ -23,6 +24,7 @@
     {
         "description": "unevaluatedProperties schema",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "unevaluatedProperties": {
                 "type": "string",
@@ -54,6 +56,7 @@
     {
         "description": "unevaluatedProperties false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -75,6 +78,7 @@
     {
         "description": "unevaluatedProperties with adjacent properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -102,6 +106,7 @@
     {
         "description": "unevaluatedProperties with adjacent patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "patternProperties": {
                 "^foo": { "type": "string" }
@@ -129,6 +134,7 @@
     {
         "description": "unevaluatedProperties with adjacent additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -157,6 +163,7 @@
     {
         "description": "unevaluatedProperties with nested properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -193,6 +200,7 @@
     {
         "description": "unevaluatedProperties with nested patternProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -229,6 +237,7 @@
     {
         "description": "unevaluatedProperties with nested additionalProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -261,6 +270,7 @@
     {
         "description": "unevaluatedProperties with nested unevaluatedProperties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -296,6 +306,7 @@
     {
         "description": "unevaluatedProperties with anyOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -364,6 +375,7 @@
     {
         "description": "unevaluatedProperties with oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -407,6 +419,7 @@
     {
         "description": "unevaluatedProperties with not",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -435,6 +448,7 @@
     {
         "description": "unevaluatedProperties with if/then/else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -494,6 +508,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, then not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -547,6 +562,7 @@
     {
         "description": "unevaluatedProperties with if/then/else, else not defined",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "if": {
                 "properties": {
@@ -600,6 +616,7 @@
     {
         "description": "unevaluatedProperties with dependentSchemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -635,6 +652,7 @@
     {
         "description": "unevaluatedProperties with boolean schemas",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -662,6 +680,7 @@
     {
         "description": "unevaluatedProperties with $ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "$ref": "#/$defs/bar",
             "properties": {
@@ -699,6 +718,7 @@
     {
         "description": "unevaluatedProperties can't see inside cousins",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {
                     "properties": {
@@ -723,6 +743,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -755,6 +776,7 @@
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -787,6 +809,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": { "type": "string" }
@@ -819,6 +842,7 @@
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -851,6 +875,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, true with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -885,6 +910,7 @@
     {
         "description": "cousin unevaluatedProperties, true and false, false with properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -920,6 +946,7 @@
         "description": "property is evaluated in an uncle schema to unevaluatedProperties",
         "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "foo": {
@@ -971,6 +998,7 @@
     {
         "description": "in-place applicator siblings, allOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1016,6 +1044,7 @@
     {
         "description": "in-place applicator siblings, anyOf has unevaluated",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "allOf": [
                 {
@@ -1061,6 +1090,7 @@
     {
         "description": "unevaluatedProperties + single cyclic ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
                 "x": { "$ref": "#" }
@@ -1108,6 +1138,7 @@
     {
         "description": "unevaluatedProperties + ref inside allOf / oneOf",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "one": {
                     "properties": { "a": true }
@@ -1178,6 +1209,7 @@
     {
         "description": "dynamic evalation inside nested refs",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "one": {
                     "oneOf": [
@@ -1310,7 +1342,10 @@
     },
     {
         "description": "non-object instances are valid",
-        "schema": {"unevaluatedProperties": false},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedProperties": false
+        },
         "tests": [
             {
                 "description": "ignores booleans",
@@ -1347,6 +1382,7 @@
     {
         "description": "unevaluatedProperties with null valued instance properties",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unevaluatedProperties": {
                 "type": "null"
             }

--- a/tests/draft2020-12/uniqueItems.json
+++ b/tests/draft2020-12/uniqueItems.json
@@ -1,7 +1,10 @@
 [
     {
         "description": "uniqueItems validation",
-        "schema": {"uniqueItems": true},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": true
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -149,6 +152,7 @@
     {
         "description": "uniqueItems with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true
         },
@@ -198,6 +202,7 @@
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": true,
             "items": false
@@ -232,7 +237,10 @@
     },
     {
         "description": "uniqueItems=false validation",
-        "schema": { "uniqueItems": false },
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": false
+        },
         "tests": [
             {
                 "description": "unique array of integers is valid",
@@ -320,6 +328,7 @@
     {
         "description": "uniqueItems=false with an array of items",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false
         },
@@ -369,6 +378,7 @@
     {
         "description": "uniqueItems=false with an array of items and additionalItems=false",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
             "uniqueItems": false,
             "items": false

--- a/tests/draft2020-12/unknownKeyword.json
+++ b/tests/draft2020-12/unknownKeyword.json
@@ -3,6 +3,7 @@
         "description": "$id inside an unknown keyword is not a real identifier",
         "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "id_in_unknown0": {
                     "not": {

--- a/tests/draft2020-12/unknownKeyword.json
+++ b/tests/draft2020-12/unknownKeyword.json
@@ -9,21 +9,21 @@
                     "not": {
                         "array_of_schemas": [
                             {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
                               "type": "null"
                             }
                         ]
                     }
                 },
                 "real_id_in_schema": {
-                    "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                    "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
                     "type": "string"
                 },
                 "id_in_unknown1": {
                     "not": {
                         "object_of_schemas": {
                             "foo": {
-                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
                               "type": "integer"
                             }
                         }
@@ -33,7 +33,7 @@
             "anyOf": [
                 { "$ref": "#/$defs/id_in_unknown0" },
                 { "$ref": "#/$defs/id_in_unknown1" },
-                { "$ref": "https://localhost:1234/unknownKeyword/my_identifier.json" }
+                { "$ref": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json" }
             ]
         },
         "tests": [


### PR DESCRIPTION
Fixes #311.  To recap so folks don't have to dig through that whole discussion:

* starting with 2019-09, implementations are explicitly allowed to refuse to process schemas without `$schema`, therefore all tests for 2019-09 and 2020-12 need to have the correct `$schema`
* in draft-03, using `$schema` to determine behavior was only a MAY, and therefore cannot be used to control the behavior of required tests
* in draft-04 through draft-07, no normative language provides guidance on the usage of `$schema` to control behavior, and nothing indicates that an implementation can refuse to process a `$schema`-less schema, therefore adding `$schema` does not provide benefits over the long-standing practice of configuring the draft based on the directory name.

Therefore, we are only adding `$schema` to 2019-09 and 2020-12.  I am unsure what to do with draft-next, as there is certainly no normative language around detecting unpublished work, so I have not added `$schema` to those tests, and do not plan to unless someone makes an argument in favor of that.

@Julian I updated the README as best I could, but I would be happy to change it.  I think it's important to convey that 2019-09 and later are intended to function through `$schema`-detection (particularly since that is a change), but I avoided mandating the behavior.