### PR TITLE
Cross draft tests

### DIFF
--- a/remotes/draft2019-09/dependentRequired.json
+++ b/remotes/draft2019-09/dependentRequired.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2019-09/dependentRequired.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "dependentRequired": {
+        "foo": ["bar"]
+    }
+}

--- a/remotes/draft2019-09/ignore-prefixItems.json
+++ b/remotes/draft2019-09/ignore-prefixItems.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2019-09/ignore-prefixItems.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "prefixItems": [
+        {"type": "string"}
+    ]
+}

--- a/remotes/draft2020-12/prefixItems.json
+++ b/remotes/draft2020-12/prefixItems.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/prefixItems.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "prefixItems": [
+        {"type": "string"}
+    ]
+}

--- a/remotes/draft7/ignore-dependentRequired.json
+++ b/remotes/draft7/ignore-dependentRequired.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft7/integer.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "dependentRequired": {
+        "foo": ["bar"]
+    }
+}

--- a/tests/draft2019-09/optional/cross-draft.json
+++ b/tests/draft2019-09/optional/cross-draft.json
@@ -19,5 +19,23 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "refs to historic drafts are processed as historic drafts",
+        "schema": {
+            "type": "object",
+            "allOf": [
+                { "properties": { "foo": true } },
+                { "$ref": "http://localhost:1234/draft7/ignore-dependentRequired.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "missing bar is valid",
+                "$comment": "if the implementation is not processing the $ref as a draft 7 schema, this test will fail",
+                "data": {"foo": "any value"},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/optional/cross-draft.json
+++ b/tests/draft2019-09/optional/cross-draft.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "refs to future drafts are processed as future drafts",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "array",
+            "$ref": "http://localhost:1234/draft2020-12/prefixItems.json"
+        },
+        "tests": [
+            {
+                "description": "first item not a string is invalid",
+                "$comment": "if the implementation is not processing the $ref as a 2020-12 schema, this test will fail",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "first item is a string is valid",
+                "data": ["a string", 1, 2, 3],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft2019-09/optional/cross-draft.json
+++ b/tests/draft2019-09/optional/cross-draft.json
@@ -9,7 +9,7 @@
         "tests": [
             {
                 "description": "first item not a string is invalid",
-                "$comment": "if the implementation is not processing the $ref as a 2020-12 schema, this test will fail",
+                "comment": "if the implementation is not processing the $ref as a 2020-12 schema, this test will fail",
                 "data": [1, 2, 3],
                 "valid": false
             },
@@ -32,7 +32,7 @@
         "tests": [
             {
                 "description": "missing bar is valid",
-                "$comment": "if the implementation is not processing the $ref as a draft 7 schema, this test will fail",
+                "comment": "if the implementation is not processing the $ref as a draft 7 schema, this test will fail",
                 "data": {"foo": "any value"},
                 "valid": true
             }

--- a/tests/draft2020-12/optional/cross-draft.json
+++ b/tests/draft2020-12/optional/cross-draft.json
@@ -9,7 +9,7 @@
         "tests": [
             {
                 "description": "first item not a string is valid",
-                "$comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
                 "data": [1, 2, 3],
                 "valid": true
             }

--- a/tests/draft2020-12/optional/cross-draft.json
+++ b/tests/draft2020-12/optional/cross-draft.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "refs to historic drafts are processed as historic drafts",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "$ref": "http://localhost:1234/draft2019-09/ignore-prefixItems.json"
+        },
+        "tests": [
+            {
+                "description": "first item not a string is valid",
+                "$comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "data": [1, 2, 3],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/cross-draft.json
+++ b/tests/draft7/optional/cross-draft.json
@@ -1,0 +1,24 @@
+[
+    {
+        "description": "refs to future drafts are processed as future drafts",
+        "schema": {
+            "type": "object",
+            "allOf": [
+                { "properties": { "foo": true } },
+                { "$ref": "http://localhost:1234/draft2019-09/dependentRequired.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "missing bar is invalid",
+                "data": {"foo": "any value"},
+                "valid": false
+            },
+            {
+                "description": "present bar is valid",
+                "data": {"foo": "any value", "bar": "also any value"},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/cross-draft.json
+++ b/tests/draft7/optional/cross-draft.json
@@ -11,7 +11,7 @@
         "tests": [
             {
                 "description": "missing bar is invalid",
-                "$comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
                 "data": {"foo": "any value"},
                 "valid": false
             },

--- a/tests/draft7/optional/cross-draft.json
+++ b/tests/draft7/optional/cross-draft.json
@@ -11,6 +11,7 @@
         "tests": [
             {
                 "description": "missing bar is invalid",
+                "$comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
                 "data": {"foo": "any value"},
                 "valid": false
             },


### PR DESCRIPTION
Replaces #210 

I've put these in optional for now.  My validator passes all of them, though.

The approach was to create two remotes: one that uses a new keyword in that draft, and one that uses a new keyword in the next draft (which should be ignored).

Then tests just reference those remotes and check to see if those keywords are processed accordingly.