### PR TITLE
Add an $id for the test suite schema.

### DIFF
--- a/test-schema.json
+++ b/test-schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/main/test-schema.json",
     "description": "A schema for files contained within this suite",
 
     "type": "array",


### PR DESCRIPTION
(I'd like to propose adding this to schemastore, which is what made me notice we didn't put this here previously.)

Ideally I think we'd have the canonical URI be something that isn't `raw.githubusercontent.com`, but perhaps we revisit whether it's worth hosting this somewhere ourselves after the new site is up.