### PR TITLE
Add tests for some more differing URI scenarios.

### DIFF
--- a/remotes/different-id-ref-string.json
+++ b/remotes/different-id-ref-string.json
@@ -1,0 +1,5 @@
+{
+    "$id": "http://localhost:1234/real-id-ref-string.json",
+    "$defs": {"bar": {"type": "string"}},
+    "$ref": "#/$defs/bar"
+}

--- a/remotes/nested-absolute-ref-to-string.json
+++ b/remotes/nested-absolute-ref-to-string.json
@@ -1,0 +1,9 @@
+{
+    "$defs": {
+        "bar": {
+            "$id": "http://localhost:1234/the-nested-id.json",
+            "type": "string"
+        }
+    },
+    "$ref": "http://localhost:1234/the-nested-id.json"
+}

--- a/remotes/urn-ref-string.json
+++ b/remotes/urn-ref-string.json
@@ -1,0 +1,5 @@
+{
+    "$id": "urn:uuid:feebdaed-ffff-0000-ffff-0000deadbeef",
+    "$defs": {"bar": {"type": "string"}},
+    "$ref": "#/$defs/bar"
+}

--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -830,5 +830,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft-next/refRemote.json
+++ b/tests/draft-next/refRemote.json
@@ -229,5 +229,53 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -830,5 +830,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -229,5 +229,53 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -830,5 +830,30 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -229,5 +229,53 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Covers:

    * A $ref to an absolute URI present in the retrieved schema
    * A schema with URN $id with a nested $ref
    * Retrieving a schema with a different $id than the retrieval URI
    * Retrieving a schema with $ref whose retrieval URI was an HTTP URI
      but whose $id is an URN

(These involve sibling $refs so don't apply to pre-2019).

Missing is a test for an URN retrieval URL, which unfortunately we have
no way of communicating at the minute.

Refs: https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/578#issuecomment-1200425108