### PR TITLE
also test allOf schemas presented in the reverse order

### DIFF
--- a/tests/draft-next/unevaluatedProperties.json
+++ b/tests/draft-next/unevaluatedProperties.json
@@ -741,6 +741,31 @@
         ]
     },
     {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -741,6 +741,31 @@
         ]
     },
     {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -741,6 +741,31 @@
         ]
     },
     {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Nothing in the specification says that allOf subschemas are evaluated in order; if they are evaluated in the reverse order an erroneous implementation could still pass this test.