### PR TITLE
test duration format 'element without unit'

### DIFF
--- a/tests/draft-next/optional/format/duration.json
+++ b/tests/draft-next/optional/format/duration.json
@@ -125,6 +125,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -125,6 +125,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -125,6 +125,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "P২Y",
                 "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
jsonschema spec: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
RFC: https://datatracker.ietf.org/doc/html/rfc3339#appendix-A