### PR TITLE
Test time format 'offset not starting with plus or minus'

### DIFF
--- a/tests/draft-next/optional/format/time.json
+++ b/tests/draft-next/optional/format/time.json
@@ -200,6 +200,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -200,6 +200,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -200,6 +200,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -197,6 +197,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২:00:00Z",
                 "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
jsonschema spec: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-dates-times-and-duration
RFC: https://datatracker.ietf.org/doc/html/rfc3339#appendix-A