### PR TITLE
added json-everything to 'who uses' section of readme; removed manatee.json (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Node-specific support is maintained in a [separate repository](https://github.co
 
 ### .NET
 
+* [JsonSchema.Net](https://github.com/gregsdennis/json-everything)
 * [Newtonsoft.Json.Schema](https://github.com/JamesNK/Newtonsoft.Json.Schema)
-* [Manatee.Json](https://github.com/gregsdennis/Manatee.Json)
 
 ### Perl
 


### PR DESCRIPTION
Not sure how I missed this file.  Added in the order they appear on the implementations page.