### PR TITLE
add tests for `unevaluatedProperties` seeing inside `propertyDependencies`

### DIFF
--- a/tests/draft-next/unevaluatedProperties.json
+++ b/tests/draft-next/unevaluatedProperties.json
@@ -1470,5 +1470,46 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties can see inside propertyDependencies",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyDependencies": {
+                "foo": {
+                    "foo1": { 
+                        "properties": {
+                            "bar": true
+                        }
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "allows bar if foo = foo1",
+                "data": {
+                    "foo": "foo1",
+                    "bar": 42
+                },
+                "valid": true
+            },
+            {
+                "description": "disallows bar if foo != foo1",
+                "data": {
+                    "foo": "foo2",
+                    "bar": 42
+                },
+                "valid": false
+            },
+            {
+                "description": "disallows bar if foo is absent",
+                "data": {
+                    "bar": 42
+                },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Resolves #614 

I couldn't think of a way to get `unevaluatedItems` to interact with `propertyDependencies`.  Open to suggestions if anyone can make that work.