### PR TITLE
added type:object to contentSchema schemas

### DIFF
--- a/tests/draft-next/content.json
+++ b/tests/draft-next/content.json
@@ -83,7 +83,7 @@
             "$schema": "https://json-schema.org/draft/next/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
-            "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
         },
         "tests": [
             {

--- a/tests/draft2019-09/content.json
+++ b/tests/draft2019-09/content.json
@@ -83,7 +83,7 @@
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
-            "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
         },
         "tests": [
             {

--- a/tests/draft2020-12/content.json
+++ b/tests/draft2020-12/content.json
@@ -83,7 +83,7 @@
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
-            "contentSchema": { "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
         },
         "tests": [
             {


### PR DESCRIPTION
Resolves #609 

That issue is a whole thing, but in the end my implementation had two bugs that cancelled each other out to pass the test.  Either one of them separately would have caused one of these test cases to fail.

Regardless, adding this to the content schema still improves the test and prevents implementations from just evaluating the string itself against the schema.

The test I was wanting where the decoded content failed the content schema already exists as `an invalid base64-encoded JSON document; validates true`.