### PR TITLE
fixed propertyDependencies `$schema` & `$id`; removed invalid test cases

### DIFF
--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -495,6 +495,11 @@
                     "$id": "inner",
                     "$dynamicAnchor": "foo",
                     "type": "object",
+                    "properties": {
+                        "expectedTypes": {
+                            "type": "string"
+                        }
+                    },
                     "additionalProperties": {
                         "$dynamicRef": "#foo"
                     }

--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -488,8 +488,8 @@
     {
         "description": "$dynamicAnchor inside propertyDependencies",
         "schema": {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "http://localhost:1234/draft2020-12/dynamicanchor-in-propertydependencies.json",
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/dynamicanchor-in-propertydependencies.json",
             "$defs": {
                 "inner": {
                     "$id": "inner",
@@ -555,20 +555,6 @@
                 "data": {
                     "expectedTypes": "integers",
                     "anotherProperty": "a string"
-                },
-                "valid": false
-            },
-            {
-                "description": "expected missing - additional property as an object is valid",
-                "data": {
-                    "anotherProperty": {}
-                },
-                "valid": true
-            },
-            {
-                "description": "expected missing - additional property as not object is invalid",
-                "data": {
-                    "anotherProperty": 42
                 },
                 "valid": false
             }

--- a/tests/draft-next/unevaluatedProperties.json
+++ b/tests/draft-next/unevaluatedProperties.json
@@ -1475,6 +1475,11 @@
         "description": "unevaluatedProperties can see inside propertyDependencies",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                }
+            },
             "propertyDependencies": {
                 "foo": {
                     "foo1": { 


### PR DESCRIPTION
Found these while working on my implementation.

- `$schema` & `$id` values should have "draft next" instead of "2020-12"
- Removed tests are invalid because when `expectedTypes` is missing, nothing in the schema is referring to `#/$defs/inner` that would trigger the `$dynamicRef` to need resolving.

I'll also update based on the result of [this conversation in Slack](https://json-schema.slack.com/archives/CT7FF623C/p1670983347707119), if needed.  (Update: the test was wrong; updated here.)