### PR TITLE
test that annations are collected inside a "not"

### DIFF
--- a/tests/draft-next/not.json
+++ b/tests/draft-next/not.json
@@ -123,5 +123,31 @@
                 "valid": true
             }
         ]
-    }
+    },
+    {
+        "description": "collect annotations inside a 'not', even if collection is disabled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": {
+                "$comment": "this subschema must still produce annotations internally, even though the 'not' will ultimately discard them",
+                "anyOf": [
+                    true,
+                    { "properties": { "foo": true } }
+                ],
+                "unevaluatedProperties": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no properties to evaluate",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "annotations are still collected inside a 'not'",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+     }
 ]

--- a/tests/draft2019-09/not.json
+++ b/tests/draft2019-09/not.json
@@ -123,5 +123,31 @@
                 "valid": true
             }
         ]
-    }
+    },
+    {
+        "description": "collect annotations inside a 'not', even if collection is disabled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": {
+                "$comment": "this subschema must still produce annotations internally, even though the 'not' will ultimately discard them",
+                "anyOf": [
+                    true,
+                    { "properties": { "foo": true } }
+                ],
+                "unevaluatedProperties": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no properties to evaluate",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "annotations are still collected inside a 'not'",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+     }
 ]

--- a/tests/draft2020-12/not.json
+++ b/tests/draft2020-12/not.json
@@ -123,5 +123,31 @@
                 "valid": true
             }
         ]
-    }
+    },
+    {
+        "description": "collect annotations inside a 'not', even if collection is disabled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {
+                "$comment": "this subschema must still produce annotations internally, even though the 'not' will ultimately discard them",
+                "anyOf": [
+                    true,
+                    { "properties": { "foo": true } }
+                ],
+                "unevaluatedProperties": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no properties to evaluate",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "annotations are still collected inside a 'not'",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+     }
 ]


### PR DESCRIPTION
Normally we can skip collecting annotations below a "not" keyword, because if the subschema passes (and produces annotations) the "not" turns that to an invalid result and annotations are discarded, and if the subschema is invalid no annotations are produced. However, annotations must still be collected *inside* the "not" if there is a reason to do so, such as the presence of an "unevaluated" keyword.