### PR TITLE
Correct "valid date-time with a leap second, with minus offset"

### DIFF
--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -63,7 +63,7 @@
             },
             {
                 "description": "a valid date-time with a leap second, with minus offset",
-                "data": "1998-12-31T15:59:60.123-08:00",
+                "data": "1998-12-31T23:59:60.123-08:00",
                 "valid": true
             },
             {


### PR DESCRIPTION
This test is wrong.
Date is not valid as the hour is not 23
as tested in "an invalid date-time with leap second on a wrong hour, UTC"