### PR TITLE
Add a test for 2019's interaction between additional/unevaluatedItems

### DIFF
--- a/tests/draft-next/unevaluatedItems.json
+++ b/tests/draft-next/unevaluatedItems.json
@@ -99,7 +99,7 @@
         ]
     },
     {
-        "description": "unevaluatedItems with items",
+        "description": "unevaluatedItems with items and prefixItems",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "prefixItems": [
@@ -113,6 +113,27 @@
                 "description": "unevaluatedItems doesn't apply",
                 "data": ["foo", 42],
                 "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": {"type": "number"},
+            "unevaluatedItems": {"type": "string"}
+        },
+        "tests": [
+            {
+                "description": "valid under items",
+                "comment": "no elements are considered by unevaluatedItems",
+                "data": [5, 6, 7, 8],
+                "valid": true
+            },
+            {
+                "description": "invalid under items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
             }
         ]
     },

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -99,7 +99,7 @@
         ]
     },
     {
-        "description": "unevaluatedItems with additionalItems",
+        "description": "unevaluatedItems with items and additionalItems",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "items": [
@@ -112,6 +112,48 @@
             {
                 "description": "unevaluatedItems doesn't apply",
                 "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with ignored additionalItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalItems": {"type": "number"},
+            "unevaluatedItems": {"type": "string"}
+        },
+        "tests": [
+            {
+                "description": "invalid under unevaluatedItems",
+                "comment": "additionalItems is entirely ignored when items isn't present, so all elements need to be valid against the unevaluatedItems schema",
+                "data": ["foo", 1],
+                "valid": false
+            },
+            {
+                "description": "all valid under unevaluatedItems",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with ignored applicator additionalItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [ { "additionalItems": { "type": "number" } } ],
+            "unevaluatedItems": {"type": "string"}
+        },
+        "tests": [
+            {
+                "description": "invalid under unevaluatedItems",
+                "comment": "additionalItems is entirely ignored when items isn't present, so all elements need to be valid against the unevaluatedItems schema",
+                "data": ["foo", 1],
+                "valid": false
+            },
+            {
+                "description": "all valid under unevaluatedItems",
+                "data": ["foo", "bar", "baz"],
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -99,7 +99,7 @@
         ]
     },
     {
-        "description": "unevaluatedItems with items",
+        "description": "unevaluatedItems with items and prefixItems",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "prefixItems": [
@@ -113,6 +113,27 @@
                 "description": "unevaluatedItems doesn't apply",
                 "data": ["foo", 42],
                 "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": {"type": "number"},
+            "unevaluatedItems": {"type": "string"}
+        },
+        "tests": [
+            {
+                "description": "valid under items",
+                "comment": "no elements are considered by unevaluatedItems",
+                "data": [5, 6, 7, 8],
+                "valid": true
+            },
+            {
+                "description": "invalid under items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
             }
         ]
     },


### PR DESCRIPTION
The interesting bit here actually *only* applies to 2019, as it's the only draft containing both unevaluatedItems as well as additionalItems -- the latter in its specified behavior containing:

   if "items" is absent or its annotation result is the
   boolean true, "additionalItems" MUST be ignored.

(from https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02#section-9.3.1.2)

In newer drafts (i.e. 2020), when additionalItems "became" items, this condition was dropped (i.e. items without a neighboring prefixItems now is indeed *not* ignored).

Refs: https://github.com/orgs/json-schema-org/discussions/57

Closes: #292