### PR TITLE
test: guarding against infinite recursion

### DIFF
--- a/tests/draft2020-12/infinite-loop-detection.json
+++ b/tests/draft2020-12/infinite-loop-detection.json
@@ -33,5 +33,29 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "guard against infinite recursion",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "alice": {
+                    "$anchor": "alice",
+                    "allOf": [{"$ref": "#bob"}]
+                },
+                "bob": {
+                    "$anchor": "bob",
+                    "allOf": [{"$ref": "#alice"}]
+                }
+            },
+            "$ref": "#alice"
+        },
+        "tests": [
+            {
+                "description": "infinite recursion detected",
+                "data": {},
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
example from https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01#section-9.4.1

the above section says:
```
A schema MUST NOT be run into an infinite loop against an instance. For example, 
if two schemas "#alice" and "#bob" both have an "allOf" property that refers to the 
other, a naive validator might get stuck in an infinite recursive loop trying to validate 
the instance. 
```

test passed with impl https://github.com/santhosh-tekuri/boon

if ok, will add to remaining drafts