### PR TITLE
test: percent-encoded char in json-pointer

### DIFF
--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -949,5 +949,27 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "percent-encoded char in json-pointer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a b": {"type": "number"}
+            },
+            "$ref": "#/$defs/a%20b"
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": "foobar",
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
from https://www.rfc-editor.org/rfc/rfc6901#section-6:

```
   A JSON Pointer can be represented in a URI fragment identifier by
   encoding it into octets using UTF-8 [[RFC3629](https://www.rfc-editor.org/rfc/rfc3629)], while percent-encoding
   those characters not allowed by the fragment rule in [[RFC3986](https://www.rfc-editor.org/rfc/rfc3986)].
```

test passed with impl https://github.com/santhosh-tekuri/boon

if test is ok, will add to remaining drafts