### PR TITLE
test: A $dynamicRef without anchor in fragment behaves identical to $ref

### DIFF
--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -118,6 +118,44 @@
         ]
     },
     {
+        "description": "A $dynamicRef without anchor in fragment behaves identical to $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-without-anchor/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#/$defs/items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items",
+                          "type": "number"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is invalid",
+                "data": ["foo", "bar"],
+                "valid": false
+            },
+            {
+                "description": "An array of numbers is valid",
+                "data": [24, 42],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
from https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01#section-8.2.3.2:

```
If the initially resolved starting point URI includes a fragment that was 
created by the "$dynamicAnchor" keyword, the initial URI MUST be r
eplaced by the URI (including the fragment) for the outermost schema 
resource in the dynamic scope that defines an identically named fragment 
with "$dynamicAnchor"

Otherwise, its behavior is identical to "$ref", and no runtime resolution is needed.
```

please ensure that my understanding is correct and the test case is valid