### PR TITLE
test: cover ISO8601 date values accepted by Python 3.11 datetime module

### DIFF
--- a/tests/draft-next/optional/format/date.json
+++ b/tests/draft-next/optional/format/date.json
@@ -220,6 +220,26 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
+                "data": "20230328",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number implicit day of week (2023-01-02)",
+                "data": "2023-W01",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number with day of week (2023-03-28)",
+                "data": "2023-W13-2",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number rollover to next year (2023-01-01)",
+                "data": "2022W527",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -220,6 +220,26 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
+                "data": "20230328",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number implicit day of week (2023-01-02)",
+                "data": "2023-W01",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number with day of week (2023-03-28)",
+                "data": "2023-W13-2",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number rollover to next year (2023-01-01)",
+                "data": "2022W527",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -220,6 +220,26 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
+                "data": "20230328",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number implicit day of week (2023-01-02)",
+                "data": "2023-W01",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number with day of week (2023-03-28)",
+                "data": "2023-W13-2",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number rollover to next year (2023-01-01)",
+                "data": "2022W527",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -217,6 +217,26 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4)",
                 "data": "1963-06-1৪",
                 "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
+                "data": "20230328",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number implicit day of week (2023-01-02)",
+                "data": "2023-W01",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number with day of week (2023-03-28)",
+                "data": "2023-W13-2",
+                "valid": false
+            },
+            {
+                "description": "ISO8601 / non-RFC3339: week number rollover to next year (2023-01-01)",
+                "data": "2022W527",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Python 3.11 `datetime` module allows additional ISO8601 date, time and date-time formats that are not RFC3339 5.6 compliant.

This change adds tests for invalid `date` values that are at the moment allowed by at least Python `jsonschema` library as valid `date` sttrings.

Looks like `date-time` and `time` test cases already cover at least some values that are valid by ISO8601 but not by RFC3339 section 5.6.

See:
 * https://docs.python.org/3/whatsnew/3.11.html#datetime
 * https://github.com/python/cpython/commit/1303f8c927
 * https://docs.python.org/3.11/library/datetime.html#datetime.date.fromisoformat
 * https://www.rfc-editor.org/rfc/rfc3339#section-5.6

PR sent to `jsonschema` library python-jsonschema/jsonschema#1076.