### PR TITLE
Revert "Revert "by default, "format" only annotates, not validates""

### DIFF
--- a/tests/draft-next/format.json
+++ b/tests/draft-next/format.json
@@ -35,6 +35,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid email string is only an annotation by default",
+                "data": "2962",
+                "valid": true
             }
         ]
     },
@@ -73,6 +78,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-email string is only an annotation by default",
+                "data": "2962",
                 "valid": true
             }
         ]
@@ -113,6 +123,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid regex string is only an annotation by default",
+                "data": "^(abc]",
+                "valid": true
             }
         ]
     },
@@ -151,6 +166,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ipv4 string is only an annotation by default",
+                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -191,6 +211,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid ipv6 string is only an annotation by default",
+                "data": "12345::",
+                "valid": true
             }
         ]
     },
@@ -229,6 +254,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-hostname string is only an annotation by default",
+                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -269,6 +299,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid hostname string is only an annotation by default",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": true
             }
         ]
     },
@@ -307,6 +342,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date string is only an annotation by default",
+                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -347,6 +387,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid date-time string is only an annotation by default",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": true
             }
         ]
     },
@@ -385,6 +430,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid time string is only an annotation by default",
+                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -425,6 +475,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid json-pointer string is only an annotation by default",
+                "data": "/foo/bar~",
+                "valid": true
             }
         ]
     },
@@ -463,6 +518,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid relative-json-pointer string is only an annotation by default",
+                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -503,6 +563,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid iri string is only an annotation by default",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": true
             }
         ]
     },
@@ -541,6 +606,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid iri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -581,6 +651,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri string is only an annotation by default",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
             }
         ]
     },
@@ -619,6 +694,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid uri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -659,6 +739,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri-template string is only an annotation by default",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": true
             }
         ]
     },
@@ -698,6 +783,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uuid string is only an annotation by default",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": true
             }
         ]
     },
@@ -736,6 +826,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid duration string is only an annotation by default",
+                "data": "PT1D",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/format.json
+++ b/tests/draft2020-12/format.json
@@ -35,6 +35,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid email string is only an annotation by default",
+                "data": "2962",
+                "valid": true
             }
         ]
     },
@@ -73,6 +78,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-email string is only an annotation by default",
+                "data": "2962",
                 "valid": true
             }
         ]
@@ -113,6 +123,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid regex string is only an annotation by default",
+                "data": "^(abc]",
+                "valid": true
             }
         ]
     },
@@ -151,6 +166,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid ipv4 string is only an annotation by default",
+                "data": "127.0.0.0.1",
                 "valid": true
             }
         ]
@@ -191,6 +211,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid ipv6 string is only an annotation by default",
+                "data": "12345::",
+                "valid": true
             }
         ]
     },
@@ -229,6 +254,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid idn-hostname string is only an annotation by default",
+                "data": "〮실례.테스트",
                 "valid": true
             }
         ]
@@ -269,6 +299,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid hostname string is only an annotation by default",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": true
             }
         ]
     },
@@ -307,6 +342,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid date string is only an annotation by default",
+                "data": "06/19/1963",
                 "valid": true
             }
         ]
@@ -347,6 +387,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid date-time string is only an annotation by default",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": true
             }
         ]
     },
@@ -385,6 +430,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid time string is only an annotation by default",
+                "data": "08:30:06 PST",
                 "valid": true
             }
         ]
@@ -425,6 +475,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid json-pointer string is only an annotation by default",
+                "data": "/foo/bar~",
+                "valid": true
             }
         ]
     },
@@ -463,6 +518,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid relative-json-pointer string is only an annotation by default",
+                "data": "/foo/bar",
                 "valid": true
             }
         ]
@@ -503,6 +563,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid iri string is only an annotation by default",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": true
             }
         ]
     },
@@ -541,6 +606,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid iri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\filëßåré",
                 "valid": true
             }
         ]
@@ -581,6 +651,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri string is only an annotation by default",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
             }
         ]
     },
@@ -619,6 +694,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid uri-reference string is only an annotation by default",
+                "data": "\\\\WINDOWS\\fileshare",
                 "valid": true
             }
         ]
@@ -659,6 +739,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uri-template string is only an annotation by default",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": true
             }
         ]
     },
@@ -698,6 +783,11 @@
                 "description": "all string formats ignore nulls",
                 "data": null,
                 "valid": true
+            },
+            {
+                "description": "invalid uuid string is only an annotation by default",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": true
             }
         ]
     },
@@ -736,6 +826,11 @@
             {
                 "description": "all string formats ignore nulls",
                 "data": null,
+                "valid": true
+            },
+            {
+                "description": "invalid duration string is only an annotation by default",
+                "data": "PT1D",
                 "valid": true
             }
         ]


### PR DESCRIPTION
This reverts the parts of commit 0173a0835468bcba04b3eb578fc33f587e3abcc6 that pertain to draft2020-12 and draft-next.

Resolves #660.