### PR TITLE
Make all root $ids absolute URIs

### DIFF
--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -601,16 +601,16 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/draft/next/ref-and-id1/base.json",
+            "$id": "https://example.com/draft/next/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$comment": "canonical uri: https://example.com/ref-and-id1/int.json",
                     "$id": "int.json",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$comment": "canonical uri: https://example.com/ref-and-id1-int.json",
                     "$id": "/draft/next/ref-and-id1-int.json",
                     "maximum": 2
                 }
@@ -634,16 +634,16 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/draft/next/ref-and-id2/base.json",
+            "$id": "https://example.com/draft/next/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$comment": "canonical uri: https://example.com/ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: https://example.com/ref-and-id2/base.json#bigint",
                     "$anchor": "bigint",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$comment": "canonical uri: https://example.com/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint",
                     "$id": "/draft/next/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2

--- a/tests/draft2019-09/recursiveRef.json
+++ b/tests/draft2019-09/recursiveRef.json
@@ -318,7 +318,7 @@
         "description": "multiple dynamic paths to the $recursiveRef keyword",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "recursiveRef8_main.json",
+            "$id": "https://example.com/recursiveRef8_main.json",
             "$defs": {
                 "inner": {
                     "$id": "recursiveRef8_inner.json",
@@ -365,7 +365,7 @@
         "description": "dynamic $recursiveRef destination (not predictable at schema compile time)",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "main.json",
+            "$id": "https://example.com/main.json",
             "$defs": {
                 "inner": {
                     "$id": "inner.json",

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -601,16 +601,16 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/draft2019-09/ref-and-id1/base.json",
+            "$id": "https://example.com/draft2019-09/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /draft2019-09/ref-and-id1/int.json",
+                    "$comment": "canonical uri: https://example.com/draft2019-09/ref-and-id1/int.json",
                     "$id": "int.json",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /draft2019-09/ref-and-id1-int.json",
+                    "$comment": "canonical uri: https://example.com/draft2019-09/ref-and-id1-int.json",
                     "$id": "/draft2019-09/ref-and-id1-int.json",
                     "maximum": 2
                 }
@@ -634,16 +634,16 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
-            "$id": "/draft2019-09/ref-and-id2/base.json",
+            "$id": "https://example.com/draft2019-09/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /draft2019-09/ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$comment": "canonical uri: https://example.com/draft2019-09/ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: https://example.com/ref-and-id2/base.json#bigint",
                     "$anchor": "bigint",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /draft2019-09/ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$comment": "canonical uri: https://example.com/draft2019-09/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint",
                     "$id": "/draft2019-09/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -601,16 +601,16 @@
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "/draft2020-12/ref-and-id1/base.json",
+            "$id": "https://example.com/draft2020-12/ref-and-id1/base.json",
             "$ref": "int.json",
             "$defs": {
                 "bigint": {
-                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$comment": "canonical uri: https://example.com/ref-and-id1/int.json",
                     "$id": "int.json",
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$comment": "canonical uri: https://example.com/ref-and-id1-int.json",
                     "$id": "/draft2020-12/ref-and-id1-int.json",
                     "maximum": 2
                 }
@@ -634,7 +634,7 @@
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "/draft2020-12/ref-and-id2/base.json",
+            "$id": "https://example.com/draft2020-12/ref-and-id2/base.json",
             "$ref": "#bigint",
             "$defs": {
                 "bigint": {
@@ -643,8 +643,8 @@
                     "maximum": 10
                 },
                 "smallint": {
-                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
-                    "$id": "/draft2020-12/ref-and-id2/",
+                    "$comment": "canonical uri: https://example.com/ref-and-id2#/$defs/smallint; another valid uri for this location: https://example.com/ref-and-id2/#bigint",
+                    "$id": "https://example.com/draft2020-12/ref-and-id2/",
                     "$anchor": "bigint",
                     "maximum": 2
                 }


### PR DESCRIPTION
I noticed that there are a few root `$id`s in some tests that aren't absolute. These tests should work if the test harness assigns an arbitrary retrieval URI, but I don't think that should be expected.