### PR TITLE
test if without then/else creates annotations

### DIFF
--- a/tests/draft-next/unevaluatedItems.json
+++ b/tests/draft-next/unevaluatedItems.json
@@ -692,5 +692,28 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "prefixItems": [{"const": "a"}]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": [ "a" ],
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": [ "b" ],
+                "valid": false
+            }
+
+        ]
     }
 ]

--- a/tests/draft-next/unevaluatedProperties.json
+++ b/tests/draft-next/unevaluatedProperties.json
@@ -1538,5 +1538,35 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "patternProperties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": {
+                    "foo": "a"
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -600,5 +600,28 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "items": [{"const": "a"}]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": [ "a" ],
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": [ "b" ],
+                "valid": false
+            }
+
+        ]
     }
 ]

--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -1441,5 +1441,35 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "patternProperties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": {
+                    "foo": "a"
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -692,5 +692,28 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "unevaluatedItems can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "prefixItems": [{"const": "a"}]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": [ "a" ],
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": [ "b" ],
+                "valid": false
+            }
+
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1441,5 +1441,35 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "unevaluatedProperties can see annotations from if without then and else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "patternProperties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "valid in case if is evaluated",
+                "data": {
+                    "foo": "a"
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid in case if is evaluated",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
additional tests, testing `if` creates annotations without `then` and `else`.

Ref: https://json-schema.slack.com/archives/CT8QRGTK5/p1681141864534459