### PR TITLE
Remove invalid output tests

### DIFF
--- a/output-tests/draft2019-09/content/type.json
+++ b/output-tests/draft2019-09/content/type.json
@@ -31,32 +31,6 @@
                         "required": ["errors"]
                     }
                 }
-            },
-            {
-                "description": "correct type yields an output unit",
-                "data": "a string",
-                "output": {
-                    "basic": {
-                        "$id": "https://json-schema.org/tests/content/draft2019-09/type/0/tests/1/basic",
-                        "$ref": "/draft/2019-09/output/schema",
-                        "properties": {
-                            "annotations": {
-                                "contains": {
-                                    "properties": {
-                                        "valid": {"const": true},
-                                        "keywordLocation": {"const": "/type"},
-                                        "absoluteKeywordLocation": {"const": "https://json-schema.org/tests/content/draft2019-09/type/0#/type"},
-                                        "instanceLocation": {"const": ""},
-                                        "annotation": false,
-                                        "error": false
-                                    },
-                                    "required": ["keywordLocation", "instanceLocation"]
-                                }
-                            }
-                        },
-                        "required": ["annotations"]
-                    }
-                }
             }
         ]
     }

--- a/output-tests/draft2020-12/content/type.json
+++ b/output-tests/draft2020-12/content/type.json
@@ -31,32 +31,6 @@
                         "required": ["errors"]
                     }
                 }
-            },
-            {
-                "description": "correct type yields an output unit",
-                "data": "a string",
-                "output": {
-                    "basic": {
-                        "$id": "https://json-schema.org/tests/content/draft2020-12/type/0/tests/1/basic",
-                        "$ref": "/draft/2020-12/output/schema",
-                        "properties": {
-                            "annotations": {
-                                "contains": {
-                                    "properties": {
-                                        "valid": {"const": true},
-                                        "keywordLocation": {"const": "/type"},
-                                        "absoluteKeywordLocation": {"const": "https://json-schema.org/tests/content/draft2020-12/type/0#/type"},
-                                        "instanceLocation": {"const": ""},
-                                        "annotation": false,
-                                        "error": false
-                                    },
-                                    "required": ["keywordLocation", "instanceLocation"]
-                                }
-                            }
-                        },
-                        "required": ["annotations"]
-                    }
-                }
             }
         ]
     }


### PR DESCRIPTION
The 2019-09 and 2020-12 specifications do not require an output unit to be generated for a passing keyword that does not produce an annotation.