### PR TITLE
test: hostname format check fails on empty string

### DIFF
--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -95,6 +95,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -301,6 +301,11 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "\u0628\u064a\u200c\u0628\u064a",
                 "valid": true
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -95,6 +95,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -301,6 +301,11 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "\u0628\u064a\u200c\u0628\u064a",
                 "valid": true
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -95,6 +95,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -301,6 +301,11 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "\u0628\u064a\u200c\u0628\u064a",
                 "valid": true
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/host-name.json
+++ b/tests/draft3/optional/format/host-name.json
@@ -57,6 +57,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -92,6 +92,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -92,6 +92,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -92,6 +92,11 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -298,6 +298,11 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "\u0628\u064a\u200c\u0628\u064a",
                 "valid": true
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Assert that hostname format validation fails gracefully on empty strings.

This is especially for Python `jsonschema` library that raises an unexpected ValueError exception on `hostname` check (python-jsonschema/jsonschema#1121).

Adds similar test for:
 * draft3: host-name
 * draft4: hostname
 * draft6: hosntame
 * draft7: hostname, idn-hostname
 * draft2019-09: hostname, idn-hostname
 * draft2020-12: hostname, idn-hostname
 * draft-next: hostname, idn-hostname