### PR TITLE
Simplify test for dynamic ref with multiple paths

### DIFF
--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -207,45 +207,75 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
+            "propertyDependencies": {
+                "kindOfList": {
+                    "numbers": { "$ref": "numberList" },
+                    "strings": { "$ref": "stringList" }
+                }
+            },
             "$defs": {
-                "inner": {
-                    "$id": "inner",
-                    "$dynamicAnchor": "foo",
-                    "title": "inner",
-                    "additionalProperties": {
-                        "$dynamicRef": "#foo"
+                "genericList": {
+                    "$id": "genericList",
+                    "properties": {
+                        "list": {
+                            "items": { "$dynamicRef": "#itemType" }
+                        }
                     }
+                },
+                "numberList": {
+                    "$id": "numberList",
+                    "$defs": {
+                        "itemType": {
+                            "$dynamicAnchor": "itemType",
+                            "type": "number"
+                        }
+                    },
+                    "$ref": "genericList"
+                },
+                "stringList": {
+                    "$id": "stringList",
+                    "$defs": {
+                        "itemType": {
+                            "$dynamicAnchor": "itemType",
+                            "type": "string"
+                        }
+                    },
+                    "$ref": "genericList"
                 }
-            },
-            "if": {
-                "propertyNames": {
-                    "pattern": "^[a-m]"
-                }
-            },
-            "then": {
-                "title": "any type of node",
-                "$id": "anyLeafNode",
-                "$dynamicAnchor": "foo",
-                "$ref": "inner"
-            },
-            "else": {
-                "title": "integer node",
-                "$id": "integerNode",
-                "$dynamicAnchor": "foo",
-                "type": [ "object", "integer" ],
-                "$ref": "inner"
             }
         },
         "tests": [
             {
-                "description": "recurse to anyLeafNode - floats are allowed",
-                "data": { "alpha": 1.1 },
+                "description": "number list with number values",
+                "data": {
+                    "kindOfList": "numbers",
+                    "list": [1.1]
+                },
                 "valid": true
             },
             {
-                "description": "recurse to integerNode - floats are not allowed",
-                "data": { "november": 1.1 },
+                "description": "number list with string values",
+                "data": {
+                    "kindOfList": "numbers",
+                    "list": ["foo"]
+                },
                 "valid": false
+            },
+            {
+                "description": "string list with number values",
+                "data": {
+                    "kindOfList": "strings",
+                    "list": [1.1]
+                },
+                "valid": false
+            },
+            {
+                "description": "string list with string values",
+                "data": {
+                    "kindOfList": "strings",
+                    "list": ["foo"]
+                },
+                "valid": true
             }
         ]
     },

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -393,59 +393,82 @@
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
             "if": {
-                "propertyNames": {
-                    "pattern": "^[a-m]"
-                }
-            },
-            "then": {
-                "$id": "numberValues",
-                "$defs": {
-                  "foo": {
-                    "$dynamicAnchor": "foo",
-                    "type": "number"
-                  }
+                "properties": {
+                    "kindOfList": { "const": "numbers" }
                 },
-                "$ref": "inner"
+                "required": ["kindOfList"]
             },
-            "else": {
-                "$id": "stringValues",
-                "$defs": {
-                  "foo": {
-                    "$dynamicAnchor": "foo",
-                    "type": "string"
-                  }
-                },
-                "$ref": "inner"
-            },
+            "then": { "$ref": "numberList" },
+            "else": { "$ref": "stringList" },
+
             "$defs": {
-                "inner": {
-                    "$id": "inner",
-                    "$dynamicAnchor": "foo",
-                    "additionalProperties": {
-                        "$dynamicRef": "#foo"
+                "genericList": {
+                    "$id": "genericList",
+                    "properties": {
+                        "list": {
+                            "items": { "$dynamicRef": "#itemType" }
+                        }
+                    },
+                    "$defs": {
+                        "defaultItemType": {
+                            "$comment": "Only needed to satisfy bookending requirement",
+                            "$dynamicAnchor": "itemType"
+                        }
                     }
+                },
+                "numberList": {
+                    "$id": "numberList",
+                    "$defs": {
+                        "itemType": {
+                            "$dynamicAnchor": "itemType",
+                            "type": "number"
+                        }
+                    },
+                    "$ref": "genericList"
+                },
+                "stringList": {
+                    "$id": "stringList",
+                    "$defs": {
+                        "itemType": {
+                            "$dynamicAnchor": "itemType",
+                            "type": "string"
+                        }
+                    },
+                    "$ref": "genericList"
                 }
             }
         },
         "tests": [
             {
-                "description": "alpha with number values",
-                "data": { "alpha": 1.1 },
+                "description": "number list with number values",
+                "data": {
+                    "kindOfList": "numbers",
+                    "list": [1.1]
+                },
                 "valid": true
             },
             {
-                "description": "alpha with string values",
-                "data": { "alpha": "foo" },
+                "description": "number list with string values",
+                "data": {
+                    "kindOfList": "numbers",
+                    "list": ["foo"]
+                },
                 "valid": false
             },
             {
-                "description": "november with number values",
-                "data": { "november": 1.1 },
+                "description": "string list with number values",
+                "data": {
+                    "kindOfList": "strings",
+                    "list": [1.1]
+                },
                 "valid": false
             },
             {
-                "description": "november with string values",
-                "data": { "november": "foo" },
+                "description": "string list with string values",
+                "data": {
+                    "kindOfList": "strings",
+                    "list": ["foo"]
+                },
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -392,45 +392,61 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
-            "$defs": {
-                "inner": {
-                    "$id": "inner",
-                    "$dynamicAnchor": "foo",
-                    "title": "inner",
-                    "additionalProperties": {
-                        "$dynamicRef": "#foo"
-                    }
-                }
-            },
             "if": {
                 "propertyNames": {
                     "pattern": "^[a-m]"
                 }
             },
             "then": {
-                "title": "any type of node",
-                "$id": "anyLeafNode",
-                "$dynamicAnchor": "foo",
+                "$id": "numberValues",
+                "$defs": {
+                  "foo": {
+                    "$dynamicAnchor": "foo",
+                    "type": "number"
+                  }
+                },
                 "$ref": "inner"
             },
             "else": {
-                "title": "integer node",
-                "$id": "integerNode",
-                "$dynamicAnchor": "foo",
-                "type": [ "object", "integer" ],
+                "$id": "stringValues",
+                "$defs": {
+                  "foo": {
+                    "$dynamicAnchor": "foo",
+                    "type": "string"
+                  }
+                },
                 "$ref": "inner"
+            },
+            "$defs": {
+                "inner": {
+                    "$id": "inner",
+                    "$dynamicAnchor": "foo",
+                    "additionalProperties": {
+                        "$dynamicRef": "#foo"
+                    }
+                }
             }
         },
         "tests": [
             {
-                "description": "recurse to anyLeafNode - floats are allowed",
+                "description": "alpha with number values",
                 "data": { "alpha": 1.1 },
                 "valid": true
             },
             {
-                "description": "recurse to integerNode - floats are not allowed",
+                "description": "alpha with string values",
+                "data": { "alpha": "foo" },
+                "valid": false
+            },
+            {
+                "description": "november with number values",
                 "data": { "november": 1.1 },
                 "valid": false
+            },
+            {
+                "description": "november with string values",
+                "data": { "november": "foo" },
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
I was trying to use one of our tests to explain how dynamic references depend on instances, but the behavior of the schema is really hard to follow. Confusing tests are not good tests, so I'm proposing to change the test to something that tests the same behavior, but does so in a less confusing way.