### PR TITLE
Bump the sanity check to use a released version of jsonschema

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -14,9 +14,11 @@ import warnings
 try:
     import jsonschema.validators
 except ImportError:
-    jsonschema = None
+    jsonschema = Unresolvable = None
     VALIDATORS = {}
 else:
+    from referencing.exceptions import Unresolvable
+
     VALIDATORS = {
         "draft3": jsonschema.validators.Draft3Validator,
         "draft4": jsonschema.validators.Draft4Validator,
@@ -587,7 +589,7 @@ class SanityTests(unittest.TestCase):
                 with self.subTest(case=case, version=version.name):
                     try:
                         Validator(case["schema"]).is_valid(12)
-                    except jsonschema.exceptions.RefResolutionError:
+                    except Unresolvable:
                         pass
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
@@ -615,9 +617,6 @@ class SanityTests(unittest.TestCase):
             with self.subTest(path=path):
                 try:
                     validator.validate(cases)
-                except jsonschema.exceptions.RefResolutionError:
-                    # python-jsonschema/jsonschema#884
-                    pass
                 except jsonschema.ValidationError as error:
                     self.fail(str(error))
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ skipsdist = True
 
 [testenv:sanity]
 # used just for validating the structure of the test case files themselves
-deps = jsonschema==4.18.0a4
+deps = jsonschema==4.19.0
 commands = {envpython} bin/jsonschema_suite check


### PR DESCRIPTION
It was previously pinned to an alpha.

(This really was intended to get committed directly rather than uselessly pinging whoever is watching this repo, but our repo permissions are still broken and prevent doing so.)