### PR TITLE
Added tests to encoded refs to unknown keywords.

### DIFF
--- a/tests/draft-next/optional/refOfUnknownKeyword.json
+++ b/tests/draft-next/optional/refOfUnknownKeyword.json
@@ -2,7 +2,7 @@
     {
         "description": "reference of a root arbitrary keyword ",
         "schema": {
-            "$schema": "https://json-schema.org/draft/next/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unknown-keyword": {"type": "integer"},
             "properties": {
                 "bar": {"$ref": "#/unknown-keyword"}
@@ -22,12 +22,56 @@
         ]
     },
     {
+        "description": "reference of a root arbitrary keyword with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unknown/keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown~1keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
-            "$schema": "https://json-schema.org/draft/next/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"unknown/keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown~1keyword"}
             }
         },
         "tests": [

--- a/tests/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/tests/draft2019-09/optional/refOfUnknownKeyword.json
@@ -2,7 +2,7 @@
     {
         "description": "reference of a root arbitrary keyword ",
         "schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "unknown-keyword": {"type": "integer"},
             "properties": {
                 "bar": {"$ref": "#/unknown-keyword"}
@@ -22,12 +22,56 @@
         ]
     },
     {
+        "description": "reference of a root arbitrary keyword with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unknown/keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown~1keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"unknown/keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown~1keyword"}
             }
         },
         "tests": [

--- a/tests/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/tests/draft2020-12/optional/refOfUnknownKeyword.json
@@ -22,12 +22,56 @@
         ]
     },
     {
+        "description": "reference of a root arbitrary keyword with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unknown/keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown~1keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "reference of an arbitrary keyword of a sub-schema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {"unknown-keyword": {"type": "integer"}},
                 "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema with encoded ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"unknown/keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown~1keyword"}
             }
         },
         "tests": [


### PR DESCRIPTION
An issue was opened against my json-schema implementation https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/238

This turned out to be an implementation-specific bug that related to the handling of references to non-keyword schema islands.

While this is very much an "implementation specific" issue, it is similar to the existing `refOfUnknownKeyword` tests, and catches a case that is not otherwise validated, but is common in e.g. OpenAPI.

The Slack discussion is to be found:

https://json-schema.slack.com/archives/C8CQ81GKF/p1690501470341369

This PR adds tests to the existing `optional/refOfUnknownKeyword.json` tests in `draft2020-12`, `draft2019-09` and `draft-next`.