### PR TITLE
test single label hostnames

### DIFF
--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -95,6 +95,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -97,6 +97,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true

--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -107,8 +107,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -95,6 +95,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -97,6 +97,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -107,8 +107,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -95,6 +95,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -97,6 +97,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -107,8 +107,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -104,8 +104,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -111,7 +111,7 @@
             {
                 "description": "single label starting with digit",
                 "data": "1host",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "single label ending with digit",

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -109,11 +109,6 @@
                 "valid": true
             },
             {
-                "description": "single label starting with digit",
-                "data": "1host",
-                "valid": false
-            },
-            {
                 "description": "single label ending with digit",
                 "data": "hostnam3",
                 "valid": true

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -92,6 +92,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -94,6 +94,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -104,8 +104,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -111,7 +111,7 @@
             {
                 "description": "single label starting with digit",
                 "data": "1host",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "single label ending with digit",

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -109,11 +109,6 @@
                 "valid": true
             },
             {
-                "description": "single label starting with digit",
-                "data": "1host",
-                "valid": false
-            },
-            {
                 "description": "single label ending with digit",
                 "data": "hostnam3",
                 "valid": true

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -92,6 +92,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -94,6 +94,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -104,8 +104,18 @@
                 "valid": true
             },
             {
+                "description": "single label with digits",
+                "data": "h0stn4me",
+                "valid": true
+            },
+            {
                 "description": "single label starting with digit",
                 "data": "1host",
+                "valid": true
+            },
+            {
+                "description": "single label ending with digit",
+                "data": "hostnam3",
                 "valid": true
             }
         ]

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -111,7 +111,7 @@
             {
                 "description": "single label starting with digit",
                 "data": "1host",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "single label ending with digit",

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -109,11 +109,6 @@
                 "valid": true
             },
             {
-                "description": "single label starting with digit",
-                "data": "1host",
-                "valid": false
-            },
-            {
                 "description": "single label ending with digit",
                 "data": "hostnam3",
                 "valid": true

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -92,6 +92,16 @@
                 "description": "exceeds maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "single label with hyphen",
+                "data": "host-name",
+                "valid": true
+            },
+            {
+                "description": "single label starting with digit",
+                "data": "1host",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -94,6 +94,11 @@
                 "valid": false
             },
             {
+                "description": "single label",
+                "data": "hostname",
+                "valid": true
+            },
+            {
                 "description": "single label with hyphen",
                 "data": "host-name",
                 "valid": true


### PR DESCRIPTION
RFC1123 allows single label hostnames with hyphens in between and starting with a digit.