### PR TITLE
Updates python-experimental implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Node-specific support is maintained in a [separate repository](https://github.co
 * [fastjsonschema](https://github.com/seznam/python-fastjsonschema)
 * [hypothesis-jsonschema](https://github.com/Zac-HD/hypothesis-jsonschema)
 * [jschon](https://github.com/marksparkza/jschon)
-* [python-experimental, OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/python-experimental.md)
+* [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator)
 
 ### Ruby
 


### PR DESCRIPTION
In openapi-generator, [the `python-experimental` generator was removed](https://github.com/OpenAPITools/openapi-generator/pull/15486), and has now been moved to the repo https://github.com/openapi-json-schema-tools/openapi-json-schema-generator

This PR updates the python implementation link to point to that updated location.

Note: I am the author of the python-experimental generator and the new `openapi-json-schema-generator` repo