### PR TITLE
Add missing $schema keyword to required test cases

### DIFF
--- a/tests/draft-next/dependentSchemas.json
+++ b/tests/draft-next/dependentSchemas.json
@@ -132,6 +132,7 @@
     {
         "description": "dependent subschema incompatible with root",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "properties": {
                 "foo": {}
             },

--- a/tests/draft-next/ref.json
+++ b/tests/draft-next/ref.json
@@ -862,6 +862,7 @@
     {
         "description": "URN ref with nested pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
             "$defs": {
                 "foo": {
@@ -887,6 +888,7 @@
     {
         "description": "ref to if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "http://example.com/ref/if",
             "if": {
                 "$id": "http://example.com/ref/if",
@@ -909,6 +911,7 @@
     {
         "description": "ref to then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "http://example.com/ref/then",
             "then": {
                 "$id": "http://example.com/ref/then",
@@ -931,6 +934,7 @@
     {
         "description": "ref to else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "http://example.com/ref/else",
             "else": {
                 "$id": "http://example.com/ref/else",
@@ -953,6 +957,7 @@
     {
         "description": "ref with absolute-path-reference",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "http://example.com/ref/absref.json",
             "$defs": {
                 "a": {
@@ -982,6 +987,7 @@
     {
         "description": "$id with file URI still resolves pointers - *nix",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "file:///folder/file.json",
             "$defs": {
                 "foo": {
@@ -1006,6 +1012,7 @@
     {
         "description": "$id with file URI still resolves pointers - windows",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$id": "file:///c:/folder/file.json",
             "$defs": {
                 "foo": {
@@ -1030,6 +1037,7 @@
     {
         "description": "empty tokens in $ref json-pointer",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$defs": {
                 "": {
                     "$defs": {

--- a/tests/draft-next/refRemote.json
+++ b/tests/draft-next/refRemote.json
@@ -265,7 +265,10 @@
     },
     {
         "description": "remote HTTP ref with different $id",
-        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/different-id-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -281,7 +284,10 @@
     },
     {
         "description": "remote HTTP ref with different URN $id",
-        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/urn-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -297,7 +303,10 @@
     },
     {
         "description": "remote HTTP ref with nested absolute ref",
-        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -314,6 +323,7 @@
     {
        "description": "$ref to $ref finds detached $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
             "$ref": "http://localhost:1234/draft-next/detached-ref.json#/$defs/foo"
         },
         "tests": [

--- a/tests/draft2019-09/dependentSchemas.json
+++ b/tests/draft2019-09/dependentSchemas.json
@@ -132,6 +132,7 @@
     {
         "description": "dependent subschema incompatible with root",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "properties": {
                 "foo": {}
             },

--- a/tests/draft2019-09/ref.json
+++ b/tests/draft2019-09/ref.json
@@ -862,6 +862,7 @@
     {
         "description": "URN ref with nested pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
             "$defs": {
                 "foo": {
@@ -887,6 +888,7 @@
     {
         "description": "ref to if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://example.com/ref/if",
             "if": {
                 "$id": "http://example.com/ref/if",
@@ -909,6 +911,7 @@
     {
         "description": "ref to then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://example.com/ref/then",
             "then": {
                 "$id": "http://example.com/ref/then",
@@ -931,6 +934,7 @@
     {
         "description": "ref to else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://example.com/ref/else",
             "else": {
                 "$id": "http://example.com/ref/else",
@@ -953,6 +957,7 @@
     {
          "description": "ref with absolute-path-reference",
          "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
              "$id": "http://example.com/ref/absref.json",
              "$defs": {
                  "a": {
@@ -982,6 +987,7 @@
      {
          "description": "$id with file URI still resolves pointers - *nix",
          "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
              "$id": "file:///folder/file.json",
              "$defs": {
                  "foo": {
@@ -1006,6 +1012,7 @@
      {
          "description": "$id with file URI still resolves pointers - windows",
          "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
              "$id": "file:///c:/folder/file.json",
              "$defs": {
                  "foo": {
@@ -1030,6 +1037,7 @@
      {
          "description": "empty tokens in $ref json-pointer",
          "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
              "$defs": {
                  "": {
                      "$defs": {

--- a/tests/draft2019-09/refRemote.json
+++ b/tests/draft2019-09/refRemote.json
@@ -265,7 +265,10 @@
     },
     {
         "description": "remote HTTP ref with different $id",
-        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/different-id-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -281,7 +284,10 @@
     },
     {
         "description": "remote HTTP ref with different URN $id",
-        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/urn-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -297,7 +303,10 @@
     },
     {
         "description": "remote HTTP ref with nested absolute ref",
-        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -314,6 +323,7 @@
     {
        "description": "$ref to $ref finds detached $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "$ref": "http://localhost:1234/draft2019-09/detached-ref.json#/$defs/foo"
         },
         "tests": [

--- a/tests/draft2020-12/dependentSchemas.json
+++ b/tests/draft2020-12/dependentSchemas.json
@@ -132,6 +132,7 @@
     {
         "description": "dependent subschema incompatible with root",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "properties": {
                 "foo": {}
             },

--- a/tests/draft2020-12/ref.json
+++ b/tests/draft2020-12/ref.json
@@ -862,6 +862,7 @@
     {
         "description": "URN ref with nested pointer ref",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
             "$defs": {
                 "foo": {
@@ -887,6 +888,7 @@
     {
         "description": "ref to if",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://example.com/ref/if",
             "if": {
                 "$id": "http://example.com/ref/if",
@@ -909,6 +911,7 @@
     {
         "description": "ref to then",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://example.com/ref/then",
             "then": {
                 "$id": "http://example.com/ref/then",
@@ -931,6 +934,7 @@
     {
         "description": "ref to else",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://example.com/ref/else",
             "else": {
                 "$id": "http://example.com/ref/else",
@@ -953,6 +957,7 @@
     {
         "description": "ref with absolute-path-reference",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "http://example.com/ref/absref.json",
             "$defs": {
                 "a": {
@@ -982,6 +987,7 @@
     {
         "description": "$id with file URI still resolves pointers - *nix",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "file:///folder/file.json",
             "$defs": {
                 "foo": {
@@ -1006,6 +1012,7 @@
     {
         "description": "$id with file URI still resolves pointers - windows",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "file:///c:/folder/file.json",
             "$defs": {
                 "foo": {
@@ -1030,6 +1037,7 @@
     {
         "description": "empty tokens in $ref json-pointer",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$defs": {
                 "": {
                     "$defs": {

--- a/tests/draft2020-12/refRemote.json
+++ b/tests/draft2020-12/refRemote.json
@@ -265,7 +265,10 @@
     },
     {
         "description": "remote HTTP ref with different $id",
-        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/different-id-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -281,7 +284,10 @@
     },
     {
         "description": "remote HTTP ref with different URN $id",
-        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/urn-ref-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -297,7 +303,10 @@
     },
     {
         "description": "remote HTTP ref with nested absolute ref",
-        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"
+        },
         "tests": [
             {
                 "description": "number is invalid",
@@ -314,6 +323,7 @@
     {
         "description": "$ref to $ref finds detached $anchor",
         "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$ref": "http://localhost:1234/draft2020-12/detached-ref.json#/$defs/foo"
         },
         "tests": [


### PR DESCRIPTION
This PR adds missing `$schema` keywords to required test cases.

Validation with absent `$schema` keyword shouldn't be considered as required by implementations.

### Spec reference:

> The "$schema" keyword SHOULD be used in the document root schema object, and MAY be used in the root schema objects of embedded schema resources. It MUST NOT appear in non-resource root schema objects. If absent from the document root schema, the resulting behavior is implementation-defined.

https://json-schema.org/draft/2020-12/json-schema-core#section-8.1.1-4