### PR TITLE
Add a test case for ipv4 with netmask

### DIFF
--- a/tests/draft-next/optional/format/ipv4.json
+++ b/tests/draft-next/optional/format/ipv4.json
@@ -81,6 +81,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -81,6 +81,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -81,6 +81,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -78,6 +78,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -78,6 +78,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -78,6 +78,11 @@
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
                 "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv4 address",
+                "data": "192.168.1.0/24",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
This PR adds a case to test that ipv4 format validation fails for address with a netmask. We already have such test case for ipv6, so why not add one for ipv4 😅 

### Spec reference:

> A string instance is valid against this attribute if it is a valid representation of an IPv4 address according to the "dotted-quad" ABNF syntax as defined in [RFC 2673, section 3.2](https://json-schema.org/draft-04/draft-fge-json-schema-validation-00#RFC2673) [RFC2673].

https://json-schema.org/draft-04/draft-fge-json-schema-validation-00#rfc.section.7.3.4.2