### PR TITLE
Add tests for heterogeneous arrays with additionalItems

### DIFF
--- a/tests/draft-next/items.json
+++ b/tests/draft-next/items.json
@@ -266,6 +266,26 @@
         ]
     },
     {
+        "description": "items with heterogeneous array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{}],
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "items with null instance elements",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",

--- a/tests/draft2019-09/additionalItems.json
+++ b/tests/draft2019-09/additionalItems.json
@@ -183,6 +183,26 @@
         ]
     },
     {
+        "description": "additionalItems with heterogeneous array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "additionalItems with null instance elements",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/tests/draft2020-12/items.json
+++ b/tests/draft2020-12/items.json
@@ -266,6 +266,26 @@
         ]
     },
     {
+        "description": "items with heterogeneous array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{}],
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "items with null instance elements",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/tests/draft3/additionalItems.json
+++ b/tests/draft3/additionalItems.json
@@ -111,6 +111,25 @@
         ]
     },
     {
+        "description": "additionalItems with heterogeneous array",
+        "schema": {
+            "items": [{}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "additionalItems with null instance elements",
         "schema": {
             "additionalItems": {

--- a/tests/draft4/additionalItems.json
+++ b/tests/draft4/additionalItems.json
@@ -147,6 +147,25 @@
         ]
     },
     {
+        "description": "additionalItems with heterogeneous array",
+        "schema": {
+            "items": [{}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "additionalItems with null instance elements",
         "schema": {
             "additionalItems": {

--- a/tests/draft6/additionalItems.json
+++ b/tests/draft6/additionalItems.json
@@ -170,6 +170,25 @@
         ]
     },
     {
+        "description": "additionalItems with heterogeneous array",
+        "schema": {
+            "items": [{}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "additionalItems with null instance elements",
         "schema": {
             "additionalItems": {

--- a/tests/draft7/additionalItems.json
+++ b/tests/draft7/additionalItems.json
@@ -170,6 +170,25 @@
         ]
     },
     {
+        "description": "additionalItems with heterogeneous array",
+        "schema": {
+            "items": [{}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "heterogeneous invalid instance",
+                "data": [ "foo", "bar", 37 ],
+                "valid": false
+            },
+            {
+                "description": "valid instance",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "additionalItems with null instance elements",
         "schema": {
             "additionalItems": {


### PR DESCRIPTION
We actually don't have any of these! -- I.e. tests where the instance is heterogeneous and additionalItems has to cope with items of different types.

Ref: python-jsonschema/jsonschema#1157