### PR TITLE
add optional tests for `$ref`ing into known non-applicator keywords

### DIFF
--- a/tests/draft-next/optional/refOfUnknownKeyword.json
+++ b/tests/draft-next/optional/refOfUnknownKeyword.json
@@ -42,5 +42,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "reference internals of known non-applicator",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "/base",
+            "examples": [
+              { "type": "string" }
+            ],
+            "$ref": "#/examples/0"
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 42,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/tests/draft2019-09/optional/refOfUnknownKeyword.json
@@ -42,5 +42,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "reference internals of known non-applicator",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "/base",
+            "examples": [
+              { "type": "string" }
+            ],
+            "$ref": "#/examples/0"
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 42,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/tests/draft2020-12/optional/refOfUnknownKeyword.json
@@ -42,5 +42,28 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "reference internals of known non-applicator",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/base",
+            "examples": [
+              { "type": "string" }
+            ],
+            "$ref": "#/examples/0"
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 42,
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Relates to https://github.com/gregsdennis/json-everything/issues/537

I've put these in the optional tests as we already have some "reference into weird places" tests here.