### PR TITLE
test when $dynamicRef references a boolean schema

### DIFF
--- a/tests/draft-next/dynamicRef.json
+++ b/tests/draft-next/dynamicRef.json
@@ -612,5 +612,35 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$dynamicRef points to a boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "true": true,
+                "false": false
+            },
+            "properties": {
+                "true": {
+                    "$dynamicRef": "#/$defs/true"
+                },
+                "false": {
+                    "$dynamicRef": "#/$defs/false"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "follow $dynamicRef to a true schema",
+                "data": { "true": 1 },
+                "valid": true
+            },
+            {
+                "description": "follow $dynamicRef to a false schema",
+                "data": { "false": 1 },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -726,5 +726,35 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$dynamicRef points to a boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "true": true,
+                "false": false
+            },
+            "properties": {
+                "true": {
+                    "$dynamicRef": "#/$defs/true"
+                },
+                "false": {
+                    "$dynamicRef": "#/$defs/false"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "follow $dynamicRef to a true schema",
+                "data": { "true": 1 },
+                "valid": true
+            },
+            {
+                "description": "follow $dynamicRef to a false schema",
+                "data": { "false": 1 },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This was an interesting one in my implementation - when looking for a `$dynamicAnchor` keyword at the destination schema, it threw an exception when that schema wasn't an object, but rather a boolean.