### PR TITLE
Add more detail around test runner requirements for `format` tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If your implementation supports multiple versions, run the above procedure for e
     ```
 
 2. Test cases found within [special subdirectories](#subdirectories-within-each-draft) may require additional configuration to run.
-   In particular, tests within the `optional/format` subdirectory may require implementations to change the way they treat the `"format"`keyword (particularly on older drafts which did not have a notion of vocabularies).
+   In particular, when running tests within the `optional/format` subdirectory, test runners should configure implementations to enable format validation, where the implementation supports it.
 
 ### Invariants & Guarantees
 


### PR DESCRIPTION
fixes: #702

Feels like the docs would benefit from something more specific than was currently there. Happy to reword as you see fit. 