### PR TITLE
Add tests for enum validation with arrays of boolean values

### DIFF
--- a/tests/draft-next/enum.json
+++ b/tests/draft-next/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/tests/draft2019-09/enum.json
+++ b/tests/draft2019-09/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/enum.json
+++ b/tests/draft2020-12/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/tests/draft4/enum.json
+++ b/tests/draft4/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/tests/draft6/enum.json
+++ b/tests/draft6/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/tests/draft7/enum.json
+++ b/tests/draft7/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]


### PR DESCRIPTION
For the `const` keyword, there are tests like

https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/589a08581ac1528df9a5422fba56b33cef2497a0/tests/draft2020-12/const.json#L147

This PR adds corresponding tests for `enum` (for all drafts except draft3).
