### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ This suite is being used by:
 * [Justify](https://github.com/leadpony/justify)
 * [Snow](https://github.com/ssilverman/snowy-json)
 * [jsonschemafriend](https://github.com/jimblackler/jsonschemafriend)
+* [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator)
 
 ### JavaScript
 


### PR DESCRIPTION
Adds openapi json schema generator to Java section because it now supports generation and validation of schemas in java

Per the latest release: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/4.1.0