### PR TITLE
add `$dynamicAnchor` to meta-schemas

### DIFF
--- a/remotes/draft-next/format-assertion-false.json
+++ b/remotes/draft-next/format-assertion-false.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/next/vocab/core": true,
         "https://json-schema.org/draft/next/vocab/format-assertion": false
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/next/meta/core" },
         { "$ref": "https://json-schema.org/draft/next/meta/format-assertion" }

--- a/remotes/draft-next/format-assertion-true.json
+++ b/remotes/draft-next/format-assertion-true.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/next/vocab/core": true,
         "https://json-schema.org/draft/next/vocab/format-assertion": true
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/next/meta/core" },
         { "$ref": "https://json-schema.org/draft/next/meta/format-assertion" }

--- a/remotes/draft-next/metaschema-no-validation.json
+++ b/remotes/draft-next/metaschema-no-validation.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/next/vocab/applicator": true,
         "https://json-schema.org/draft/next/vocab/core": true
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/next/meta/applicator" },
         { "$ref": "https://json-schema.org/draft/next/meta/core" }

--- a/remotes/draft-next/metaschema-optional-vocabulary.json
+++ b/remotes/draft-next/metaschema-optional-vocabulary.json
@@ -6,6 +6,7 @@
         "https://json-schema.org/draft/next/vocab/core": true,
         "http://localhost:1234/draft/next/vocab/custom": false
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/next/meta/validation" },
         { "$ref": "https://json-schema.org/draft/next/meta/core" }

--- a/remotes/draft2019-09/metaschema-no-validation.json
+++ b/remotes/draft2019-09/metaschema-no-validation.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/2019-09/vocab/applicator": true,
         "https://json-schema.org/draft/2019-09/vocab/core": true
     },
+    "$recursiveAnchor": true,
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2019-09/meta/applicator" },
         { "$ref": "https://json-schema.org/draft/2019-09/meta/core" }

--- a/remotes/draft2019-09/metaschema-optional-vocabulary.json
+++ b/remotes/draft2019-09/metaschema-optional-vocabulary.json
@@ -6,6 +6,7 @@
         "https://json-schema.org/draft/2019-09/vocab/core": true,
         "http://localhost:1234/draft/2019-09/vocab/custom": false
     },
+    "$recursiveAnchor": true,
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2019-09/meta/validation" },
         { "$ref": "https://json-schema.org/draft/2019-09/meta/core" }

--- a/remotes/draft2020-12/format-assertion-false.json
+++ b/remotes/draft2020-12/format-assertion-false.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "https://json-schema.org/draft/2020-12/vocab/format-assertion": false
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
         { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }

--- a/remotes/draft2020-12/format-assertion-true.json
+++ b/remotes/draft2020-12/format-assertion-true.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
         { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }

--- a/remotes/draft2020-12/metaschema-no-validation.json
+++ b/remotes/draft2020-12/metaschema-no-validation.json
@@ -5,6 +5,7 @@
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/core": true
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2020-12/meta/applicator" },
         { "$ref": "https://json-schema.org/draft/2020-12/meta/core" }

--- a/remotes/draft2020-12/metaschema-optional-vocabulary.json
+++ b/remotes/draft2020-12/metaschema-optional-vocabulary.json
@@ -6,6 +6,7 @@
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "http://localhost:1234/draft/2020-12/vocab/custom": false
     },
+    "$dynamicAnchor": "meta",
     "allOf": [
         { "$ref": "https://json-schema.org/draft/2020-12/meta/validation" },
         { "$ref": "https://json-schema.org/draft/2020-12/meta/core" }


### PR DESCRIPTION
These meta-schemas need $dynamicAnchor. The `meta/core` and `meta/applicator` vocabulary schemas use `$dynamicRef: "#meta"` and without $dynamicAnchor in these meta-schemas, those resolve to the vocabulary schema's $dynamicAnchor instead of resolving to these meta-schemas. For a schema described by one of these meta-schemas, its subschemas are then described by the vocabulary schema, but not the meta-schema. This affects subschemas such as the `properties` subschemas in https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/b41167c7/tests/draft2020-12/vocabulary.json#L8-L11

That example is the only place it's actually an issue in practice, because no other test schemas using these meta-schemas have any subschemas.

I did this for 2020-12 and draft-next - I don't have an implementation of 2019-09 but I think its custom meta-schemas should have `$recursiveAnchor: true`? Somebody with an implementation or better knowledge, please weigh in.