### PR TITLE
Test for unevaluatedItems with contains

### DIFF
--- a/tests/draft2019-09/unevaluatedItems.json
+++ b/tests/draft2019-09/unevaluatedItems.json
@@ -699,5 +699,138 @@
             }
 
         ]
+    },
+    {
+        "description": "unevaluatedItems depends on adjacent contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": [true],
+            "contains": {"type": "string"},
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "second item is evaluated by contains",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "contains fails, second item is not evaluated",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "contains passes, second item is not evaluated",
+                "data": [ 1, 2, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on multiple nested contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedItems": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": [ 2, 3, 4, 5, 6 ],
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": [ 2, 3, 4, 7, 8 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems and contains interact to control item dependency relationship",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "contains": {"const": "a"}
+            },
+            "then": {
+                "if": {
+                    "contains": {"const": "b"}
+                },
+                "then": {
+                    "if": {
+                        "contains": {"const": "c"}
+                    }
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "only a's are valid",
+                "data": [ "a", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's and b's are valid",
+                "data": [ "a", "b", "a", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's, b's and c's are valid",
+                "data": [ "c", "a", "c", "c", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "only b's are invalid",
+                "data": [ "b", "b" ],
+                "valid": false
+            },
+            {
+                "description": "only c's are invalid",
+                "data": [ "c", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only b's and c's are invalid",
+                "data": [ "c", "b", "c", "b", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only a's and c's are invalid",
+                "data": [ "c", "a", "c", "a", "c" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Exceeding items from minContains are also evaluated" , 
+        "schema":{
+            "$schema":"https://json-schema.org/draft/2019-09/schema",
+            "type": "array",
+            "contains": {"type": "string"},
+            "minContains": 2 , 
+            "unevaluatedItems": false
+        }, 
+        "tests":[
+            {
+                "description": "contains items are consider as the evaluated",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "execeding contains items also consider as the evaluated", 
+                "data": ["foo", "bar" , "exceeded_item1", "exceeded_item2"],
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -795,5 +795,27 @@
             }
 
         ]
+    },
+    {
+        "description": "Exceeding items from minContains are also evaluated" , 
+        "schema":{
+            "$schema":"https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "contains": {"type": "string"},
+            "minContains": 2 , 
+            "unevaluatedItems": false
+        }, 
+        "tests":[
+            {
+                "description": "contains items are consider as the evaluated",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "execeding contains items also consider as the evaluated", 
+                "data": ["foo", "bar" , "exceeded_item"],
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Based on the conclusion of the discussion in [this GitHub issue](https://github.com/json-schema-org/json-schema-spec/issues/810), the `contains` keyword annotation is collected by `unevaluatedItems` in 2019-09 draft . Therefore, all the tests for contains in the 2020-12 draft should also apply to the 2019-09 draft, if i am not wrong here.

Additionally, since the extra items from minContains are also evaluated as shown in #293 , it would be beneficial to add tests for that as well.