### PR TITLE
Move test of \a regex character to optional/format/regex

### DIFF
--- a/tests/draft-next/optional/ecmascript-regex.json
+++ b/tests/draft-next/optional/ecmascript-regex.json
@@ -409,12 +409,12 @@
         "description": "\\a is not an ECMA 262 control escape",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
-            "$ref": "https://json-schema.org/draft/next/schema"
+            "format": "regex"
         },
         "tests": [
             {
                 "description": "when used as a pattern",
-                "data": { "pattern": "\\a" },
+                "data": "\\a",
                 "valid": false
             }
         ]

--- a/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/ecmascript-regex.json
@@ -409,12 +409,12 @@
         "description": "\\a is not an ECMA 262 control escape",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$ref": "https://json-schema.org/draft/2020-12/schema"
+            "format": "regex"
         },
         "tests": [
             {
                 "description": "when used as a pattern",
-                "data": { "pattern": "\\a" },
+                "data": "\\a",
                 "valid": false
             }
         ]


### PR DESCRIPTION
This was validating "\\a" as a schema `pattern` described by the meta-schema as `format: regex`. This moves it to directly test the pattern against a `format: regex` schema.

related: https://github.com/json-schema-org/JSON-Schema-Test-Suite/commit/e42e8417, https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/309, https://github.com/json-schema-org/json-schema-spec/issues/821