### PR TITLE
Use spaces instead of tabs

### DIFF
--- a/tests/draft-next/oneOf.json
+++ b/tests/draft-next/oneOf.json
@@ -220,7 +220,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",

--- a/tests/draft2019-09/oneOf.json
+++ b/tests/draft2019-09/oneOf.json
@@ -220,7 +220,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/tests/draft2020-12/oneOf.json
+++ b/tests/draft2020-12/oneOf.json
@@ -220,7 +220,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/tests/draft4/oneOf.json
+++ b/tests/draft4/oneOf.json
@@ -159,7 +159,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "oneOf": [

--- a/tests/draft6/oneOf.json
+++ b/tests/draft6/oneOf.json
@@ -203,7 +203,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "oneOf": [

--- a/tests/draft7/oneOf.json
+++ b/tests/draft7/oneOf.json
@@ -203,7 +203,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "oneOf": [


### PR DESCRIPTION
Funny stuff: my YAML 1.1 parser panics on these tabs, wondering if it's mandated by spec or just this lib specific behavior. 