### PR TITLE
Reject single '.' character for hostname formats

### DIFF
--- a/tests/draft-next/optional/format/hostname.json
+++ b/tests/draft-next/optional/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -331,6 +331,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -331,6 +331,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -331,6 +331,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -117,6 +117,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -117,6 +117,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -117,6 +117,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -323,6 +323,11 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "single dot",
+                "data": ".",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
_This is a follow-up from #758._

Add negative tests for "." for hostname formats, based on RFC 1123 not allowing this value.