### PR TITLE
Add test cases for other valid label separators in IDN hostnames

### DIFF
--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -1,9 +1,6 @@
 [
     {
         "description": "validation of internationalized host names",
-        "specification": [
-            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
-        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "format": "idn-hostname"
@@ -334,39 +331,56 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
-            },
+            }
+        ]
+    },
+    {
+        "description": "validation of separators in internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
             {
                 "description": "single dot",
                 "data": ".",
                 "valid": false
             },
             {
-                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "description": "single ideographic full stop",
                 "data": "\u3002",
                 "valid": false
             },
             {
-                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "description": "single fullwidth full stop",
                 "data": "\uff0e",
                 "valid": false
             },
             {
-                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "description": "single halfwidth ideographic full stop",
                 "data": "\uff61",
                 "valid": false
             },
             {
-                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "dot as label separator",
+                "data": "a.b",
+                "valid": true
+            },
+            {
+                "description": "ideographic full stop as label separator",
                 "data": "a\u3002b",
                 "valid": true
             },
             {
-                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "description": "fullwidth full stop as label separator",
                 "data": "a\uff0eb",
                 "valid": true
             },
             {
-                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "halfwidth ideographic full stop as label separator",
                 "data": "a\uff61b",
                 "valid": true
             }

--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -336,6 +336,36 @@
                 "description": "single dot",
                 "data": ".",
                 "valid": false
+            },
+            {
+                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "data": "\u3002",
+                "valid": false
+            },
+            {
+                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "data": "\uff0e",
+                "valid": false
+            },
+            {
+                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "data": "\uff61",
+                "valid": false
+            },
+            {
+                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\u3002b",
+                "valid": true
+            },
+            {
+                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff0eb",
+                "valid": true
+            },
+            {
+                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff61b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft-next/optional/format/idn-hostname.json
+++ b/tests/draft-next/optional/format/idn-hostname.json
@@ -1,6 +1,9 @@
 [
     {
         "description": "validation of internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
             "format": "idn-hostname"

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -336,6 +336,36 @@
                 "description": "single dot",
                 "data": ".",
                 "valid": false
+            },
+            {
+                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "data": "\u3002",
+                "valid": false
+            },
+            {
+                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "data": "\uff0e",
+                "valid": false
+            },
+            {
+                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "data": "\uff61",
+                "valid": false
+            },
+            {
+                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\u3002b",
+                "valid": true
+            },
+            {
+                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff0eb",
+                "valid": true
+            },
+            {
+                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff61b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -1,6 +1,9 @@
 [
     {
         "description": "validation of internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "format": "idn-hostname"

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -1,9 +1,6 @@
 [
     {
         "description": "validation of internationalized host names",
-        "specification": [
-            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
-        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "format": "idn-hostname"
@@ -334,39 +331,56 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
-            },
+            }
+        ]
+    },
+    {
+        "description": "validation of separators in internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
             {
                 "description": "single dot",
                 "data": ".",
                 "valid": false
             },
             {
-                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "description": "single ideographic full stop",
                 "data": "\u3002",
                 "valid": false
             },
             {
-                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "description": "single fullwidth full stop",
                 "data": "\uff0e",
                 "valid": false
             },
             {
-                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "description": "single halfwidth ideographic full stop",
                 "data": "\uff61",
                 "valid": false
             },
             {
-                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "dot as label separator",
+                "data": "a.b",
+                "valid": true
+            },
+            {
+                "description": "ideographic full stop as label separator",
                 "data": "a\u3002b",
                 "valid": true
             },
             {
-                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "description": "fullwidth full stop as label separator",
                 "data": "a\uff0eb",
                 "valid": true
             },
             {
-                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "halfwidth ideographic full stop as label separator",
                 "data": "a\uff61b",
                 "valid": true
             }

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -336,6 +336,36 @@
                 "description": "single dot",
                 "data": ".",
                 "valid": false
+            },
+            {
+                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "data": "\u3002",
+                "valid": false
+            },
+            {
+                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "data": "\uff0e",
+                "valid": false
+            },
+            {
+                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "data": "\uff61",
+                "valid": false
+            },
+            {
+                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\u3002b",
+                "valid": true
+            },
+            {
+                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff0eb",
+                "valid": true
+            },
+            {
+                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff61b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -1,6 +1,9 @@
 [
     {
         "description": "validation of internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "format": "idn-hostname"

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -1,9 +1,6 @@
 [
     {
         "description": "validation of internationalized host names",
-        "specification": [
-            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
-        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "format": "idn-hostname"
@@ -334,39 +331,56 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
-            },
+            }
+        ]
+    },
+    {
+        "description": "validation of separators in internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
             {
                 "description": "single dot",
                 "data": ".",
                 "valid": false
             },
             {
-                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "description": "single ideographic full stop",
                 "data": "\u3002",
                 "valid": false
             },
             {
-                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "description": "single fullwidth full stop",
                 "data": "\uff0e",
                 "valid": false
             },
             {
-                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "description": "single halfwidth ideographic full stop",
                 "data": "\uff61",
                 "valid": false
             },
             {
-                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "dot as label separator",
+                "data": "a.b",
+                "valid": true
+            },
+            {
+                "description": "ideographic full stop as label separator",
                 "data": "a\u3002b",
                 "valid": true
             },
             {
-                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "description": "fullwidth full stop as label separator",
                 "data": "a\uff0eb",
                 "valid": true
             },
             {
-                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "halfwidth ideographic full stop as label separator",
                 "data": "a\uff61b",
                 "valid": true
             }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -1,6 +1,9 @@
 [
     {
         "description": "validation of internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
         "schema": { "format": "idn-hostname" },
         "tests": [
             {

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -328,6 +328,36 @@
                 "description": "single dot",
                 "data": ".",
                 "valid": false
+            },
+            {
+                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "data": "\u3002",
+                "valid": false
+            },
+            {
+                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "data": "\uff0e",
+                "valid": false
+            },
+            {
+                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "data": "\uff61",
+                "valid": false
+            },
+            {
+                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\u3002b",
+                "valid": true
+            },
+            {
+                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff0eb",
+                "valid": true
+            },
+            {
+                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "data": "a\uff61b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -1,9 +1,6 @@
 [
     {
         "description": "validation of internationalized host names",
-        "specification": [
-            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
-        ],
         "schema": { "format": "idn-hostname" },
         "tests": [
             {
@@ -326,39 +323,53 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
-            },
+            }
+        ]
+    },
+    {
+        "description": "validation of separators in internationalized host names",
+        "specification": [
+            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+        ],
+        "schema": { "format": "idn-hostname" },
+        "tests": [
             {
                 "description": "single dot",
                 "data": ".",
                 "valid": false
             },
             {
-                "description": "single ideographic full stop (RFC 3490#3.1)",
+                "description": "single ideographic full stop",
                 "data": "\u3002",
                 "valid": false
             },
             {
-                "description": "single fullwidth full stop (RFC 3490#3.1)",
+                "description": "single fullwidth full stop",
                 "data": "\uff0e",
                 "valid": false
             },
             {
-                "description": "single halfwidth ideographic full stop (RFC 3490#3.1)",
+                "description": "single halfwidth ideographic full stop",
                 "data": "\uff61",
                 "valid": false
             },
             {
-                "description": "ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "dot as label separator",
+                "data": "a.b",
+                "valid": true
+            },
+            {
+                "description": "ideographic full stop as label separator",
                 "data": "a\u3002b",
                 "valid": true
             },
             {
-                "description": "fullwidth full stop (RFC 3490#3.1) as label separator",
+                "description": "fullwidth full stop as label separator",
                 "data": "a\uff0eb",
                 "valid": true
             },
             {
-                "description": "halfwidth ideographic full stop (RFC 3490#3.1) as label separator",
+                "description": "halfwidth ideographic full stop as label separator",
                 "data": "a\uff61b",
                 "valid": true
             }


### PR DESCRIPTION
According to [RFC 3490 Section 3.1](https://datatracker.ietf.org/doc/html/rfc3490#section-3.1), the following characters should be recognized as a dot in IDN hostname:

- U+002E (full stop) - regular dot
- U+3002 (ideographic full stop)
- U+FF0E (fullwidth full stop)
- U+FF61 (halfwidth ideographic full stop)

This PR adds test cases for the remaining characters.

Please, let me know if you have any questions.

Continues #759 