### PR TITLE
Correct annotation python script to correctly work with rfc and iso links

### DIFF
--- a/bin/annotate-specification-links
+++ b/bin/annotate-specification-links
@@ -61,6 +61,18 @@ def line_number_of(path: Path, case: dict[str, Any]) -> int:
             1,
         )
 
+def extract_kind_and_spec(key: str) -> (str, str):
+    """
+    Extracts specification number and kind from the defined key
+    """
+    can_have_spec = ["rfc", "iso"]
+    if not any(key.startswith(el) for el in can_have_spec):
+        return key, ""
+    number = re.search(r"\d+", key)
+    spec = "" if number is None else number.group(0)
+    kind = key.removesuffix(spec)
+    return kind, spec
+
 
 def main():
     # Clear annotations which may have been emitted by a previous run.
@@ -82,20 +94,33 @@ def main():
                     line=error.lineno,
                     col=error.pos + 1,
                     title=str(error),
+                    message=f"cannot load {path}"
                 )
                 sys.stdout.write(error)
+                continue
 
             for test_case in contents:
                 specifications = test_case.get("specification")
                 if specifications is not None:
                     for each in specifications:
                         quote = each.pop("quote", "")
-                        (kind, section), = each.items()
+                        (key, section), = each.items()
 
-                        number = re.search(r"\d+", kind)
-                        spec = "" if number is None else number.group(0)
+                        (kind, spec) = extract_kind_and_spec(key)
 
-                        url = version_urls[kind].expand(
+                        url_template = version_urls[kind]
+                        if url_template is None:
+                            error = annotation(
+                                level="error",
+                                path=path,
+                                line=line_number_of(path, test_case),
+                                title=f"unsupported template '{kind}'",
+                                message=f"cannot find a URL template for '{kind}'"
+                            )
+                            sys.stdout.write(error)
+                            continue
+
+                        url = url_template.expand(
                             spec=spec,
                             section=section,
                         )

--- a/bin/specification_urls.json
+++ b/bin/specification_urls.json
@@ -28,7 +28,7 @@
   "external": {
     "ecma262": "https://262.ecma-international.org/{section}",
     "perl5": "https://perldoc.perl.org/perlre#{section}",
-    "rfc": "https://www.rfc-editor.org/rfc/{spec}.txt#{section}",
+    "rfc": "https://www.rfc-editor.org/rfc/rfc{spec}.txt#{section}",
     "iso": "https://www.iso.org/obp/ui"
   }
 }


### PR DESCRIPTION
Currently, the script cannot process links for rfc and iso - it does not trim the number suffix from a key and it cannot find the right URL template because of that. An example of an unsuccessful run can be found here:
https://github.com/json-schema-org/JSON-Schema-Test-Suite/actions/runs/13163116845/job/36736600257?pr=760

This PR corrects that behaviour and correctly extracts the URL kind and a spec from the key in the `specification` block. Also, it adds an additional check to avoid a crash in case of an incorrect kind - the error will be reported as an annotation.

The URL template for RFC had incorrect spec path - it was also updated (there is also an issue with anchor - txt format does not support them, but this will be changed in a separate PR)