### PR TITLE
Update RFC link to support section anchors

### DIFF
--- a/bin/specification_urls.json
+++ b/bin/specification_urls.json
@@ -28,7 +28,7 @@
   "external": {
     "ecma262": "https://262.ecma-international.org/{section}",
     "perl5": "https://perldoc.perl.org/perlre#{section}",
-    "rfc": "https://www.rfc-editor.org/rfc/rfc{spec}.html#{section}",
+    "rfc": "https://www.rfc-editor.org/rfc/rfc{spec}.html#section-{section}",
     "iso": "https://www.iso.org/obp/ui"
   }
 }

--- a/bin/specification_urls.json
+++ b/bin/specification_urls.json
@@ -28,7 +28,7 @@
   "external": {
     "ecma262": "https://262.ecma-international.org/{section}",
     "perl5": "https://perldoc.perl.org/perlre#{section}",
-    "rfc": "https://www.rfc-editor.org/rfc/rfc{spec}.txt#{section}",
+    "rfc": "https://www.rfc-editor.org/rfc/rfc{spec}.html#{section}",
     "iso": "https://www.iso.org/obp/ui"
   }
 }


### PR DESCRIPTION
The current RFC link uses TXT format to open the content. That format does not support anchors at all. This PR changes the format from TXT to HTML and corrects the anchor part of the URL template.

Here are a few examples of resulting links:

https://www.rfc-editor.org/rfc/rfc3986.html#section-1
https://www.rfc-editor.org/rfc/rfc3986.html#section-1.1
https://www.rfc-editor.org/rfc/rfc3986.html#section-1.1.1