### PR TITLE
Add tests for propertyNames with const/enum

### DIFF
--- a/tests/draft2019-09/propertyNames.json
+++ b/tests/draft2019-09/propertyNames.json
@@ -111,5 +111,58 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "propertyNames with const",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": {"const": "foo"}
+        },
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": {"enum": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property foo and bar is valid",
+                "data": {"foo": 1, "bar": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"baz": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/propertyNames.json
+++ b/tests/draft2020-12/propertyNames.json
@@ -45,6 +45,36 @@
         ]
     },
     {
+        "description": "propertyNames validation with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": { "pattern": "^a+$" }
+        },
+        "tests": [
+            {
+                "description": "matching property names valid",
+                "data": {
+                    "a": {},
+                    "aa": {},
+                    "aaa": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "non-matching property name is invalid",
+                "data": {
+                    "aaA": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "propertyNames with boolean schema true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -73,6 +103,59 @@
             {
                 "description": "object with any properties is invalid",
                 "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with const",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": {"const": "foo"}
+        },
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": {"enum": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property foo and bar is valid",
+                "data": {"foo": 1, "bar": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"baz": 1},
                 "valid": false
             },
             {

--- a/tests/draft6/propertyNames.json
+++ b/tests/draft6/propertyNames.json
@@ -103,5 +103,52 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "propertyNames with const",
+        "schema": {"propertyNames": {"const": "foo"}},
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with enum",
+        "schema": {"propertyNames": {"enum": ["foo", "bar"]}},
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property foo and bar is valid",
+                "data": {"foo": 1, "bar": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"baz": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/propertyNames.json
+++ b/tests/draft7/propertyNames.json
@@ -103,5 +103,52 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "propertyNames with const",
+        "schema": {"propertyNames": {"const": "foo"}},
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with enum",
+        "schema": {"propertyNames": {"enum": ["foo", "bar"]}},
+        "tests": [
+            {
+                "description": "object with property foo is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property foo and bar is valid",
+                "data": {"foo": 1, "bar": 1},
+                "valid": true
+            },
+            {
+                "description": "object with any other property is invalid",
+                "data": {"baz": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This checks for the correct functioning of `propertyNames` with a `const` or `enum` schema.
This inspired by a [bug](https://github.com/sourcemeta/blaze/pull/376) reported in the Blaze validator for this specific case.
