### PR TITLE
Add tests for unevaluatedItems with minContains = 0

### DIFF
--- a/tests/draft-next/unevaluatedItems.json
+++ b/tests/draft-next/unevaluatedItems.json
@@ -712,6 +712,37 @@
         ]
     },
     {
+        "description" : "unevaluatedItems with minContains = 0",
+        "schema" : {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {"type": "string"},
+            "minContains": 0,
+            "unevaluatedItems": false
+        },
+        "tests" : [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "no items evaluated by contains",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "some but not all items evaluated by contains",
+                "data": ["foo", 0],
+                "valid": false
+            },
+            {
+                "description": "all items evaluated by contains",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "non-array instances are valid",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",

--- a/tests/draft2020-12/unevaluatedItems.json
+++ b/tests/draft2020-12/unevaluatedItems.json
@@ -719,6 +719,37 @@
         ]
     },
     {
+        "description" : "unevaluatedItems with minContains = 0",
+        "schema" : {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"type": "string"},
+            "minContains": 0,
+            "unevaluatedItems": false
+        },
+        "tests" : [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "no items evaluated by contains",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "some but not all items evaluated by contains",
+                "data": ["foo", 0],
+                "valid": false
+            },
+            {
+                "description": "all items evaluated by contains",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "non-array instances are valid",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
It is tempting to forgo evaluation of the 'contains' schema when `minContains = 0`. However, when an `unevaluatedItems` schema is present, the `contains` schema must still be evaluated as it will affect the results of the `unevaluatedItems` schema.

It is my understanding that the interaction between `contains` and `unevaluatedItems` is not defined prior to the `draft2020-12` specification, so I have not added the test for any earlier versions.