### PR TITLE
ensure we do not parse email strings permissively

### DIFF
--- a/tests/draft-next/optional/format/email.json
+++ b/tests/draft-next/optional/format/email.json
@@ -115,6 +115,16 @@
                 "description": "an invalid IPv4-address-literal",
                 "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -80,6 +80,16 @@
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -115,6 +115,16 @@
                 "description": "an invalid IPv4-address-literal",
                 "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/email.json
+++ b/tests/draft3/optional/format/email.json
@@ -47,6 +47,16 @@
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -77,6 +77,16 @@
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -77,6 +77,16 @@
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -77,6 +77,16 @@
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
                 "valid": false
+            },
+            {
+                "description": "two email addresses is not valid",
+                "data": "user1@oceania.org, user2@oceania.org",
+                "valid": false
+            },
+            {
+                "description": "full \"From\" header is invalid",
+                "data": "\"Winston Smith\" <winston.smith@recdep.minitrue> (Records Department)",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
e.g. we do not accept the entire "From" line from an email, nor two comma-separated email addresses

(one of these test cases was not being caught by my implementation!) :o