### PR TITLE
Update annotation test description for propertyNames

### DIFF
--- a/annotations/tests/applicators.json
+++ b/annotations/tests/applicators.json
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "description": "`propertyNames`",
+      "description": "`propertyNames` doesn't annotate property values",
       "compatibility": "6",
       "schema": {
         "propertyNames": {


### PR DESCRIPTION
Related to https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/772

This updates the `propertyNames` annotation test description to make it clear that it's testing that annotations on property names shouldn't appear on property values.