### PR TITLE
Remove instances of `$id` in content related annotation tests

### DIFF
--- a/annotations/tests/content.json
+++ b/annotations/tests/content.json
@@ -80,7 +80,7 @@
               "location": "",
               "keyword": "contentSchema",
               "expected": {
-                "#": { "type": "number" }
+                "https://annotations.json-schema.org/test/contentSchema-is-an-annotation#": { "type": "number" }
               }
             }
           ]

--- a/annotations/tests/content.json
+++ b/annotations/tests/content.json
@@ -68,7 +68,6 @@
       "description": "`contentSchema` is an annotation for string instances",
       "compatibility": "2019",
       "schema": {
-        "$id": "https://annotations.json-schema.org/test/contentSchema-is-an-annotation",
         "contentMediaType": "application/json",
         "contentSchema": { "type": "number" }
       },
@@ -80,7 +79,7 @@
               "location": "",
               "keyword": "contentSchema",
               "expected": {
-                "https://annotations.json-schema.org/test/contentSchema-is-an-annotation#": { "type": "number" }
+                "#": { "type": "number" }
               }
             }
           ]
@@ -101,7 +100,6 @@
       "description": "`contentSchema` requires `contentMediaType`",
       "compatibility": "2019",
       "schema": {
-        "$id": "https://annotations.json-schema.org/test/contentSchema-is-an-annotation",
         "contentSchema": { "type": "number" }
       },
       "tests": [


### PR DESCRIPTION
I've been trying to finally incorporate the annotation test suite in Blaze, and this is the one issue I found. Given the schema declares `$id`, the assertion should probably assert against the actual full URI?