### PR TITLE
Add test for invalid "shifted" dashes in uuid format (#780)

### DIFF
--- a/tests/draft-next/optional/format/uuid.json
+++ b/tests/draft-next/optional/format/uuid.json
@@ -92,6 +92,11 @@
                 "valid": false
             },
             {
+                "description": "shifted dashes",
+                "data": "2eb8aa0-8aa98-11e-ab4aa7-3b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -92,6 +92,11 @@
                 "valid": false
             },
             {
+                "description": "shifted dashes",
+                "data": "2eb8aa0-8aa98-11e-ab4aa7-3b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -92,6 +92,11 @@
                 "valid": false
             },
             {
+                "description": "shifted dashes",
+                "data": "2eb8aa0-8aa98-11e-ab4aa7-3b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true


### PR DESCRIPTION
Naive attempt to implement #780. I hope I have captured all relevant test suites. `bin/jsonschema_suite` seems to be fine with the changes. Please let me know if anything is missing or wrong.