### PR TITLE
Fix `unevaluatedProperties with adjacent bool additionalProperties` test case

### DIFF
--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -132,7 +132,7 @@
         ]
     },
     {
-        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "description": "unevaluatedProperties with adjacent bool additionalProperties",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",
@@ -140,6 +140,35 @@
                 "foo": { "type": "string" }
             },
             "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent non-bool additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": {"type": "string"},
             "unevaluatedProperties": false
         },
         "tests": [

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -130,6 +130,10 @@
         "description": "unevaluatedProperties with adjacent bool additionalProperties",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
             "additionalProperties": true,
             "unevaluatedProperties": false
         },
@@ -155,24 +159,28 @@
         "description": "unevaluatedProperties with adjacent non-bool additionalProperties",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "additionalProperties": { "type": "string" },
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": {"type": "string"},
             "unevaluatedProperties": false
         },
         "tests": [
             {
-                "description": "with only valid additional properties",
+                "description": "with no additional properties",
                 "data": {
                     "foo": "foo"
                 },
                 "valid": true
             },
             {
-                "description": "with invalid additional properties",
+                "description": "with additional properties",
                 "data": {
                     "foo": "foo",
-                    "bar": 1
+                    "bar": "bar"
                 },
-                "valid": false
+                "valid": true
             }
         ]
     },

--- a/tests/v1/unevaluatedProperties.json
+++ b/tests/v1/unevaluatedProperties.json
@@ -132,7 +132,7 @@
         ]
     },
     {
-        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "description": "unevaluatedProperties with adjacent bool additionalProperties",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -140,6 +140,35 @@
                 "foo": { "type": "string" }
             },
             "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent non-bool additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": {"type": "string"},
             "unevaluatedProperties": false
         },
         "tests": [


### PR DESCRIPTION
Unless I'm missing something, it looks like there's an additional property in the `with no additional properties` test case of the `unevaluatedProperties with adjacent bool additionalProperties` suite.

The case with additional properties is the next one.