### PR TITLE
Add a test for respecting dynamic scopes while avoiding the root of each schema

### DIFF
--- a/tests/draft2020-12/dynamicRef.json
+++ b/tests/draft2020-12/dynamicRef.json
@@ -811,5 +811,63 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$dynamicRef avoids the root of each schema, but scopes are still registered",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-avoids-root-of-each-schema/base",
+            "$ref": "first#/$defs/stuff",
+            "$defs": {
+                "first": {
+                    "$id": "first",
+                    "$defs": {
+                        "stuff": {
+                            "$ref": "second#/$defs/stuff"
+                        },
+                        "length": {
+                            "$comment": "unused, because there is no $dynamicAnchor here",
+                            "maxLength": 1
+                        }
+                    }
+                },
+                "second": {
+                    "$id": "second",
+                    "$defs": {
+                        "stuff": {
+                            "$ref": "third#/$defs/stuff"
+                        },
+                        "length": {
+                            "$dynamicAnchor": "length",
+                            "maxLength": 2
+                        }
+                    }
+                },
+                "third": {
+                    "$id": "third",
+                    "$defs": {
+                        "stuff": {
+                            "$dynamicRef": "#length"
+                        },
+                        "length": {
+                            "$dynamicAnchor": "length",
+                            "maxLength": 3
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is sufficient for schema at second#/$defs/length",
+                "data": "hi",
+                "valid": true
+            },
+            {
+                "description": "data is not sufficient for schema at second#/$defs/length",
+                "data": "hey",
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/v1/dynamicRef.json
+++ b/tests/v1/dynamicRef.json
@@ -592,5 +592,63 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$dynamicRef avoids the root of each schema, but scopes are still registered",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "$id": "https://test.json-schema.org/dynamic-ref-avoids-root-of-each-schema/base",
+            "$ref": "first#/$defs/stuff",
+            "$defs": {
+                "first": {
+                    "$id": "first",
+                    "$defs": {
+                        "stuff": {
+                            "$ref": "second#/$defs/stuff"
+                        },
+                        "length": {
+                            "$comment": "unused, because there is no $dynamicAnchor here",
+                            "maxLength": 1
+                        }
+                    }
+                },
+                "second": {
+                    "$id": "second",
+                    "$defs": {
+                        "stuff": {
+                            "$ref": "third#/$defs/stuff"
+                        },
+                        "length": {
+                            "$dynamicAnchor": "length",
+                            "maxLength": 2
+                        }
+                    }
+                },
+                "third": {
+                    "$id": "third",
+                    "$defs": {
+                        "stuff": {
+                            "$dynamicRef": "#length"
+                        },
+                        "length": {
+                            "$dynamicAnchor": "length",
+                            "maxLength": 3
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is sufficient for schema at second#/$defs/length",
+                "data": "hi",
+                "valid": true
+            },
+            {
+                "description": "data is not sufficient for schema at second#/$defs/length",
+                "data": "hey",
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
We $ref from base -> first#/$defs/stuff -> second#/$defs/stuff -> third#/$defs/stuff and then follow a $dynamicRef to #length. At no point do we ever actually evaluate at the root schema for each scope. The dynamic scope is [ base, first, second, third ] and we check the scopes in order, therefore the first scope we find with a dynamic anchor "length" is "second".

This revealed a bug in my implementation, where dynamic scopes were only being recorded while evaluating an $id keyword, but not when using a $ref that went to a sub-resource that lacked an $id.