### PR TITLE
Add if/then/else test cases for issue #767

### DIFF
--- a/tests/draft2019-09/if-then-else.json
+++ b/tests/draft2019-09/if-then-else.json
@@ -302,26 +302,6 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "then and else both are false",
-        "schema":{
-            "if":{"type":"number"},
-            "then":false,
-            "else":false
-        },
-        "tests":[
-            {
-                "description": "matches if → then executes and else does not execute → invalid",
-                "data": 4,
-                "valid": false
-            },
-            {
-                "description": "does not match if → else executes → invalid",
-                "data": "foo",
-                "valid": false
-            }
-        ]
-    }      
+    }
 ]
 

--- a/tests/draft2020-12/if-then-else.json
+++ b/tests/draft2020-12/if-then-else.json
@@ -302,25 +302,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "then and else both are false",
-        "schema":{
-            "if":{"type":"number"},
-            "then":false,
-            "else":false
-        },
-        "tests":[
-            {
-                "description": "matches if → then executes and else does not execute → invalid",
-                "data": 4,
-                "valid": false
-            },
-            {
-                "description": "does not match if → else executes → invalid",
-                "data": "foo",
-                "valid": false
-            }
-        ]
-    }      
+    }
 ]

--- a/tests/draft7/if-then-else.json
+++ b/tests/draft7/if-then-else.json
@@ -292,25 +292,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "then and else both are false",
-        "schema":{
-            "if":{"type":"number"},
-            "then":false,
-            "else":false
-        },
-        "tests":[
-            {
-                "description": "matches if → then executes and else does not execute → invalid",
-                "data": 4,
-                "valid": false
-            },
-            {
-                "description": "does not match if → else executes → invalid",
-                "data": "foo",
-                "valid": false
-            }
-        ]
-    }      
+    }
 ]


### PR DESCRIPTION
This PR adds additional tests for correct handling of the `false` schema within
conditional keywords (`if`, `then`, `else`), as described in Issue #767.

### What these tests cover
- When `if` matches, `then: false` must cause validation to fail.
- When `if` does not match, `else: false` must cause validation to fail.
- When both `then` and `else` are `false`, all data must be invalid regardless
  of the branch taken.
- Ensures that `false` is treated as a schema that always fails, matching JSON
  Schema semantics, rather than being interpreted as `{}`.

These tests fill gaps in draft2020-12 conditional logic coverage, addressing the
behavior described in Issue #767.

Fixes #767.

