### PR TITLE
Add specification links for type keyword tests

### DIFF
--- a/tests/draft2020-12/type.json
+++ b/tests/draft2020-12/type.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "integer type matches integers",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "integer"
@@ -55,6 +56,7 @@
     },
     {
         "description": "number type matches numbers",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "number"
@@ -109,6 +111,7 @@
     },
     {
         "description": "string type matches strings",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "string"
@@ -163,6 +166,7 @@
     },
     {
         "description": "object type matches objects",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object"
@@ -207,6 +211,7 @@
     },
     {
         "description": "array type matches arrays",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "array"
@@ -251,6 +256,7 @@
     },
     {
         "description": "boolean type matches booleans",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "boolean"
@@ -310,6 +316,7 @@
     },
     {
         "description": "null type matches only the null object",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "null"
@@ -369,6 +376,7 @@
     },
     {
         "description": "multiple types can be specified in an array",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["integer", "string"]
@@ -413,6 +421,7 @@
     },
     {
         "description": "type as array with one item",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["string"]
@@ -432,6 +441,7 @@
     },
     {
         "description": "type: array or object",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["array", "object"]
@@ -466,6 +476,7 @@
     },
     {
         "description": "type: array, object or null",
+        "specification": [{"validation": "6.1.1"}],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": ["array", "object", "null"]


### PR DESCRIPTION
Added specification field to the type tests in type.json so each test now points to the official JSON Schema type keyword docs: https://json-schema.org/draft/2020-12/json-schema-validation#type

This helps anyone reading the tests understand which part of the spec each test is based on. No changes to test logic, just added reference links.