### PR TITLE
Fixes #809 : Added tests for oneOf nested inside allOf

### DIFF
--- a/tests/draft2020-12/allOf.json
+++ b/tests/draft2020-12/allOf.json
@@ -6,37 +6,55 @@
             "allOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {
+                            "type": "integer"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "allOf",
-                "data": {"foo": "baz", "bar": 2},
+                "data": {
+                    "foo": "baz",
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "mismatch second",
-                "data": {"foo": "baz"},
+                "data": {
+                    "foo": "baz"
+                },
                 "valid": false
             },
             {
                 "description": "mismatch first",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "wrong type",
-                "data": {"foo": "baz", "bar": "quux"},
+                "data": {
+                    "foo": "baz",
+                    "bar": "quux"
+                },
                 "valid": false
             }
         ]
@@ -45,47 +63,76 @@
         "description": "allOf with base schema",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "properties": {"bar": {"type": "integer"}},
-            "required": ["bar"],
-            "allOf" : [
+            "properties": {
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "bar"
+            ],
+            "allOf": [
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 },
                 {
                     "properties": {
-                        "baz": {"type": "null"}
+                        "baz": {
+                            "type": "null"
+                        }
                     },
-                    "required": ["baz"]
+                    "required": [
+                        "baz"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "valid",
-                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2,
+                    "baz": null
+                },
                 "valid": true
             },
             {
                 "description": "mismatch base schema",
-                "data": {"foo": "quux", "baz": null},
+                "data": {
+                    "foo": "quux",
+                    "baz": null
+                },
                 "valid": false
             },
             {
                 "description": "mismatch first allOf",
-                "data": {"bar": 2, "baz": null},
+                "data": {
+                    "bar": 2,
+                    "baz": null
+                },
                 "valid": false
             },
             {
                 "description": "mismatch second allOf",
-                "data": {"foo": "quux", "bar": 2},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "mismatch both",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             }
         ]
@@ -95,8 +142,12 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
-                {"maximum": 30},
-                {"minimum": 20}
+                {
+                    "maximum": 30
+                },
+                {
+                    "minimum": 20
+                }
             ]
         },
         "tests": [
@@ -116,7 +167,10 @@
         "description": "allOf with boolean schemas, all true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "allOf": [true, true]
+            "allOf": [
+                true,
+                true
+            ]
         },
         "tests": [
             {
@@ -130,7 +184,10 @@
         "description": "allOf with boolean schemas, some false",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "allOf": [true, false]
+            "allOf": [
+                true,
+                false
+            ]
         },
         "tests": [
             {
@@ -144,7 +201,10 @@
         "description": "allOf with boolean schemas, all false",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "allOf": [false, false]
+            "allOf": [
+                false,
+                false
+            ]
         },
         "tests": [
             {
@@ -193,7 +253,9 @@
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
                 {},
-                { "type": "number" }
+                {
+                    "type": "number"
+                }
             ]
         },
         "tests": [
@@ -214,7 +276,9 @@
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "allOf": [
-                { "type": "number" },
+                {
+                    "type": "number"
+                },
                 {}
             ]
         },
@@ -262,9 +326,21 @@
         "description": "allOf combined with anyOf, oneOf",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "allOf": [ { "multipleOf": 2 } ],
-            "anyOf": [ { "multipleOf": 3 } ],
-            "oneOf": [ { "multipleOf": 5 } ]
+            "allOf": [
+                {
+                    "multipleOf": 2
+                }
+            ],
+            "anyOf": [
+                {
+                    "multipleOf": 3
+                }
+            ],
+            "oneOf": [
+                {
+                    "multipleOf": 5
+                }
+            ]
         },
         "tests": [
             {
@@ -306,6 +382,89 @@
                 "description": "allOf: true, anyOf: true, oneOf: true",
                 "data": 30,
                 "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf inside allOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "foo"
+                    ]
+                },
+                {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "bar": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "bar"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "baz": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "baz"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid: matches oneOf[0]",
+                "data": {
+                    "foo": "a",
+                    "bar": "b"
+                },
+                "valid": true
+            },
+            {
+                "description": "valid: matches oneOf[1]",
+                "data": {
+                    "foo": "a",
+                    "baz": "c"
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid: matches both oneOfs",
+                "data": {
+                    "foo": "a",
+                    "bar": "b",
+                    "baz": "c"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid: matches neither oneOf",
+                "data": {
+                    "foo": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid: matches oneOf but fails allOf required",
+                "data": {
+                    "bar": "b"
+                },
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
### Description
This PR adds missing test coverage for schemas where `oneOf` is nested inside `allOf`.

### Context
While reviewing the test suite, I noticed that scenarios involving `oneOf` nested within `allOf` were not explicitly covered. This combination is subtle and has caused inconsistencies across validator implementations.

### What this PR adds
The new test case covers:
- A valid instance where exactly one `oneOf` subschema matches
- An invalid instance where multiple `oneOf` subschemas match
- An invalid instance where none of the `oneOf` subschemas match

This ensures that `allOf` correctly constrains `oneOf` evaluation according to the specification.

### Spec version
- draft-2020-12

### Notes
I ran the test suite locally to ensure the added tests integrate cleanly without regressions.

I’d be happy to work on additional test coverage or other issues if there are areas that would benefit from further contributions.
