### PR TITLE
Clarify that the test-suite is not a style guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build Status](https://github.com/json-schema-org/JSON-Schema-Test-Suite/workflows/Test%20Suite%20Sanity%20Checking/badge.svg)](https://github.com/json-schema-org/JSON-Schema-Test-Suite/actions?query=workflow%3A%22Test+Suite+Sanity+Checking%22)
 
 This repository contains a set of JSON objects that implementers of JSON Schema validation libraries can use to test their validators.
-The test suite repository exists to verify specified behavior defined by the JSON Schema specification and should not be confused with a style guide. It is not intended to demonstrate how tests ought to be written. Tests may appear unusual or unintuitive, but they exist solely to reflect behavior prescribed by the specification.
+The test suite repository exists to verify specified behavior defined by the JSON Schema specification and should not be confused with a style guide. It is not intended to demonstrate how schemas ought to be written. Tests may appear unusual or unintuitive, but they exist solely to exercise behavior prescribed by the specification.
 
 It is meant to be language agnostic and should require only a JSON parser.
 The conversion of the JSON objects into tests within a specific language and test framework of choice is left to be done by the validator implementer.


### PR DESCRIPTION
This PR clarifies the purpose of the JSON Schema Test Suite by explicitly stating that it is intended to verify behaviour defined by the specification, not to serve as a style guide or a set of recommended schema patterns.

The goal is to reduce confusion for both schema authors and implementors by making it clear that the presence of a test does not imply best practice, only that the behaviour is specified.

Fixes #324