### PR TITLE
Add edge case tests for exclusiveMinimum and exclusiveMaximum

### DIFF
--- a/tests/draft2019-09/exclusiveMaximum.json
+++ b/tests/draft2019-09/exclusiveMaximum.json
@@ -27,5 +27,83 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMaximum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMaximum": -1
+        },
+        "tests": [
+            {
+                "description": "negative below the exclusiveMaximum is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -1.0,
+                "valid": false
+            },
+            {
+                "description": "float above the exclusiveMaximum is invalid",
+                "data": -0.9999,
+                "valid": false
+            },
+            {
+                "description": "positive int above the exclusiveMaximum is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMaximum": 0
+        },
+        "tests": [
+            {
+                "description": "negative number is valid",
+                "data": -0.1,
+                "valid": true
+            },
+            {
+                "description": "negative integer is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "positive number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "positive float is invalid",
+                "data": 0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2019-09/exclusiveMinimum.json
+++ b/tests/draft2019-09/exclusiveMinimum.json
@@ -27,5 +27,88 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMinimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMinimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the exclusiveMinimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the exclusiveMinimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -2,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -2.0,
+                "valid": false
+            },
+            {
+                "description": "float below the exclusiveMinimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the exclusiveMinimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMinimum": 0
+        },
+        "tests": [
+            {
+                "description": "positive number is valid",
+                "data": 0.1,
+                "valid": true
+            },
+            {
+                "description": "positive integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "negative number is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "negative float is invalid",
+                "data": -0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/exclusiveMaximum.json
+++ b/tests/draft2020-12/exclusiveMaximum.json
@@ -27,5 +27,83 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMaximum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": -1
+        },
+        "tests": [
+            {
+                "description": "negative below the exclusiveMaximum is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -1.0,
+                "valid": false
+            },
+            {
+                "description": "float above the exclusiveMaximum is invalid",
+                "data": -0.9999,
+                "valid": false
+            },
+            {
+                "description": "positive int above the exclusiveMaximum is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": 0
+        },
+        "tests": [
+            {
+                "description": "negative number is valid",
+                "data": -0.1,
+                "valid": true
+            },
+            {
+                "description": "negative integer is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "positive number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "positive float is invalid",
+                "data": 0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/exclusiveMinimum.json
+++ b/tests/draft2020-12/exclusiveMinimum.json
@@ -27,5 +27,88 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMinimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the exclusiveMinimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the exclusiveMinimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -2,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -2.0,
+                "valid": false
+            },
+            {
+                "description": "float below the exclusiveMinimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the exclusiveMinimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": 0
+        },
+        "tests": [
+            {
+                "description": "positive number is valid",
+                "data": 0.1,
+                "valid": true
+            },
+            {
+                "description": "positive integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "negative number is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "negative float is invalid",
+                "data": -0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/exclusiveMaximum.json
+++ b/tests/draft7/exclusiveMaximum.json
@@ -26,5 +26,81 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMaximum validation with signed integer",
+        "schema": {
+            "exclusiveMaximum": -1
+        },
+        "tests": [
+            {
+                "description": "negative below the exclusiveMaximum is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -1.0,
+                "valid": false
+            },
+            {
+                "description": "float above the exclusiveMaximum is invalid",
+                "data": -0.9999,
+                "valid": false
+            },
+            {
+                "description": "positive int above the exclusiveMaximum is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum with zero",
+        "schema": {
+            "exclusiveMaximum": 0
+        },
+        "tests": [
+            {
+                "description": "negative number is valid",
+                "data": -0.1,
+                "valid": true
+            },
+            {
+                "description": "negative integer is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "positive number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "positive float is invalid",
+                "data": 0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft7/exclusiveMinimum.json
+++ b/tests/draft7/exclusiveMinimum.json
@@ -26,5 +26,86 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMinimum validation with signed integer",
+        "schema": {
+            "exclusiveMinimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the exclusiveMinimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the exclusiveMinimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -2,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -2.0,
+                "valid": false
+            },
+            {
+                "description": "float below the exclusiveMinimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the exclusiveMinimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum with zero",
+        "schema": {
+            "exclusiveMinimum": 0
+        },
+        "tests": [
+            {
+                "description": "positive number is valid",
+                "data": 0.1,
+                "valid": true
+            },
+            {
+                "description": "positive integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "negative number is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "negative float is invalid",
+                "data": -0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/v1/exclusiveMaximum.json
+++ b/tests/v1/exclusiveMaximum.json
@@ -27,5 +27,83 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMaximum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "exclusiveMaximum": -1
+        },
+        "tests": [
+            {
+                "description": "negative below the exclusiveMaximum is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -1.0,
+                "valid": false
+            },
+            {
+                "description": "float above the exclusiveMaximum is invalid",
+                "data": -0.9999,
+                "valid": false
+            },
+            {
+                "description": "positive int above the exclusiveMaximum is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "exclusiveMaximum": 0
+        },
+        "tests": [
+            {
+                "description": "negative number is valid",
+                "data": -0.1,
+                "valid": true
+            },
+            {
+                "description": "negative integer is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "positive number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "positive float is invalid",
+                "data": 0.001,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/v1/exclusiveMinimum.json
+++ b/tests/v1/exclusiveMinimum.json
@@ -27,5 +27,88 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "exclusiveMinimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "exclusiveMinimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the exclusiveMinimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the exclusiveMinimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": -2,
+                "valid": false
+            },
+            {
+                "description": "boundary point with float is invalid",
+                "data": -2.0,
+                "valid": false
+            },
+            {
+                "description": "float below the exclusiveMinimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the exclusiveMinimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum with zero",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "exclusiveMinimum": 0
+        },
+        "tests": [
+            {
+                "description": "positive number is valid",
+                "data": 0.1,
+                "valid": true
+            },
+            {
+                "description": "positive integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "zero integer is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "zero float is invalid",
+                "data": 0.0,
+                "valid": false
+            },
+            {
+                "description": "negative number is invalid",
+                "data": -1,
+                "valid": false
+            },
+            {
+                "description": "negative float is invalid",
+                "data": -0.001,
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## Summary

Addresses #819 by adding comprehensive edge case tests for `exclusiveMinimum` and `exclusiveMaximum` keywords.

## Changes

Added the following test cases to all applicable drafts (draft-07, draft-2019-09, draft-2020-12, and v1):

### exclusiveMinimum
1. **Signed integer validation** - Tests with `exclusiveMinimum: -2` including:
   - Negative values above the boundary (valid)
   - Positive values above the boundary (valid)
   - Boundary point integer (invalid)
   - Boundary point float representation (invalid)
   - Values below the boundary (invalid)

2. **Zero edge cases** - Tests with `exclusiveMinimum: 0` including:
   - Positive numbers and integers (valid)
   - Zero as integer and float (invalid)
   - Negative numbers (invalid)

### exclusiveMaximum
1. **Signed integer validation** - Tests with `exclusiveMaximum: -1` including:
   - Negative values below the boundary (valid)
   - Boundary point integer and float (invalid)
   - Values above the boundary (invalid)

2. **Zero edge cases** - Tests with `exclusiveMaximum: 0` including:
   - Negative numbers and integers (valid)
   - Zero as integer and float (invalid)
   - Positive numbers (invalid)

## Files Modified

- `tests/draft2020-12/exclusiveMinimum.json`
- `tests/draft2020-12/exclusiveMaximum.json`
- `tests/draft2019-09/exclusiveMinimum.json`
- `tests/draft2019-09/exclusiveMaximum.json`
- `tests/draft7/exclusiveMinimum.json`
- `tests/draft7/exclusiveMaximum.json`
- `tests/v1/exclusiveMinimum.json`
- `tests/v1/exclusiveMaximum.json`

## Implementation Notes

- Followed the CONTRIBUTING guidelines with minimal schemas
- Matched existing test patterns from `minimum.json` and `maximum.json`
- Included both valid and invalid instances for each test case
- Used appropriate `$schema` for each draft version

Fixes #819