### PR TITLE
Add test case for minLength: 1 to verify empty string behavior

### DIFF
--- a/tests/draft2020-12/minLength.json
+++ b/tests/draft2020-12/minLength.json
@@ -51,5 +51,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "minLength validation with value 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 1
+        },
+        "tests": [
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "string with one character is valid",
+                "data": "a",
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## What does this PR do?
This PR adds a test case for the `minLength` keyword with a value of `1`.

## Why is this change important?
Currently, `minLength.json` tests `minLength: 2`, but there is no explicit test case for `minLength: 1`.
`minLength: 1` is a very common pattern used to ensure a field is not empty. This test verifies that an empty string `""` is correctly invalidated when `minLength` is set to `1`.

## References
- Spec: https://json-schema.org/understanding-json-schema/reference/numeric.html#range