### PR TITLE
Add M3 JSON Schema validator to Who Uses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ This suite is being used by:
 
 * [jinx](https://github.com/juxt/jinx)
 * [json-schema](https://github.com/tatut/json-schema)
+* [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Kotlin, Scala, and JavaScript)
 
 ### Coffeescript
 
@@ -261,6 +262,7 @@ This suite is being used by:
 * [Snow](https://github.com/ssilverman/snowy-json)
 * [jsonschemafriend](https://github.com/jimblackler/jsonschemafriend)
 * [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator)
+* [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Kotlin, Scala, and JavaScript)
 
 ### JavaScript
 
@@ -279,11 +281,13 @@ This suite is being used by:
 * [jsen](https://github.com/bugventure/jsen)
 * [ajv](https://github.com/epoberezkin/ajv)
 * [djv](https://github.com/korzio/djv)
+* [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Kotlin, and Scala)
 
 ### Kotlin
 
 * [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/functional) (Comparison site for JVM-based validator implementations)
 * [kotlinx-schema](https://github.com/Kotlin/kotlinx-schema)
+* [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Scala, and JavaScript)
 
 ### Lua
 
@@ -338,6 +342,7 @@ Node-specific support is maintained in a [separate repository](https://github.co
 ### Scala
 
 * [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/functional) (Comparison site for JVM-based validator implementations)
+* [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Kotlin, and JavaScript)
 
 ### Swift
 


### PR DESCRIPTION
## Summary

Adds [M3](https://github.com/JulesGosnell/m3) to the "Who Uses the Test Suite" section under all languages it supports:

- **Clojure** — M3's native language
- **Java** — via JVM interop (gen-class facade)
- **Kotlin** — via JVM interop
- **Scala** — via JVM interop
- **JavaScript** — via Node.js

M3 is a pure Clojure JSON Schema validator that passes all tests across all seven drafts (draft-03 through draft-next) — 9,622 assertions with zero failures. It is listed under each supported language so developers searching for a validator in their language can discover it.