### PR TITLE
Add tests for out-of-range time components in date-time format

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -97,6 +97,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -97,6 +97,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -79,6 +79,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -79,6 +79,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -79,6 +79,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid day in date-time string",
                 "data": "1990-02-31T15:59:59.123-08:00",
                 "valid": false

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -97,6 +97,21 @@
                 "valid": false
             },
             {
+                "description": "an invalid hour in date-time string",
+                "data": "1990-12-31T24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string",
+                "data": "1990-12-31T15:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset minute in date-time string",
+                "data": "1990-12-31T10:00:00+10:60",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
                 "valid": false


### PR DESCRIPTION
Added negative test cases for out-of-range time components in the `date-time` format as discussed in #832 
