### PR TITLE
Add test rejecting dotted-decimal IPv4 addresses in hostname format

### DIFF
--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -128,23 +128,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -333,23 +333,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -128,23 +128,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -333,23 +333,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -139,23 +139,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -139,23 +139,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -125,23 +125,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -325,23 +325,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -128,23 +128,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -333,23 +333,18 @@
                 "valid": false
             },
             {
-                "description": "dotted-decimal IP addresses are not valid hostnames",
-                "data": "192.168.0.1",
+                "description": "hostname with top level label completely numeric is invalid",
+                "data": "example.123",
                 "valid": false
             },
             {
-                "description": "numeric labels are allowed in hostnames",
-                "data": "123.example.com",
+                "description": "hostname with top level label partially numeric is valid",
+                "data": "example.12a",
                 "valid": true
             },
             {
-                "description": "ipv4-like but last label not purely numeric",
-                "data": "192.168.0.1a",
-                "valid": true
-            },
-            {
-                "description": "ipv4-like but first label not purely numeric",
-                "data": "a192.168.0.1",
+                "description": "hostname with numeric labels except the top level label is valid",
+                "data": "123.456.789.example",
                 "valid": true
             }
         ]


### PR DESCRIPTION
Added the negative test cases for dotted-decimal IPv4 addresses (`#.#.#.#`) as discussed in #838 