### PR TITLE
Added a simple test for a string containing only a space, Linked issue #845

### DIFF
--- a/tests/draft7/type.json
+++ b/tests/draft7/type.json
@@ -149,6 +149,11 @@
                 "description": "null is not a string",
                 "data": null,
                 "valid": false
+            },
+            {
+            "description": "string containing only a space",
+            "data": " ",
+            "valid": true
             }
         ]
     },


### PR DESCRIPTION
Added a tiny test case for a string containing only a space to type.json in the JSON Schema test suite.