### PR TITLE
Test: add additional edge cases for uri format across active drafts

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -197,6 +197,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -197,6 +197,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -194,6 +194,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -194,6 +194,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -194,6 +194,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -197,6 +197,36 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://example.com/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://example.com/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://example.com/%",
+                "valid": false
+            },
+            {
+                "description": "scheme must start with a letter",
+                "data": "1http://example.com",
+                "valid": false
+            },
+            {
+                "description": "invalid character in scheme",
+                "data": "ht_tp://example.com",
+                "valid": false
+            },
+            {
+                "description": "non-numeric port is invalid",
+                "data": "http://example.com:abc/path",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
## Summary

Adds additional boundary edge cases for the `uri` format across active drafts (draft3 through draft2020-12).

## What’s included

The new cases focus on:

- Invalid percent-encoding sequences (non-hex digits, incomplete triplets, lone `%`)
- Invalid scheme syntax (non-letter start, disallowed characters)
- Non-numeric port values

These cases align with the generic URI syntax defined in RFC 3986 (§2.1, §3.1, and §3.2.3).

## Scope

- Applied consistently to all active drafts that define `format: "uri"`
- No existing tests were modified

