### PR TITLE
test(draft2020-12): add literal Unicode coverage for pattern and patternProperties

### DIFF
--- a/tests/draft2020-12/pattern.json
+++ b/tests/draft2020-12/pattern.json
@@ -61,5 +61,49 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "pattern with literal Unicode characters (draft 2020-12)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^λ+$"
+        },
+        "tests": [
+            {
+                "description": "matching repeated Greek letter",
+                "data": "λλλ",
+                "valid": true
+            },
+            {
+                "description": "non-matching mixed characters",
+                "data": "λaλ",
+                "valid": false
+            },
+            {
+                "description": "matching single literal",
+                "data": "λ",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern with literal emoji character",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^😊$"
+        },
+        "tests": [
+            {
+                "description": "exact emoji match",
+                "data": "😊",
+                "valid": true
+            },
+            {
+                "description": "emoji plus extra character fails",
+                "data": "😊a",
+                "valid": false
+            }
+        ]
     }
+
 ]

--- a/tests/draft2020-12/patternProperties.json
+++ b/tests/draft2020-12/patternProperties.json
@@ -172,5 +172,32 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "patternProperties with literal Unicode key patterns (draft 2020-12)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "^λ+$": { "type": "number" }
+            }
+        },
+        "tests": [
+            {
+                "description": "matching Unicode property name",
+                "data": { "λλ": 1 },
+                "valid": true
+            },
+            {
+                "description": "non-matching property name ignored",
+                "data": { "aa": 1 },
+                "valid": true
+            },
+            {
+                "description": "matching property name with invalid type",
+                "data": { "λλ": "not number" },
+                "valid": false
+            }
+        ]
     }
+
 ]


### PR DESCRIPTION
## Summary

Adds literal Unicode test cases to `pattern.json` and `patternProperties.json` for draft-2020-12.

## Technical Context

Draft-2020-12 requires Unicode-aware regular expression handling. These tests add simple literal Unicode cases (Greek letters and emoji) without relying on advanced regex features or engine-specific behavior.

The goal is to strengthen coverage around required Unicode semantics while keeping tests portable and spec-aligned.

## Changes

- Added literal Greek character pattern tests (`^λ+$`)
- Added literal emoji pattern test (`^😊$`)
- Added corresponding `patternProperties` coverage using literal Unicode property names

## Validation

Validated JSON integrity locally using Node.js:

```bash
node -e "JSON.parse(require('fs').readFileSync('tests/draft2020-12/pattern.json','utf8'))"
node -e "JSON.parse(require('fs').readFileSync('tests/draft2020-12/patternProperties.json','utf8'))"