### PR TITLE
Test: add additional ipv4 boundary invalid cases across active drafts

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -86,6 +86,26 @@
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false
+            },
+            {
+                "description": "ipv4 with three octets",
+                "data": "1.2.3",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with negative octet",
+                "data": "1.2.3.-1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with trailing dot",
+                "data": "1.2.3.4.",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with internal whitespace",
+                "data": "1.2.3. 4",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -86,6 +86,26 @@
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false
+            },
+            {
+                "description": "ipv4 with three octets",
+                "data": "1.2.3",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with negative octet",
+                "data": "1.2.3.-1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with trailing dot",
+                "data": "1.2.3.4.",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with internal whitespace",
+                "data": "1.2.3. 4",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -83,6 +83,26 @@
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false
+            },
+            {
+                "description": "ipv4 with three octets",
+                "data": "1.2.3",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with negative octet",
+                "data": "1.2.3.-1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with trailing dot",
+                "data": "1.2.3.4.",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with internal whitespace",
+                "data": "1.2.3. 4",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -83,6 +83,26 @@
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false
+            },
+            {
+                "description": "ipv4 with three octets",
+                "data": "1.2.3",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with negative octet",
+                "data": "1.2.3.-1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with trailing dot",
+                "data": "1.2.3.4.",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with internal whitespace",
+                "data": "1.2.3. 4",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -83,6 +83,26 @@
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false
+            },
+            {
+                "description": "ipv4 with three octets",
+                "data": "1.2.3",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with negative octet",
+                "data": "1.2.3.-1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with trailing dot",
+                "data": "1.2.3.4.",
+                "valid": false
+            },
+            {
+                "description": "ipv4 with internal whitespace",
+                "data": "1.2.3. 4",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
## Summary

Adds additional invalid boundary test cases for the `ipv4` format across active drafts (draft4 through draft2020-12).

## What’s included

The following malformed IPv4 dotted-decimal inputs were added as invalid cases:

- `1.2.3` (three octets)
- `1.2.3.-1` (negative octet)
- `1.2.3.4.` (trailing dot)
- `1.2.3. 4` (internal whitespace)

These cases reflect violations of the IPv4 dotted-decimal address syntax as defined in RFC 791 and ensure implementations correctly reject structurally invalid input.

## Scope

- Applied consistently to all active drafts defining `format: "ipv4"`
- No existing tests were modified