### PR TITLE
docs: clarify intent of format-assertion vocabulary test cases

### DIFF
--- a/tests/draft2020-12/optional/format-assertion.json
+++ b/tests/draft2020-12/optional/format-assertion.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "schema that uses custom metaschema with format-assertion: false",
+        "comment": "The true/false boolean in $vocabulary only controls behavior for implementations that do not recognize the vocabulary. For implementations that do understand format-assertion, the boolean has no impact on validation behavior — hence both test groups produce identical results.",
         "schema": {
             "$id": "https://schema/using/format-assertion/false",
             "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
@@ -14,6 +15,7 @@
             },
             {
                 "description": "format-assertion: false: invalid string",
+                "comment": "valid: false is intentional — the false value in $vocabulary only affects unknown vocabulary handling, not validation behavior itself",
                 "data": "not-an-ipv4",
                 "valid": false
             }


### PR DESCRIPTION
Both test groups in this file produce identical results, which can be 
surprising at first glance. Adding a `comment` to clarify that the 
true/false boolean in `$vocabulary` only controls behavior for 
implementations that do not recognize the vocabulary — it has no impact 
on validation behavior for implementations that do understand 
format-assertion.

Inspired by the discussion in #519 .