### PR TITLE
test: add structural invalid boundary cases for uuid format

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -97,6 +97,26 @@
                 "valid": false
             },
             {
+                "description": "too long",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d163800",
+                "valid": false
+            },
+            {
+                "description": "first segment too short",
+                "data": "2eb8aa0-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "second segment too long",
+                "data": "2eb8aa08-aa980-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "extra hyphen",
+                "data": "2eb8aa08--aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -97,6 +97,26 @@
                 "valid": false
             },
             {
+                "description": "too long",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d163800",
+                "valid": false
+            },
+            {
+                "description": "first segment too short",
+                "data": "2eb8aa0-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "second segment too long",
+                "data": "2eb8aa08-aa980-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "extra hyphen",
+                "data": "2eb8aa08--aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -97,6 +97,26 @@
                 "valid": false
             },
             {
+                "description": "too long",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d163800",
+                "valid": false
+            },
+            {
+                "description": "first segment too short",
+                "data": "2eb8aa0-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "second segment too long",
+                "data": "2eb8aa08-aa980-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "extra hyphen",
+                "data": "2eb8aa08--aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
                 "description": "valid version 4",
                 "data": "98d80576-482e-427f-8434-7f86890ab222",
                 "valid": true


### PR DESCRIPTION
## Summary

Adds four additional structural invalid boundary cases for the `uuid` format.

## What’s included

The new test cases cover structural violations of the canonical UUID textual representation:

- Overall length exceeding 36 characters  
- First segment shorter than 8 hexadecimal digits  
- Second segment longer than 4 hexadecimal digits  
- Extra hyphen in an otherwise canonical string  

These additions align with the UUID segment structure defined in RFC 4122 (Section 3).

## Scope

- Applied to draft2019-09, draft2020-12, and v1  
- No existing tests were modified  
- No semantic constraints were introduced