### PR TITLE
test(format): add RFC1123 hostname case with consecutive hyphens

### DIFF
--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -44,6 +44,11 @@
                 "valid": true
             },
             {
+                "description": "hostname with consecutive hyphens (RFC1123)",
+                "data": "ab--cd.example",
+                "valid": true
+            },
+            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -44,6 +44,11 @@
                 "valid": true
             },
             {
+                "description": "hostname with consecutive hyphens (RFC1123)",
+                "data": "ab--cd.example",
+                "valid": true
+            },
+            {
                 "description": "a host name starting with an illegal character",
                 "data": "-a-host-name-that-starts-with--",
                 "valid": false


### PR DESCRIPTION
This PR adds a test case for the `hostname` format in legacy JSON Schema drafts.

During implementation work in the Hyperjump JSON Schema validator, an inconsistency was identified between **IDNA-based hostname validation** and the **classic hostname rules expected by legacy JSON Schema drafts**. The implementation previously used an IDNA validator (`isAsciiIdn`), which applies **UTS-46 restrictions**, but drafts such as **draft-04** and **draft-06** expect validation consistent with **RFC1123 hostname syntax**.

RFC1123 allows hostname labels to contain **consecutive hyphens**, provided the label does not begin or end with a hyphen. For example:

```
ab--cd.example
```

This hostname is valid according to the classic hostname rules defined in RFC1123, but some IDNA-based validators incorrectly reject it due to stricter IDNA restrictions.

To ensure implementations follow the expected behavior for the legacy `hostname` format, this PR adds a test case verifying that such hostnames are accepted.

The following test case was added to both:

* `tests/draft4/optional/format/hostname.json`
* `tests/draft6/optional/format/hostname.json`

Test added:

```
{
  "description": "hostname with consecutive hyphens (RFC1123)",
  "data": "ab--cd.example",
  "valid": true
}
```

This test ensures that implementations validating the legacy `hostname` format accept hostnames that are valid under RFC1123.

Context: This test accompanies an implementation fix in the Hyperjump JSON Schema validator where the `hostname` format handler was updated to use the RFC1123 hostname validator instead of an IDNA validator. The related discussion and fix can be found here:

https://github.com/hyperjump-io/json-schema/pull/109

Adding this case to the JSON Schema Test Suite helps ensure consistent behavior across implementations that rely on the suite for conformance testing.
