### PR TITLE
Unify validation suite metadata around tests/v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - name: Install tox
-      run: python -m pip install tox
+    - name: Install checker dependencies
+      run: python -m pip install jsonschema==4.19.0
     - name: Run the sanity checks
-      run: python -m tox
+      run: python bin/jsonschema_suite check

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ The precise steps described do not need to be followed exactly, but the results 
 To test a specific version:
 
 * For 2019-09 and later published versions, implementations that are able to detect the version of each schema via `$schema` SHOULD be configured to do so
-* For draft-07 and earlier, v1 (not yet released), and implementations unable to detect via `$schema`, implementations MUST be configured to expect the version matching the test directory name
+* For draft-07 and earlier, and implementations unable to detect via `$schema`, implementations MUST be configured to expect the version matching the test directory name
+* The `tests/v1` directory is the unified validation suite. It uses `https://json-schema.org/v1` as a placeholder dialect marker and may include a `compatibility` property on a test case indicating which dialects the case applies to. Test runners should select a concrete dialect, filter out incompatible cases, and replace that placeholder with the concrete dialect URI before running the case.
 * Load any remote references [described below](#additional-assumptions) and configure your implementation to retrieve them via their URIs
 * Walk the filesystem tree for that version's subdirectory and for each `.json` file found:
 

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -120,14 +120,18 @@ def dialect_is_compatible(compatibility, version_name):
 
 def rewrite_v1_dialect(value, version_name):
     if isinstance(value, dict):
-        return {
-            key: (
+        rewritten = {}
+        for key, child in value.items():
+            rewritten_key = (
+                "id" if version_name in {"draft3", "draft4"} and key == "$id"
+                else key
+            )
+            rewritten[rewritten_key] = (
                 DIALECT_URI_FOR_VERSION[version_name]
                 if key == "$schema" and child == V1_DIALECT_URI
                 else rewrite_v1_dialect(child, version_name)
             )
-            for key, child in value.items()
-        }
+        return rewritten
     if isinstance(value, list):
         return [rewrite_v1_dialect(each, version_name) for each in value]
     return value
@@ -433,6 +437,7 @@ class SanityTests(unittest.TestCase):
                 "patternProperties",
                 "prefixItems",
                 "properties",
+                "propertyDependencies",
                 "propertyNames",
                 "required",
                 "then",

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -29,6 +29,25 @@ else:
         "latest": jsonschema.validators.Draft202012Validator,
     }
 
+RELEASE_FOR_DIALECT = {
+    "draft3": 3,
+    "draft4": 4,
+    "draft6": 6,
+    "draft7": 7,
+    "draft2019-09": 2019,
+    "draft2020-12": 2020,
+    "latest": 2020,
+}
+DIALECT_URI_FOR_VERSION = {
+    "draft3": "http://json-schema.org/draft-03/schema#",
+    "draft4": "http://json-schema.org/draft-04/schema#",
+    "draft6": "http://json-schema.org/draft-06/schema#",
+    "draft7": "http://json-schema.org/draft-07/schema#",
+    "draft2019-09": "https://json-schema.org/draft/2019-09/schema",
+    "draft2020-12": "https://json-schema.org/draft/2020-12/schema",
+    "latest": "https://json-schema.org/draft/2020-12/schema",
+}
+V1_DIALECT_URI = "https://json-schema.org/v1"
 
 ROOT_DIR = Path(__file__).parent.parent
 SUITE_ROOT_DIR = ROOT_DIR / "tests"
@@ -37,10 +56,18 @@ OUTPUT_ROOT_DIR = ROOT_DIR / "output-tests"
 REMOTES_DIR = ROOT_DIR / "remotes"
 REMOTES_BASE_URL = "http://localhost:1234/"
 
-TEST_SCHEMA = json.loads(ROOT_DIR.joinpath("test-schema.json").read_text())
-OUTPUT_TEST_SCHEMA = json.loads(
-    ROOT_DIR.joinpath("output-test-schema.json").read_text(),
+TEST_SCHEMA = json.loads(
+    ROOT_DIR.joinpath("test-schema.json").read_text(encoding="utf-8")
 )
+OUTPUT_TEST_SCHEMA = json.loads(
+    ROOT_DIR.joinpath("output-test-schema.json").read_text(
+        encoding="utf-8"
+    ),
+)
+
+
+def read_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
 def files(paths):
@@ -48,7 +75,7 @@ def files(paths):
     Each test file in the provided paths, as an array of test cases.
     """
     for path in paths:
-        yield path, json.loads(path.read_text())
+        yield path, read_json(path)
 
 
 def cases(paths):
@@ -69,10 +96,80 @@ def tests(paths):
             yield test
 
 
+def release_for(version_name):
+    return RELEASE_FOR_DIALECT[version_name]
+
+
+def dialect_is_compatible(compatibility, version_name):
+    if compatibility is None:
+        return True
+
+    release = release_for(version_name)
+    for raw_constraint in compatibility.split(","):
+        constraint = raw_constraint.strip()
+        if constraint.startswith("<="):
+            if release > int(constraint[2:]):
+                return False
+        elif constraint.startswith("="):
+            if release != int(constraint[1:]):
+                return False
+        elif release < int(constraint):
+            return False
+    return True
+
+
+def rewrite_v1_dialect(value, version_name):
+    if isinstance(value, dict):
+        return {
+            key: (
+                DIALECT_URI_FOR_VERSION[version_name]
+                if key == "$schema" and child == V1_DIALECT_URI
+                else rewrite_v1_dialect(child, version_name)
+            )
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [rewrite_v1_dialect(each, version_name) for each in value]
+    return value
+
+
+def cases_for_version(paths, version_name):
+    for case in cases(paths):
+        compatibility = case.get("compatibility")
+        if version_name == "v1":
+            yield case
+            continue
+        if not dialect_is_compatible(compatibility, version_name):
+            continue
+
+        rewritten = dict(case)
+        rewritten.pop("compatibility", None)
+        rewritten["schema"] = rewrite_v1_dialect(case["schema"], version_name)
+        if "tests" in rewritten:
+            rewritten["tests"] = [dict(test) for test in case["tests"]]
+        yield rewritten
+
+
+def suite_version_for(path):
+    current = Path(path)
+    current = current.parent if current.suffix == ".json" else current
+    known = set(RELEASE_FOR_DIALECT) | {"v1"}
+
+    while current.name not in known:
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return current.name
+
+
 def collect(root_dir):
     """
     All of the test file paths within the given root directory, recursively.
     """
+    root_dir = Path(root_dir)
+    if root_dir.is_file():
+        return [root_dir]
     return root_dir.rglob("*.json")
 
 
@@ -170,7 +267,7 @@ class SanityTests(unittest.TestCase):
         for path in collect(ROOT_DIR):
             with self.subTest(path=path):
                 try:
-                    json.loads(path.read_text())
+                    read_json(path)
                 except ValueError as error:
                     self.fail(f"{path} contains invalid JSON ({error})")
 
@@ -255,6 +352,27 @@ class SanityTests(unittest.TestCase):
                             "Found an invalid schema. "
                             "See the traceback for details on why."
                         )
+
+        v1 = SUITE_ROOT_DIR / "v1"
+        if v1.exists():
+            test_files = collect(v1)
+            for version_name, Validator in VALIDATORS.items():
+                if version_name in {"latest"}:
+                    continue
+
+                Validator.FORMAT_CHECKER.checkers.pop("regex", None)
+                for case in cases_for_version(test_files, version_name):
+                    with self.subTest(case=case, version=version_name):
+                        try:
+                            Validator.check_schema(
+                                case["schema"],
+                                format_checker=Validator.FORMAT_CHECKER,
+                            )
+                        except jsonschema.SchemaError:
+                            self.fail(
+                                "Found an invalid schema in tests/v1. "
+                                "See the traceback for details on why."
+                            )
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
     def test_arbitrary_schemas_do_not_use_unknown_keywords(self):
@@ -545,7 +663,7 @@ class SanityTests(unittest.TestCase):
             },
         }
 
-        def missing(d):
+        def missing(d, version_name):
             from collections.abc import Mapping
 
             class BlowUpForUnknownProperties(Mapping):
@@ -553,9 +671,9 @@ class SanityTests(unittest.TestCase):
                     return iter(d)
 
                 def __getitem__(this, k):
-                    if k not in KNOWN[version.name]:
+                    if k not in KNOWN[version_name]:
                         self.fail(
-                            f"{k} is not a known keyword for {version.name}. "
+                            f"{k} is not a known keyword for {version_name}. "
                             "If this test is testing behavior related to "
                             "unknown keywords you may need to add it to the "
                             "allowlist in the jsonschema_suite checker. "
@@ -575,7 +693,9 @@ class SanityTests(unittest.TestCase):
             self.addCleanup(
                 setattr, Validator, "VALIDATORS", Validator.VALIDATORS,
             )
-            Validator.VALIDATORS = missing(dict(Validator.VALIDATORS))
+            Validator.VALIDATORS = missing(
+                dict(Validator.VALIDATORS), version.name
+            )
 
             test_files = [
                 each for each in collect(version)
@@ -589,6 +709,32 @@ class SanityTests(unittest.TestCase):
                         Validator(case["schema"]).is_valid(12)
                     except Unresolvable:
                         pass
+
+        v1 = SUITE_ROOT_DIR / "v1"
+        if v1.exists():
+            test_files = [
+                each for each in collect(v1)
+                if each.stem != "refOfUnknownKeyword"
+            ]
+            for version_name, Validator in VALIDATORS.items():
+                if version_name in {"latest"}:
+                    continue
+
+                self.addCleanup(
+                    setattr, Validator, "VALIDATORS", Validator.VALIDATORS,
+                )
+                Validator.VALIDATORS = missing(
+                    dict(Validator.VALIDATORS), version_name
+                )
+
+                for case in cases_for_version(test_files, version_name):
+                    if "unknown keyword" in case["description"]:
+                        continue
+                    with self.subTest(case=case, version=version_name):
+                        try:
+                            Validator(case["schema"]).is_valid(12)
+                        except Unresolvable:
+                            pass
 
     @unittest.skipIf(jsonschema is None, "Validation library not present!")
     def test_suites_are_valid(self):
@@ -625,7 +771,25 @@ def main(arguments):
         result = unittest.TextTestRunner().run(suite)
         sys.exit(not result.wasSuccessful())
     elif arguments.command == "flatten":
-        selected_cases = [case for case in cases(collect(arguments.version))]
+        version_name = suite_version_for(arguments.version)
+        selected_cases = list(
+            cases_for_version(collect(arguments.version), version_name)
+        )
+
+        if version_name == "v1" and arguments.dialect is not None:
+            selected_cases = [
+                dict(
+                    case,
+                    schema=rewrite_v1_dialect(case["schema"], arguments.dialect),
+                    tests=[dict(test) for test in case["tests"]],
+                )
+                for case in selected_cases
+                if dialect_is_compatible(
+                    case.get("compatibility"), arguments.dialect
+                )
+            ]
+            for case in selected_cases:
+                case.pop("compatibility", None)
 
         if arguments.randomize:
             random.shuffle(selected_cases)
@@ -633,7 +797,7 @@ def main(arguments):
         json.dump(selected_cases, sys.stdout, indent=4, sort_keys=True)
     elif arguments.command == "remotes":
         remotes = {
-            url_for_path(path): json.loads(path.read_text())
+            url_for_path(path): read_json(path)
             for path in collect(REMOTES_DIR)
         }
         json.dump(remotes, sys.stdout, indent=4, sort_keys=True)
@@ -694,6 +858,11 @@ flatten.add_argument(
     "--randomize",
     action="store_true",
     help="Randomize the order of the outputted cases.",
+)
+flatten.add_argument(
+    "--dialect",
+    choices=sorted(RELEASE_FOR_DIALECT),
+    help="When flattening tests/v1, filter to the selected dialect and rewrite the v1 $schema marker.",
 )
 flatten.add_argument(
     "version",

--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -686,6 +686,12 @@ class SanityTests(unittest.TestCase):
 
             return BlowUpForUnknownProperties()
 
+        original_validators = {
+            version.name: dict(Validator.VALIDATORS)
+            for version, Validator in versions_and_validators()
+            if version.name != "latest"
+        }
+
         for version, Validator in versions_and_validators():
             if version.name == "latest":
                 continue
@@ -694,7 +700,7 @@ class SanityTests(unittest.TestCase):
                 setattr, Validator, "VALIDATORS", Validator.VALIDATORS,
             )
             Validator.VALIDATORS = missing(
-                dict(Validator.VALIDATORS), version.name
+                dict(original_validators[version.name]), version.name
             )
 
             test_files = [
@@ -724,7 +730,7 @@ class SanityTests(unittest.TestCase):
                     setattr, Validator, "VALIDATORS", Validator.VALIDATORS,
                 )
                 Validator.VALIDATORS = missing(
-                    dict(Validator.VALIDATORS), version_name
+                    dict(original_validators[version_name]), version_name
                 )
 
                 for case in cases_for_version(test_files, version_name):

--- a/test-schema.json
+++ b/test-schema.json
@@ -15,6 +15,11 @@
                 "description": "The test case description",
                 "type": "string"
             },
+            "compatibility": {
+                "description": "Set which dialects this test case is compatible with. Examples: \"7\" for draft-07 and above, \"<=2019\" for 2019-09 and earlier, \"6,<=2019\" for draft-06 through 2019-09, or \"=2020\" for 2020-12 only.",
+                "type": "string",
+                "pattern": "^(<=|=)?([123467]|2019|2020)(,(<=|=)?([123467]|2019|2020))*$"
+            },
             "comment": {
                 "description": "Any additional comments about the test case",
                 "type": "string"

--- a/tests/v1/additionalProperties.json
+++ b/tests/v1/additionalProperties.json
@@ -172,6 +172,7 @@
     },
     {
         "description": "additionalProperties does not look in applicators",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [

--- a/tests/v1/additionalProperties.json
+++ b/tests/v1/additionalProperties.json
@@ -1,27 +1,41 @@
 [
     {
-        "description":
-            "additionalProperties being false does not allow other properties",
+        "description": "additionalProperties being false does not allow other properties",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"foo": {}, "bar": {}},
-            "patternProperties": { "^v": {} },
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "patternProperties": {
+                "^v": {}
+            },
             "additionalProperties": false
         },
         "tests": [
             {
                 "description": "no additional properties is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "an additional property is invalid",
-                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": "boom"
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": [1, 2, 3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
@@ -36,7 +50,10 @@
             },
             {
                 "description": "patternProperties are not additional properties",
-                "data": {"foo":1, "vroom": 2},
+                "data": {
+                    "foo": 1,
+                    "vroom": 2
+                },
                 "valid": true
             }
         ]
@@ -45,18 +62,24 @@
         "description": "non-ASCII pattern with additionalProperties",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "patternProperties": {"^á": {}},
+            "patternProperties": {
+                "^á": {}
+            },
             "additionalProperties": false
         },
         "tests": [
             {
                 "description": "matching the pattern is valid",
-                "data": {"ármányos": 2},
+                "data": {
+                    "ármányos": 2
+                },
                 "valid": true
             },
             {
                 "description": "not matching the pattern is invalid",
-                "data": {"élmény": 2},
+                "data": {
+                    "élmény": 2
+                },
                 "valid": false
             }
         ]
@@ -65,43 +88,63 @@
         "description": "additionalProperties with schema",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"foo": {}, "bar": {}},
-            "additionalProperties": {"type": "boolean"}
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "additionalProperties": {
+                "type": "boolean"
+            }
         },
         "tests": [
             {
                 "description": "no additional properties is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "an additional valid property is valid",
-                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": true
+                },
                 "valid": true
             },
             {
                 "description": "an additional invalid property is invalid",
-                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": 12
+                },
                 "valid": false
             }
         ]
     },
     {
-        "description":
-            "additionalProperties can exist by itself",
+        "description": "additionalProperties can exist by itself",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "additionalProperties": {"type": "boolean"}
+            "additionalProperties": {
+                "type": "boolean"
+            }
         },
         "tests": [
             {
                 "description": "an additional valid property is valid",
-                "data": {"foo" : true},
+                "data": {
+                    "foo": true
+                },
                 "valid": true
             },
             {
                 "description": "an additional invalid property is invalid",
-                "data": {"foo" : 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": false
             }
         ]
@@ -110,12 +153,19 @@
         "description": "additionalProperties are allowed by default",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"foo": {}, "bar": {}}
+            "properties": {
+                "foo": {},
+                "bar": {}
+            }
         },
         "tests": [
             {
                 "description": "additional properties are allowed",
-                "data": {"foo": 1, "bar": 2, "quux": true},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": true
+                },
                 "valid": true
             }
         ]
@@ -125,14 +175,23 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
-                {"properties": {"foo": {}}}
+                {
+                    "properties": {
+                        "foo": {}
+                    }
+                }
             ],
-            "additionalProperties": {"type": "boolean"}
+            "additionalProperties": {
+                "type": "boolean"
+            }
         },
         "tests": [
             {
                 "description": "properties defined in allOf are not examined",
-                "data": {"foo": 1, "bar": true},
+                "data": {
+                    "foo": 1,
+                    "bar": true
+                },
                 "valid": false
             }
         ]
@@ -148,13 +207,16 @@
         "tests": [
             {
                 "description": "allows null values",
-                "data": {"foo": null},
+                "data": {
+                    "foo": null
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "additionalProperties with propertyNames",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "propertyNames": {
@@ -167,21 +229,29 @@
         "tests": [
             {
                 "description": "Valid against both keywords",
-                "data": { "apple": 4 },
+                "data": {
+                    "apple": 4
+                },
                 "valid": true
             },
             {
                 "description": "Valid against propertyNames, but not additionalProperties",
-                "data": { "fig": 2, "pear": "available" },
+                "data": {
+                    "fig": 2,
+                    "pear": "available"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "dependentSchemas with additionalProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"foo2": {}},
+            "properties": {
+                "foo2": {}
+            },
             "dependentSchemas": {
                 "foo": {},
                 "foo2": {
@@ -195,17 +265,24 @@
         "tests": [
             {
                 "description": "additionalProperties doesn't consider dependentSchemas",
-                "data": {"foo": ""},
+                "data": {
+                    "foo": ""
+                },
                 "valid": false
             },
             {
                 "description": "additionalProperties can't see bar",
-                "data": {"bar": ""},
+                "data": {
+                    "bar": ""
+                },
                 "valid": false
             },
             {
                 "description": "additionalProperties can't see bar even when foo2 is present",
-                "data": {"foo2": "", "bar": ""},
+                "data": {
+                    "foo2": "",
+                    "bar": ""
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/allOf.json
+++ b/tests/v1/allOf.json
@@ -1,102 +1,156 @@
 [
     {
         "description": "allOf",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {
+                            "type": "integer"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "allOf",
-                "data": {"foo": "baz", "bar": 2},
+                "data": {
+                    "foo": "baz",
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "mismatch second",
-                "data": {"foo": "baz"},
+                "data": {
+                    "foo": "baz"
+                },
                 "valid": false
             },
             {
                 "description": "mismatch first",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "wrong type",
-                "data": {"foo": "baz", "bar": "quux"},
+                "data": {
+                    "foo": "baz",
+                    "bar": "quux"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "allOf with base schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"bar": {"type": "integer"}},
-            "required": ["bar"],
-            "allOf" : [
+            "properties": {
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "bar"
+            ],
+            "allOf": [
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 },
                 {
                     "properties": {
-                        "baz": {"type": "null"}
+                        "baz": {
+                            "type": "null"
+                        }
                     },
-                    "required": ["baz"]
+                    "required": [
+                        "baz"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "valid",
-                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2,
+                    "baz": null
+                },
                 "valid": true
             },
             {
                 "description": "mismatch base schema",
-                "data": {"foo": "quux", "baz": null},
+                "data": {
+                    "foo": "quux",
+                    "baz": null
+                },
                 "valid": false
             },
             {
                 "description": "mismatch first allOf",
-                "data": {"bar": 2, "baz": null},
+                "data": {
+                    "bar": 2,
+                    "baz": null
+                },
                 "valid": false
             },
             {
                 "description": "mismatch second allOf",
-                "data": {"foo": "quux", "bar": 2},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "mismatch both",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "allOf simple types",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
-                {"maximum": 30},
-                {"minimum": 20}
+                {
+                    "maximum": 30
+                },
+                {
+                    "minimum": 20
+                }
             ]
         },
         "tests": [
@@ -114,9 +168,13 @@
     },
     {
         "description": "allOf with boolean schemas, all true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "allOf": [true, true]
+            "allOf": [
+                true,
+                true
+            ]
         },
         "tests": [
             {
@@ -128,9 +186,13 @@
     },
     {
         "description": "allOf with boolean schemas, some false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "allOf": [true, false]
+            "allOf": [
+                true,
+                false
+            ]
         },
         "tests": [
             {
@@ -142,9 +204,13 @@
     },
     {
         "description": "allOf with boolean schemas, all false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "allOf": [false, false]
+            "allOf": [
+                false,
+                false
+            ]
         },
         "tests": [
             {
@@ -156,6 +222,7 @@
     },
     {
         "description": "allOf with one empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -172,6 +239,7 @@
     },
     {
         "description": "allOf with two empty schemas",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -189,11 +257,14 @@
     },
     {
         "description": "allOf with the first empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
                 {},
-                { "type": "number" }
+                {
+                    "type": "number"
+                }
             ]
         },
         "tests": [
@@ -211,10 +282,13 @@
     },
     {
         "description": "allOf with the last empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
-                { "type": "number" },
+                {
+                    "type": "number"
+                },
                 {}
             ]
         },
@@ -233,6 +307,7 @@
     },
     {
         "description": "nested allOf, to check validation semantics",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -260,11 +335,24 @@
     },
     {
         "description": "allOf combined with anyOf, oneOf",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "allOf": [ { "multipleOf": 2 } ],
-            "anyOf": [ { "multipleOf": 3 } ],
-            "oneOf": [ { "multipleOf": 5 } ]
+            "allOf": [
+                {
+                    "multipleOf": 2
+                }
+            ],
+            "anyOf": [
+                {
+                    "multipleOf": 3
+                }
+            ],
+            "oneOf": [
+                {
+                    "multipleOf": 5
+                }
+            ]
         },
         "tests": [
             {

--- a/tests/v1/anchor.json
+++ b/tests/v1/anchor.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "Location-independent identifier",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#foo",
@@ -26,6 +27,7 @@
     },
     {
         "description": "Location-independent identifier with absolute URI",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/bar#foo",
@@ -52,6 +54,7 @@
     },
     {
         "description": "Location-independent identifier with base URI change in subschema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/root",
@@ -83,6 +86,7 @@
     },
     {
         "description": "same $anchor with different base uri",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/foobar",

--- a/tests/v1/anyOf.json
+++ b/tests/v1/anyOf.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "anyOf",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "anyOf": [
@@ -37,10 +38,11 @@
     },
     {
         "description": "anyOf with base schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
-            "anyOf" : [
+            "anyOf": [
                 {
                     "maxLength": 2
                 },
@@ -69,9 +71,13 @@
     },
     {
         "description": "anyOf with boolean schemas, all true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "anyOf": [true, true]
+            "anyOf": [
+                true,
+                true
+            ]
         },
         "tests": [
             {
@@ -83,9 +89,13 @@
     },
     {
         "description": "anyOf with boolean schemas, some true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "anyOf": [true, false]
+            "anyOf": [
+                true,
+                false
+            ]
         },
         "tests": [
             {
@@ -97,9 +107,13 @@
     },
     {
         "description": "anyOf with boolean schemas, all false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "anyOf": [false, false]
+            "anyOf": [
+                false,
+                false
+            ]
         },
         "tests": [
             {
@@ -111,52 +125,74 @@
     },
     {
         "description": "anyOf complex types",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "anyOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {
+                            "type": "integer"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "first anyOf valid (complex)",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "second anyOf valid (complex)",
-                "data": {"foo": "baz"},
+                "data": {
+                    "foo": "baz"
+                },
                 "valid": true
             },
             {
                 "description": "both anyOf valid (complex)",
-                "data": {"foo": "baz", "bar": 2},
+                "data": {
+                    "foo": "baz",
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "neither anyOf valid (complex)",
-                "data": {"foo": 2, "bar": "quux"},
+                "data": {
+                    "foo": 2,
+                    "bar": "quux"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "anyOf with one empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "anyOf": [
-                { "type": "number" },
+                {
+                    "type": "number"
+                },
                 {}
             ]
         },
@@ -175,6 +211,7 @@
     },
     {
         "description": "nested anyOf, to check validation semantics",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "anyOf": [

--- a/tests/v1/boolean_schema.json
+++ b/tests/v1/boolean_schema.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "boolean schema 'true'",
+        "compatibility": "6",
         "schema": true,
         "tests": [
             {
@@ -30,7 +31,9 @@
             },
             {
                 "description": "object is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
@@ -40,7 +43,9 @@
             },
             {
                 "description": "array is valid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
@@ -52,6 +57,7 @@
     },
     {
         "description": "boolean schema 'false'",
+        "compatibility": "6",
         "schema": false,
         "tests": [
             {
@@ -81,7 +87,9 @@
             },
             {
                 "description": "object is invalid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
@@ -91,7 +99,9 @@
             },
             {
                 "description": "array is invalid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             },
             {

--- a/tests/v1/const.json
+++ b/tests/v1/const.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "const validation",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": 2
@@ -25,59 +26,90 @@
     },
     {
         "description": "const with object",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": {"foo": "bar", "baz": "bax"}
+            "const": {
+                "foo": "bar",
+                "baz": "bax"
+            }
         },
         "tests": [
             {
                 "description": "same object is valid",
-                "data": {"foo": "bar", "baz": "bax"},
+                "data": {
+                    "foo": "bar",
+                    "baz": "bax"
+                },
                 "valid": true
             },
             {
                 "description": "same object with different property order is valid",
-                "data": {"baz": "bax", "foo": "bar"},
+                "data": {
+                    "baz": "bax",
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "another object is invalid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
                 "description": "another type is invalid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "const with array",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": [{ "foo": "bar" }]
+            "const": [
+                {
+                    "foo": "bar"
+                }
+            ]
         },
         "tests": [
             {
                 "description": "same array is valid",
-                "data": [{"foo": "bar"}],
+                "data": [
+                    {
+                        "foo": "bar"
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "another array item is invalid",
-                "data": [2],
+                "data": [
+                    2
+                ],
                 "valid": false
             },
             {
                 "description": "array with additional items is invalid",
-                "data": [1, 2, 3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "const with null",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": null
@@ -97,6 +129,7 @@
     },
     {
         "description": "const with false does not match 0",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": false
@@ -121,6 +154,7 @@
     },
     {
         "description": "const with true does not match 1",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": true
@@ -145,102 +179,139 @@
     },
     {
         "description": "const with [false] does not match [0]",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": [false]
+            "const": [
+                false
+            ]
         },
         "tests": [
             {
                 "description": "[false] is valid",
-                "data": [false],
+                "data": [
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[0] is invalid",
-                "data": [0],
+                "data": [
+                    0
+                ],
                 "valid": false
             },
             {
                 "description": "[0.0] is invalid",
-                "data": [0.0],
+                "data": [
+                    0.0
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "const with [true] does not match [1]",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": [true]
+            "const": [
+                true
+            ]
         },
         "tests": [
             {
                 "description": "[true] is valid",
-                "data": [true],
+                "data": [
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[1] is invalid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "[1.0] is invalid",
-                "data": [1.0],
+                "data": [
+                    1.0
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": {"a": false}
+            "const": {
+                "a": false
+            }
         },
         "tests": [
             {
                 "description": "{\"a\": false} is valid",
-                "data": {"a": false},
+                "data": {
+                    "a": false
+                },
                 "valid": true
             },
             {
                 "description": "{\"a\": 0} is invalid",
-                "data": {"a": 0},
+                "data": {
+                    "a": 0
+                },
                 "valid": false
             },
             {
                 "description": "{\"a\": 0.0} is invalid",
-                "data": {"a": 0.0},
+                "data": {
+                    "a": 0.0
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "const": {"a": true}
+            "const": {
+                "a": true
+            }
         },
         "tests": [
             {
                 "description": "{\"a\": true} is valid",
-                "data": {"a": true},
+                "data": {
+                    "a": true
+                },
                 "valid": true
             },
             {
                 "description": "{\"a\": 1} is invalid",
-                "data": {"a": 1},
+                "data": {
+                    "a": 1
+                },
                 "valid": false
             },
             {
                 "description": "{\"a\": 1.0} is invalid",
-                "data": {"a": 1.0},
+                "data": {
+                    "a": 1.0
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "const with 0 does not match other zero-like types",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": 0
@@ -280,6 +351,7 @@
     },
     {
         "description": "const with 1 does not match true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": 1
@@ -304,6 +376,7 @@
     },
     {
         "description": "const with -2.0 matches integer and float types",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": -2.0
@@ -338,6 +411,7 @@
     },
     {
         "description": "float and integers are equal up to 64-bit representation limits",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": 9007199254740992
@@ -367,6 +441,7 @@
     },
     {
         "description": "nul characters in strings",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": "hello\u0000there"
@@ -386,6 +461,7 @@
     },
     {
         "description": "characters with the same visual representation but different codepoint",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": "μ",
@@ -408,6 +484,7 @@
     },
     {
         "description": "characters with the same visual representation, but different number of codepoints",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "const": "ä",

--- a/tests/v1/contains.json
+++ b/tests/v1/contains.json
@@ -1,29 +1,49 @@
 [
     {
         "description": "contains keyword validation",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "minimum": 5 }
+            "contains": {
+                "minimum": 5
+            }
         },
         "tests": [
             {
                 "description": "array with item matching schema (5) is valid",
-                "data": [3, 4, 5],
+                "data": [
+                    3,
+                    4,
+                    5
+                ],
                 "valid": true
             },
             {
                 "description": "array with item matching schema (6) is valid",
-                "data": [3, 4, 6],
+                "data": [
+                    3,
+                    4,
+                    6
+                ],
                 "valid": true
             },
             {
                 "description": "array with two items matching schema (5, 6) is valid",
-                "data": [3, 4, 5, 6],
+                "data": [
+                    3,
+                    4,
+                    5,
+                    6
+                ],
                 "valid": true
             },
             {
                 "description": "array without items matching schema is invalid",
-                "data": [2, 3, 4],
+                "data": [
+                    2,
+                    3,
+                    4
+                ],
                 "valid": false
             },
             {
@@ -40,30 +60,48 @@
     },
     {
         "description": "contains keyword with const keyword",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 5 }
+            "contains": {
+                "const": 5
+            }
         },
         "tests": [
             {
                 "description": "array with item 5 is valid",
-                "data": [3, 4, 5],
+                "data": [
+                    3,
+                    4,
+                    5
+                ],
                 "valid": true
             },
             {
                 "description": "array with two items 5 is valid",
-                "data": [3, 4, 5, 5],
+                "data": [
+                    3,
+                    4,
+                    5,
+                    5
+                ],
                 "valid": true
             },
             {
                 "description": "array without item 5 is invalid",
-                "data": [1, 2, 3, 4],
+                "data": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "contains keyword with boolean schema true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contains": true
@@ -71,7 +109,9 @@
         "tests": [
             {
                 "description": "any non-empty array is valid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
@@ -83,6 +123,7 @@
     },
     {
         "description": "contains keyword with boolean schema false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contains": false
@@ -90,7 +131,9 @@
         "tests": [
             {
                 "description": "any non-empty array is invalid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             },
             {
@@ -127,37 +170,59 @@
     },
     {
         "description": "items + contains",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "additionalProperties": { "multipleOf": 2 },
-            "items": { "multipleOf": 2 },
-            "contains": { "multipleOf": 3 }
+            "additionalProperties": {
+                "multipleOf": 2
+            },
+            "items": {
+                "multipleOf": 2
+            },
+            "contains": {
+                "multipleOf": 3
+            }
         },
         "tests": [
             {
                 "description": "matches items, does not match contains",
-                "data": [2, 4, 8],
+                "data": [
+                    2,
+                    4,
+                    8
+                ],
                 "valid": false
             },
             {
                 "description": "does not match items, matches contains",
-                "data": [3, 6, 9],
+                "data": [
+                    3,
+                    6,
+                    9
+                ],
                 "valid": false
             },
             {
                 "description": "matches both items and contains",
-                "data": [6, 12],
+                "data": [
+                    6,
+                    12
+                ],
                 "valid": true
             },
             {
                 "description": "matches neither items nor contains",
-                "data": [1, 5],
+                "data": [
+                    1,
+                    5
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "contains with false if subschema",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contains": {
@@ -168,7 +233,9 @@
         "tests": [
             {
                 "description": "any non-empty array is valid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
@@ -180,6 +247,7 @@
     },
     {
         "description": "contains with null instance elements",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contains": {
@@ -189,7 +257,9 @@
         "tests": [
             {
                 "description": "allows null items",
-                "data": [ null ],
+                "data": [
+                    null
+                ],
                 "valid": true
             }
         ]

--- a/tests/v1/content.json
+++ b/tests/v1/content.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of string-encoded content based on media type",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contentMediaType": "application/json"
@@ -25,6 +26,7 @@
     },
     {
         "description": "validation of binary string-encoding",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contentEncoding": "base64"
@@ -49,6 +51,7 @@
     },
     {
         "description": "validation of binary-encoded media type documents",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contentMediaType": "application/json",
@@ -79,11 +82,22 @@
     },
     {
         "description": "validation of binary-encoded media type documents with schema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "contentMediaType": "application/json",
             "contentEncoding": "base64",
-            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+            "contentSchema": {
+                "type": "object",
+                "required": [
+                    "foo"
+                ],
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "tests": [
             {

--- a/tests/v1/defs.json
+++ b/tests/v1/defs.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validate definition against metaschema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "https://json-schema.org/v1"
@@ -8,12 +9,24 @@
         "tests": [
             {
                 "description": "valid definition schema",
-                "data": {"$defs": {"foo": {"type": "integer"}}},
+                "data": {
+                    "$defs": {
+                        "foo": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "invalid definition schema",
-                "data": {"$defs": {"foo": {"type": 1}}},
+                "data": {
+                    "$defs": {
+                        "foo": {
+                            "type": 1
+                        }
+                    }
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/dependentRequired.json
+++ b/tests/v1/dependentRequired.json
@@ -1,9 +1,14 @@
 [
     {
         "description": "single dependency",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependentRequired": {"bar": ["foo"]}
+            "dependentRequired": {
+                "bar": [
+                    "foo"
+                ]
+            }
         },
         "tests": [
             {
@@ -13,22 +18,31 @@
             },
             {
                 "description": "nondependant",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "with dependency",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "missing dependency",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": ["bar"],
+                "data": [
+                    "bar"
+                ],
                 "valid": true
             },
             {
@@ -45,9 +59,12 @@
     },
     {
         "description": "empty dependents",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependentRequired": {"bar": []}
+            "dependentRequired": {
+                "bar": []
+            }
         },
         "tests": [
             {
@@ -57,7 +74,9 @@
             },
             {
                 "description": "object with one property",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": true
             },
             {
@@ -69,9 +88,15 @@
     },
     {
         "description": "multiple dependents required",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependentRequired": {"quux": ["foo", "bar"]}
+            "dependentRequired": {
+                "quux": [
+                    "foo",
+                    "bar"
+                ]
+            }
         },
         "tests": [
             {
@@ -81,38 +106,58 @@
             },
             {
                 "description": "nondependants",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "with dependencies",
-                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": 3
+                },
                 "valid": true
             },
             {
                 "description": "missing dependency",
-                "data": {"foo": 1, "quux": 2},
+                "data": {
+                    "foo": 1,
+                    "quux": 2
+                },
                 "valid": false
             },
             {
                 "description": "missing other dependency",
-                "data": {"bar": 1, "quux": 2},
+                "data": {
+                    "bar": 1,
+                    "quux": 2
+                },
                 "valid": false
             },
             {
                 "description": "missing both dependencies",
-                "data": {"quux": 1},
+                "data": {
+                    "quux": 1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "dependencies with escaped characters",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependentRequired": {
-                "foo\nbar": ["foo\rbar"],
-                "foo\"bar": ["foo'bar"]
+                "foo\nbar": [
+                    "foo\rbar"
+                ],
+                "foo\"bar": [
+                    "foo'bar"
+                ]
             }
         },
         "tests": [

--- a/tests/v1/dependentSchemas.json
+++ b/tests/v1/dependentSchemas.json
@@ -1,13 +1,18 @@
 [
     {
         "description": "single dependency",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependentSchemas": {
                 "bar": {
                     "properties": {
-                        "foo": {"type": "integer"},
-                        "bar": {"type": "integer"}
+                        "foo": {
+                            "type": "integer"
+                        },
+                        "bar": {
+                            "type": "integer"
+                        }
                     }
                 }
             }
@@ -15,32 +20,48 @@
         "tests": [
             {
                 "description": "valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "no dependency",
-                "data": {"foo": "quux"},
+                "data": {
+                    "foo": "quux"
+                },
                 "valid": true
             },
             {
                 "description": "wrong type",
-                "data": {"foo": "quux", "bar": 2},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "wrong type other",
-                "data": {"foo": 2, "bar": "quux"},
+                "data": {
+                    "foo": 2,
+                    "bar": "quux"
+                },
                 "valid": false
             },
             {
                 "description": "wrong type both",
-                "data": {"foo": "quux", "bar": "quux"},
+                "data": {
+                    "foo": "quux",
+                    "bar": "quux"
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": ["bar"],
+                "data": [
+                    "bar"
+                ],
                 "valid": true
             },
             {
@@ -57,6 +78,7 @@
     },
     {
         "description": "boolean subschemas",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependentSchemas": {
@@ -67,17 +89,24 @@
         "tests": [
             {
                 "description": "object with property having schema true is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "object with property having schema false is invalid",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "object with both properties is invalid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             },
             {
@@ -89,11 +118,18 @@
     },
     {
         "description": "dependencies with escaped characters",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependentSchemas": {
-                "foo\tbar": {"minProperties": 4},
-                "foo'bar": {"required": ["foo\"bar"]}
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {
+                    "required": [
+                        "foo\"bar"
+                    ]
+                }
             }
         },
         "tests": [
@@ -110,7 +146,9 @@
             {
                 "description": "quoted quote",
                 "data": {
-                    "foo'bar": {"foo\"bar": 1}
+                    "foo'bar": {
+                        "foo\"bar": 1
+                    }
                 },
                 "valid": false
             },
@@ -124,13 +162,16 @@
             },
             {
                 "description": "quoted quote invalid under dependent schema",
-                "data": {"foo'bar": 1},
+                "data": {
+                    "foo'bar": 1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "dependent subschema incompatible with root",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -148,22 +189,31 @@
         "tests": [
             {
                 "description": "matches root",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": false
             },
             {
                 "description": "matches dependency",
-                "data": {"bar": 1},
+                "data": {
+                    "bar": 1
+                },
                 "valid": true
             },
             {
                 "description": "matches both",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "no dependency",
-                "data": {"baz": 1},
+                "data": {
+                    "baz": 1
+                },
                 "valid": true
             }
         ]

--- a/tests/v1/dynamicRef.json
+++ b/tests/v1/dynamicRef.json
@@ -1,11 +1,14 @@
 [
     {
         "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
             "type": "array",
-            "items": { "$dynamicRef": "#items" },
+            "items": {
+                "$dynamicRef": "#items"
+            },
             "$defs": {
                 "foo": {
                     "$dynamicAnchor": "items",
@@ -16,18 +19,25 @@
         "tests": [
             {
                 "description": "An array of strings is valid",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "An array containing non-strings is invalid",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
@@ -40,25 +50,34 @@
                 "list": {
                     "$id": "list",
                     "type": "array",
-                    "items": { "$dynamicRef": "#items" }
+                    "items": {
+                        "$dynamicRef": "#items"
+                    }
                 }
             }
         },
         "tests": [
             {
                 "description": "An array of strings is valid",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "An array containing non-strings is invalid",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
@@ -75,25 +94,34 @@
                 "list": {
                     "$id": "list",
                     "type": "array",
-                    "items": { "$dynamicRef": "#items" }
+                    "items": {
+                        "$dynamicRef": "#items"
+                    }
                 }
             }
         },
         "tests": [
             {
                 "description": "An array of strings is valid",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "An array containing non-strings is invalid",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
@@ -106,11 +134,13 @@
                 "list": {
                     "$id": "list",
                     "type": "array",
-                    "items": { "$dynamicRef": "#items" },
+                    "items": {
+                        "$dynamicRef": "#items"
+                    },
                     "$defs": {
-                      "items": {
-                          "$dynamicAnchor": "items"
-                      }
+                        "items": {
+                            "$dynamicAnchor": "items"
+                        }
                     }
                 }
             }
@@ -118,13 +148,17 @@
         "tests": [
             {
                 "description": "Any array is valid",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
+        "compatibility": "=2020",
         "schema": {
             "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
             "if": {
@@ -187,11 +221,11 @@
     },
     {
         "description": "strict-tree schema, guards against misspelled properties",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/strict-tree.json",
             "$dynamicAnchor": "node",
-
             "$ref": "tree.json",
             "unevaluatedProperties": false
         },
@@ -199,18 +233,22 @@
             {
                 "description": "instance with misspelled field",
                 "data": {
-                    "children": [{
+                    "children": [
+                        {
                             "daat": 1
-                        }]
+                        }
+                    ]
                 },
                 "valid": false
             },
             {
                 "description": "instance with correct field",
                 "data": {
-                    "children": [{
+                    "children": [
+                        {
                             "data": 1
-                        }]
+                        }
+                    ]
                 },
                 "valid": true
             }
@@ -218,6 +256,7 @@
     },
     {
         "description": "tests for implementation dynamic anchor and reference link",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/strict-extendible.json",
@@ -228,7 +267,9 @@
                     "properties": {
                         "a": true
                     },
-                    "required": ["a"],
+                    "required": [
+                        "a"
+                    ],
                     "additionalProperties": false
                 }
             }
@@ -245,7 +286,9 @@
                 "description": "incorrect extended schema",
                 "data": {
                     "elements": [
-                        { "b": 1 }
+                        {
+                            "b": 1
+                        }
                     ]
                 },
                 "valid": false
@@ -254,7 +297,9 @@
                 "description": "correct extended schema",
                 "data": {
                     "elements": [
-                        { "a": 1 }
+                        {
+                            "a": 1
+                        }
                     ]
                 },
                 "valid": true
@@ -263,6 +308,7 @@
     },
     {
         "description": "$ref and $dynamicAnchor are independent of order - $defs first",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/strict-extendible-allof-defs-first.json",
@@ -277,7 +323,9 @@
                             "properties": {
                                 "a": true
                             },
-                            "required": ["a"],
+                            "required": [
+                                "a"
+                            ],
                             "additionalProperties": false
                         }
                     }
@@ -296,7 +344,9 @@
                 "description": "incorrect extended schema",
                 "data": {
                     "elements": [
-                        { "b": 1 }
+                        {
+                            "b": 1
+                        }
                     ]
                 },
                 "valid": false
@@ -305,7 +355,9 @@
                 "description": "correct extended schema",
                 "data": {
                     "elements": [
-                        { "a": 1 }
+                        {
+                            "a": 1
+                        }
                     ]
                 },
                 "valid": true
@@ -314,6 +366,7 @@
     },
     {
         "description": "$ref and $dynamicAnchor are independent of order - $ref first",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/strict-extendible-allof-ref-first.json",
@@ -325,7 +378,9 @@
                             "properties": {
                                 "a": true
                             },
-                            "required": ["a"],
+                            "required": [
+                                "a"
+                            ],
                             "additionalProperties": false
                         }
                     }
@@ -347,7 +402,9 @@
                 "description": "incorrect extended schema",
                 "data": {
                     "elements": [
-                        { "b": 1 }
+                        {
+                            "b": 1
+                        }
                     ]
                 },
                 "valid": false
@@ -356,7 +413,9 @@
                 "description": "correct extended schema",
                 "data": {
                     "elements": [
-                        { "a": 1 }
+                        {
+                            "a": 1
+                        }
                     ]
                 },
                 "valid": true
@@ -365,6 +424,7 @@
     },
     {
         "description": "$ref to $dynamicRef finds detached $dynamicAnchor",
+        "compatibility": "=2020",
         "schema": {
             "$ref": "http://localhost:1234/v1/detached-dynamicref.json#/$defs/foo"
         },
@@ -383,6 +443,7 @@
     },
     {
         "description": "$dynamicRef skips over intermediate resources - direct reference",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamic-ref-skips-intermediate-resource/main",
@@ -426,18 +487,27 @@
         "tests": [
             {
                 "description": "integer property passes",
-                "data": { "bar-item": { "content": 42 } },
+                "data": {
+                    "bar-item": {
+                        "content": 42
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "string property fails",
-                "data": { "bar-item": { "content": "value" } },
+                "data": {
+                    "bar-item": {
+                        "content": "value"
+                    }
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "$dynamicRef avoids the root of each schema, but scopes are still registered",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamic-ref-avoids-root-of-each-schema/base",

--- a/tests/v1/enum.json
+++ b/tests/v1/enum.json
@@ -3,7 +3,11 @@
         "description": "simple enum validation",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [1, 2, 3]
+            "enum": [
+                1,
+                2,
+                3
+            ]
         },
         "tests": [
             {
@@ -22,7 +26,15 @@
         "description": "heterogeneous enum validation",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [6, "foo", [], true, {"foo": 12}]
+            "enum": [
+                6,
+                "foo",
+                [],
+                true,
+                {
+                    "foo": 12
+                }
+            ]
         },
         "tests": [
             {
@@ -37,17 +49,24 @@
             },
             {
                 "description": "objects are deep compared",
-                "data": {"foo": false},
+                "data": {
+                    "foo": false
+                },
                 "valid": false
             },
             {
                 "description": "valid object matches",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": true
             },
             {
                 "description": "extra properties in object is invalid",
-                "data": {"foo": 12, "boo": 42},
+                "data": {
+                    "foo": 12,
+                    "boo": 42
+                },
                 "valid": false
             }
         ]
@@ -56,7 +75,10 @@
         "description": "heterogeneous enum-with-null validation",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [6, null]
+            "enum": [
+                6,
+                null
+            ]
         },
         "tests": [
             {
@@ -80,37 +102,60 @@
         "description": "enums in properties",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type":"object",
+            "type": "object",
             "properties": {
-                "foo": {"enum":["foo"]},
-                "bar": {"enum":["bar"]}
+                "foo": {
+                    "enum": [
+                        "foo"
+                    ]
+                },
+                "bar": {
+                    "enum": [
+                        "bar"
+                    ]
+                }
             },
-            "required": ["bar"]
+            "required": [
+                "bar"
+            ]
         },
         "tests": [
             {
                 "description": "both properties are valid",
-                "data": {"foo":"foo", "bar":"bar"},
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "wrong foo value",
-                "data": {"foo":"foot", "bar":"bar"},
+                "data": {
+                    "foo": "foot",
+                    "bar": "bar"
+                },
                 "valid": false
             },
             {
                 "description": "wrong bar value",
-                "data": {"foo":"foo", "bar":"bart"},
+                "data": {
+                    "foo": "foo",
+                    "bar": "bart"
+                },
                 "valid": false
             },
             {
                 "description": "missing optional property is valid",
-                "data": {"bar":"bar"},
+                "data": {
+                    "bar": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "missing required property is invalid",
-                "data": {"foo":"foo"},
+                "data": {
+                    "foo": "foo"
+                },
                 "valid": false
             },
             {
@@ -122,9 +167,13 @@
     },
     {
         "description": "enum with escaped characters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": ["foo\nbar", "foo\rbar"]
+            "enum": [
+                "foo\nbar",
+                "foo\rbar"
+            ]
         },
         "tests": [
             {
@@ -146,9 +195,12 @@
     },
     {
         "description": "enum with false does not match 0",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [false]
+            "enum": [
+                false
+            ]
         },
         "tests": [
             {
@@ -170,33 +222,47 @@
     },
     {
         "description": "enum with [false] does not match [0]",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [[false]]
+            "enum": [
+                [
+                    false
+                ]
+            ]
         },
         "tests": [
             {
                 "description": "[false] is valid",
-                "data": [false],
+                "data": [
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[0] is invalid",
-                "data": [0],
+                "data": [
+                    0
+                ],
                 "valid": false
             },
             {
                 "description": "[0.0] is invalid",
-                "data": [0.0],
+                "data": [
+                    0.0
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "enum with true does not match 1",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [true]
+            "enum": [
+                true
+            ]
         },
         "tests": [
             {
@@ -218,33 +284,47 @@
     },
     {
         "description": "enum with [true] does not match [1]",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [[true]]
+            "enum": [
+                [
+                    true
+                ]
+            ]
         },
         "tests": [
             {
                 "description": "[true] is valid",
-                "data": [true],
+                "data": [
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[1] is invalid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "[1.0] is invalid",
-                "data": [1.0],
+                "data": [
+                    1.0
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "enum with 0 does not match false",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [0]
+            "enum": [
+                0
+            ]
         },
         "tests": [
             {
@@ -266,33 +346,47 @@
     },
     {
         "description": "enum with [0] does not match [false]",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [[0]]
+            "enum": [
+                [
+                    0
+                ]
+            ]
         },
         "tests": [
             {
                 "description": "[false] is invalid",
-                "data": [false],
+                "data": [
+                    false
+                ],
                 "valid": false
             },
             {
                 "description": "[0] is valid",
-                "data": [0],
+                "data": [
+                    0
+                ],
                 "valid": true
             },
             {
                 "description": "[0.0] is valid",
-                "data": [0.0],
+                "data": [
+                    0.0
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "enum with 1 does not match true",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [1]
+            "enum": [
+                1
+            ]
         },
         "tests": [
             {
@@ -314,24 +408,35 @@
     },
     {
         "description": "enum with [1] does not match [true]",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [[1]]
+            "enum": [
+                [
+                    1
+                ]
+            ]
         },
         "tests": [
             {
                 "description": "[true] is invalid",
-                "data": [true],
+                "data": [
+                    true
+                ],
                 "valid": false
             },
             {
                 "description": "[1] is valid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "[1.0] is valid",
-                "data": [1.0],
+                "data": [
+                    1.0
+                ],
                 "valid": true
             }
         ]
@@ -340,7 +445,9 @@
         "description": "nul characters in strings",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "enum": [ "hello\u0000there" ]
+            "enum": [
+                "hello\u0000there"
+            ]
         },
         "tests": [
             {
@@ -357,6 +464,7 @@
     },
     {
         "description": "empty enum",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "enum": []

--- a/tests/v1/enum.json
+++ b/tests/v1/enum.json
@@ -100,6 +100,7 @@
     },
     {
         "description": "enums in properties",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",

--- a/tests/v1/exclusiveMaximum.json
+++ b/tests/v1/exclusiveMaximum.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "exclusiveMaximum validation",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "exclusiveMaximum": 3.0

--- a/tests/v1/exclusiveMinimum.json
+++ b/tests/v1/exclusiveMinimum.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "exclusiveMinimum validation",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "exclusiveMinimum": 1.1

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of date strings",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "date"

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of duration strings",
+        "compatibility": "2019",
         "comment": "RFC 3339 Appendix A defines the ABNF grammar for ISO-8601 durations used by JSON Schema format 'duration'. These tests enforce only the syntax defined by that grammar.",
         "schema": {
             "$schema": "https://json-schema.org/v1",

--- a/tests/v1/format/ecmascript-regex.json
+++ b/tests/v1/format/ecmascript-regex.json
@@ -1,16 +1,17 @@
 [
-  {
-    "description": "\\a is not an ECMA 262 control escape",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
-    },
-    "tests": [
-      {
-        "description": "when used as a pattern",
-        "data": "\\a",
-        "valid": false
-      }
-    ]
-  }
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "compatibility": "=2020",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
+    }
 ]

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of host names",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "hostname"
@@ -83,7 +84,7 @@
             },
             {
                 "description": "IDN label separator",
-                "data": "example\uff0ecom",
+                "data": "example．com",
                 "valid": false
             },
             {
@@ -131,6 +132,7 @@
     },
     {
         "description": "validation of A-label (punycode) host names",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "hostname"

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of an internationalized e-mail addresses",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "idn-email"

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of internationalized host names",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "idn-hostname"
@@ -101,205 +102,205 @@
             {
                 "description": "Begins with a Spacing Combining Mark",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
-                "data": "\u0903hello",
+                "data": "ःhello",
                 "valid": false
             },
             {
                 "description": "Begins with a Nonspacing Mark",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
-                "data": "\u0300hello",
+                "data": "̀hello",
                 "valid": false
             },
             {
                 "description": "Begins with an Enclosing Mark",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
-                "data": "\u0488hello",
+                "data": "҈hello",
                 "valid": false
             },
             {
                 "description": "Exceptions that are PVALID, left-to-right chars",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
-                "data": "\u00df\u03c2\u0f0b\u3007",
+                "data": "ßς་〇",
                 "valid": true
             },
             {
                 "description": "Exceptions that are PVALID, right-to-left chars",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
-                "data": "\u06fd\u06fe",
+                "data": "۽۾",
                 "valid": true
             },
             {
                 "description": "Exceptions that are DISALLOWED, right-to-left chars",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
-                "data": "\u0640\u07fa",
+                "data": "ـߺ",
                 "valid": false
             },
             {
                 "description": "Exceptions that are DISALLOWED, left-to-right chars",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
-                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "data": "〱〲〳〴〵〮〯〻",
                 "valid": false
             },
             {
                 "description": "MIDDLE DOT with no preceding 'l'",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
-                "data": "a\u00b7l",
+                "data": "a·l",
                 "valid": false
             },
             {
                 "description": "MIDDLE DOT with nothing preceding",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
-                "data": "\u00b7l",
+                "data": "·l",
                 "valid": false
             },
             {
                 "description": "MIDDLE DOT with no following 'l'",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
-                "data": "l\u00b7a",
+                "data": "l·a",
                 "valid": false
             },
             {
                 "description": "MIDDLE DOT with nothing following",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
-                "data": "l\u00b7",
+                "data": "l·",
                 "valid": false
             },
             {
                 "description": "MIDDLE DOT with surrounding 'l's",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
-                "data": "l\u00b7l",
+                "data": "l·l",
                 "valid": true
             },
             {
                 "description": "Greek KERAIA not followed by Greek",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
-                "data": "\u03b1\u0375S",
+                "data": "α͵S",
                 "valid": false
             },
             {
                 "description": "Greek KERAIA not followed by anything",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
-                "data": "\u03b1\u0375",
+                "data": "α͵",
                 "valid": false
             },
             {
                 "description": "Greek KERAIA followed by Greek",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
-                "data": "\u03b1\u0375\u03b2",
+                "data": "α͵β",
                 "valid": true
             },
             {
                 "description": "Hebrew GERESH not preceded by Hebrew",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
-                "data": "A\u05f3\u05d1",
+                "data": "A׳ב",
                 "valid": false
             },
             {
                 "description": "Hebrew GERESH not preceded by anything",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
-                "data": "\u05f3\u05d1",
+                "data": "׳ב",
                 "valid": false
             },
             {
                 "description": "Hebrew GERESH preceded by Hebrew",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
-                "data": "\u05d0\u05f3\u05d1",
+                "data": "א׳ב",
                 "valid": true
             },
             {
                 "description": "Hebrew GERSHAYIM not preceded by Hebrew",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
-                "data": "A\u05f4\u05d1",
+                "data": "A״ב",
                 "valid": false
             },
             {
                 "description": "Hebrew GERSHAYIM not preceded by anything",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
-                "data": "\u05f4\u05d1",
+                "data": "״ב",
                 "valid": false
             },
             {
                 "description": "Hebrew GERSHAYIM preceded by Hebrew",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
-                "data": "\u05d0\u05f4\u05d1",
+                "data": "א״ב",
                 "valid": true
             },
             {
                 "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
-                "data": "def\u30fbabc",
+                "data": "def・abc",
                 "valid": false
             },
             {
                 "description": "KATAKANA MIDDLE DOT with no other characters",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
-                "data": "\u30fb",
+                "data": "・",
                 "valid": false
             },
             {
                 "description": "KATAKANA MIDDLE DOT with Hiragana",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
-                "data": "\u30fb\u3041",
+                "data": "・ぁ",
                 "valid": true
             },
             {
                 "description": "KATAKANA MIDDLE DOT with Katakana",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
-                "data": "\u30fb\u30a1",
+                "data": "・ァ",
                 "valid": true
             },
             {
                 "description": "KATAKANA MIDDLE DOT with Han",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
-                "data": "\u30fb\u4e08",
+                "data": "・丈",
                 "valid": true
             },
             {
                 "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
-                "data": "\u0628\u0660\u06f0",
+                "data": "ب٠۰",
                 "valid": false
             },
             {
                 "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
-                "data": "\u0628\u0660\u0628",
+                "data": "ب٠ب",
                 "valid": true
             },
             {
                 "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
-                "data": "\u06f00",
+                "data": "۰0",
                 "valid": true
             },
             {
                 "description": "ZERO WIDTH JOINER not preceded by Virama",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
-                "data": "\u0915\u200d\u0937",
+                "data": "क‍ष",
                 "valid": false
             },
             {
                 "description": "ZERO WIDTH JOINER not preceded by anything",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
-                "data": "\u200d\u0937",
+                "data": "‍ष",
                 "valid": false
             },
             {
                 "description": "ZERO WIDTH JOINER preceded by Virama",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
-                "data": "\u0915\u094d\u200d\u0937",
+                "data": "क्‍ष",
                 "valid": true
             },
             {
                 "description": "ZERO WIDTH NON-JOINER preceded by Virama",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
-                "data": "\u0915\u094d\u200c\u0937",
+                "data": "क्‌ष",
                 "valid": true
             },
             {
                 "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
-                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "data": "بي‌بي",
                 "valid": true
             },
             {
@@ -336,8 +337,12 @@
     },
     {
         "description": "validation of separators in internationalized host names",
+        "compatibility": "7",
         "specification": [
-            {"rfc3490": "3.1", "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"}
+            {
+                "rfc3490": "3.1",
+                "quote": "Whenever dots are used as label separators, the following characters MUST be recognized as dots: U+002E (full stop), U+3002 (ideographic full stop), U+FF0E (fullwidth full stop), U+FF61(halfwidth ideographic full stop)"
+            }
         ],
         "schema": {
             "$schema": "https://json-schema.org/v1",
@@ -351,17 +356,17 @@
             },
             {
                 "description": "single ideographic full stop",
-                "data": "\u3002",
+                "data": "。",
                 "valid": false
             },
             {
                 "description": "single fullwidth full stop",
-                "data": "\uff0e",
+                "data": "．",
                 "valid": false
             },
             {
                 "description": "single halfwidth ideographic full stop",
-                "data": "\uff61",
+                "data": "｡",
                 "valid": false
             },
             {
@@ -371,17 +376,17 @@
             },
             {
                 "description": "ideographic full stop as label separator",
-                "data": "a\u3002b",
+                "data": "a。b",
                 "valid": true
             },
             {
                 "description": "fullwidth full stop as label separator",
-                "data": "a\uff0eb",
+                "data": "a．b",
                 "valid": true
             },
             {
                 "description": "halfwidth ideographic full stop as label separator",
-                "data": "a\uff61b",
+                "data": "a｡b",
                 "valid": true
             },
             {
@@ -391,17 +396,17 @@
             },
             {
                 "description": "leading ideographic full stop",
-                "data": "\u3002example",
+                "data": "。example",
                 "valid": false
             },
             {
                 "description": "leading fullwidth full stop",
-                "data": "\uff0eexample",
+                "data": "．example",
                 "valid": false
             },
             {
                 "description": "leading halfwidth ideographic full stop",
-                "data": "\uff61example",
+                "data": "｡example",
                 "valid": false
             },
             {
@@ -411,17 +416,17 @@
             },
             {
                 "description": "trailing ideographic full stop",
-                "data": "example\u3002",
+                "data": "example。",
                 "valid": false
             },
             {
                 "description": "trailing fullwidth full stop",
-                "data": "example\uff0e",
+                "data": "example．",
                 "valid": false
             },
             {
                 "description": "trailing halfwidth ideographic full stop",
-                "data": "example\uff61",
+                "data": "example｡",
                 "valid": false
             },
             {
@@ -431,17 +436,17 @@
             },
             {
                 "description": "label too long if separator ignored (ideographic full stop)",
-                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα\u3002com",
+                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα。com",
                 "valid": true
             },
             {
                 "description": "label too long if separator ignored (fullwidth full stop)",
-                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα\uff0ecom",
+                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα．com",
                 "valid": true
             },
             {
                 "description": "label too long if separator ignored (halfwidth ideographic full stop)",
-                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα\uff61com",
+                "data": "παράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπαράδειγμαπα｡com",
                 "valid": true
             }
         ]

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of IP addresses",
+        "compatibility": "4",
         "comment": "RFC 2673, Section 3.2: dotted-quad = decbyte \".\" decbyte \".\" decbyte \".\" decbyte. A 'decbyte' (1*3DIGIT) restricts semantic values to 0-255, allows leading zeros, and strictly forbids symbols, alpha/hex, whitespace, and non-ASCII characters.",
         "schema": {
             "$schema": "https://json-schema.org/v1",

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of IRI References",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "iri-reference"

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of IRIs",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "iri"

--- a/tests/v1/format/json-pointer.json
+++ b/tests/v1/format/json-pointer.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of JSON-pointers (JSON String Representation)",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "json-pointer"

--- a/tests/v1/format/regex.json
+++ b/tests/v1/format/regex.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of regular expressions",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "regex"

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of Relative JSON Pointers (RJP)",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "relative-json-pointer"

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of time strings",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "time"

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "validation of URI References",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uri-reference"

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "format: uri-template",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uri-template"

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "uuid format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uuid"

--- a/tests/v1/if-then-else.json
+++ b/tests/v1/if-then-else.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "ignore if without then or else",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -22,6 +23,7 @@
     },
     {
         "description": "ignore then without if",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "then": {
@@ -43,6 +45,7 @@
     },
     {
         "description": "ignore else without if",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "else": {
@@ -64,6 +67,7 @@
     },
     {
         "description": "if and then without else",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -93,6 +97,7 @@
     },
     {
         "description": "if and else without then",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -122,6 +127,7 @@
     },
     {
         "description": "validate against correct branch, then vs else",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -159,6 +165,7 @@
     },
     {
         "description": "non-interference across combined schemas",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -194,11 +201,16 @@
     },
     {
         "description": "if with boolean schema true",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": true,
-            "then": { "const": "then" },
-            "else": { "const": "else" }
+            "then": {
+                "const": "then"
+            },
+            "else": {
+                "const": "else"
+            }
         },
         "tests": [
             {
@@ -215,11 +227,16 @@
     },
     {
         "description": "if with boolean schema false",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": false,
-            "then": { "const": "then" },
-            "else": { "const": "else" }
+            "then": {
+                "const": "then"
+            },
+            "else": {
+                "const": "else"
+            }
         },
         "tests": [
             {
@@ -236,11 +253,18 @@
     },
     {
         "description": "if appears at the end when serialized (keyword processing sequence)",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "then": { "const": "yes" },
-            "else": { "const": "other" },
-            "if": { "maxLength": 4 }
+            "then": {
+                "const": "yes"
+            },
+            "else": {
+                "const": "other"
+            },
+            "if": {
+                "maxLength": 4
+            }
         },
         "tests": [
             {

--- a/tests/v1/infinite-loop-detection.json
+++ b/tests/v1/infinite-loop-detection.json
@@ -1,10 +1,13 @@
 [
     {
         "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
-                "int": { "type": "integer" }
+                "int": {
+                    "type": "integer"
+                }
             },
             "allOf": [
                 {
@@ -24,12 +27,16 @@
         "tests": [
             {
                 "description": "passing case",
-                "data": { "foo": 1 },
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "failing case",
-                "data": { "foo": "a string" },
+                "data": {
+                    "foo": "a string"
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/items.json
+++ b/tests/v1/items.json
@@ -92,7 +92,7 @@
     },
     {
         "description": "items and subitems",
-        "compatibility": "4",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {

--- a/tests/v1/items.json
+++ b/tests/v1/items.json
@@ -3,22 +3,33 @@
         "description": "a schema given for items",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "items": {"type": "integer"}
+            "items": {
+                "type": "integer"
+            }
         },
         "tests": [
             {
                 "description": "valid items",
-                "data": [ 1, 2, 3 ],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
                 "description": "wrong type of items",
-                "data": [1, "x"],
+                "data": [
+                    1,
+                    "x"
+                ],
                 "valid": false
             },
             {
                 "description": "ignores non-arrays",
-                "data": {"foo" : "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
@@ -33,6 +44,7 @@
     },
     {
         "description": "items with boolean schema (true)",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "items": true
@@ -40,7 +52,11 @@
         "tests": [
             {
                 "description": "any array is valid",
-                "data": [ 1, "foo", true ],
+                "data": [
+                    1,
+                    "foo",
+                    true
+                ],
                 "valid": true
             },
             {
@@ -52,6 +68,7 @@
     },
     {
         "description": "items with boolean schema (false)",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "items": false
@@ -59,7 +76,11 @@
         "tests": [
             {
                 "description": "any non-empty array is invalid",
-                "data": [ 1, "foo", true ],
+                "data": [
+                    1,
+                    "foo",
+                    true
+                ],
                 "valid": false
             },
             {
@@ -71,6 +92,7 @@
     },
     {
         "description": "items and subitems",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -78,75 +100,203 @@
                     "type": "array",
                     "items": false,
                     "prefixItems": [
-                        { "$ref": "#/$defs/sub-item" },
-                        { "$ref": "#/$defs/sub-item" }
+                        {
+                            "$ref": "#/$defs/sub-item"
+                        },
+                        {
+                            "$ref": "#/$defs/sub-item"
+                        }
                     ]
                 },
                 "sub-item": {
                     "type": "object",
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             },
             "type": "array",
             "items": false,
             "prefixItems": [
-                { "$ref": "#/$defs/item" },
-                { "$ref": "#/$defs/item" },
-                { "$ref": "#/$defs/item" }
+                {
+                    "$ref": "#/$defs/item"
+                },
+                {
+                    "$ref": "#/$defs/item"
+                },
+                {
+                    "$ref": "#/$defs/item"
+                }
             ]
         },
         "tests": [
             {
                 "description": "valid items",
                 "data": [
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ]
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": true
             },
             {
                 "description": "too many items",
                 "data": [
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ]
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": false
             },
             {
                 "description": "too many sub-items",
                 "data": [
-                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ]
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": false
             },
             {
                 "description": "wrong item",
                 "data": [
-                    {"foo": null},
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ]
+                    {
+                        "foo": null
+                    },
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": false
             },
             {
                 "description": "wrong sub-item",
                 "data": [
-                    [ {}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ],
-                    [ {"foo": null}, {"foo": null} ]
+                    [
+                        {},
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        },
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": false
             },
             {
                 "description": "fewer items is valid",
                 "data": [
-                    [ {"foo": null} ],
-                    [ {"foo": null} ]
+                    [
+                        {
+                            "foo": null
+                        }
+                    ],
+                    [
+                        {
+                            "foo": null
+                        }
+                    ]
                 ],
                 "valid": true
             }
@@ -154,6 +304,7 @@
     },
     {
         "description": "nested items",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "array",
@@ -173,114 +324,252 @@
         "tests": [
             {
                 "description": "valid nested array",
-                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "data": [
+                    [
+                        [
+                            [
+                                1
+                            ]
+                        ],
+                        [
+                            [
+                                2
+                            ],
+                            [
+                                3
+                            ]
+                        ]
+                    ],
+                    [
+                        [
+                            [
+                                4
+                            ],
+                            [
+                                5
+                            ],
+                            [
+                                6
+                            ]
+                        ]
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "nested array with invalid type",
-                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "data": [
+                    [
+                        [
+                            [
+                                "1"
+                            ]
+                        ],
+                        [
+                            [
+                                2
+                            ],
+                            [
+                                3
+                            ]
+                        ]
+                    ],
+                    [
+                        [
+                            [
+                                4
+                            ],
+                            [
+                                5
+                            ],
+                            [
+                                6
+                            ]
+                        ]
+                    ]
+                ],
                 "valid": false
             },
             {
                 "description": "not deep enough",
-                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "data": [
+                    [
+                        [
+                            1
+                        ],
+                        [
+                            2
+                        ],
+                        [
+                            3
+                        ]
+                    ],
+                    [
+                        [
+                            4
+                        ],
+                        [
+                            5
+                        ],
+                        [
+                            6
+                        ]
+                    ]
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "prefixItems with no additional items allowed",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{}, {}, {}],
+            "prefixItems": [
+                {},
+                {},
+                {}
+            ],
             "items": false
         },
         "tests": [
             {
                 "description": "empty array",
-                "data": [ ],
+                "data": [],
                 "valid": true
             },
             {
                 "description": "fewer number of items present (1)",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "fewer number of items present (2)",
-                "data": [ 1, 2 ],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "equal number of items present",
-                "data": [ 1, 2, 3 ],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
                 "description": "additional items are not permitted",
-                "data": [ 1, 2, 3, 4 ],
+                "data": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "items does not look in applicators, valid case",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
-                { "prefixItems": [ { "minimum": 3 } ] }
+                {
+                    "prefixItems": [
+                        {
+                            "minimum": 3
+                        }
+                    ]
+                }
             ],
-            "items": { "minimum": 5 }
+            "items": {
+                "minimum": 5
+            }
         },
         "tests": [
             {
                 "description": "prefixItems in allOf does not constrain items, invalid case",
-                "data": [ 3, 5 ],
+                "data": [
+                    3,
+                    5
+                ],
                 "valid": false
             },
             {
                 "description": "prefixItems in allOf does not constrain items, valid case",
-                "data": [ 5, 5 ],
+                "data": [
+                    5,
+                    5
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "prefixItems validation adjusts the starting index for items",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [ { "type": "string" } ],
-            "items": { "type": "integer" }
+            "prefixItems": [
+                {
+                    "type": "string"
+                }
+            ],
+            "items": {
+                "type": "integer"
+            }
         },
         "tests": [
             {
                 "description": "valid items",
-                "data": [ "x", 2, 3 ],
+                "data": [
+                    "x",
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
                 "description": "wrong type of second item",
-                "data": [ "x", "y" ],
+                "data": [
+                    "x",
+                    "y"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "items with heterogeneous array",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{}],
+            "prefixItems": [
+                {}
+            ],
             "items": false
         },
         "tests": [
             {
                 "description": "heterogeneous invalid instance",
-                "data": [ "foo", "bar", 37 ],
+                "data": [
+                    "foo",
+                    "bar",
+                    37
+                ],
                 "valid": false
             },
             {
                 "description": "valid instance",
-                "data": [ null ],
+                "data": [
+                    null
+                ],
                 "valid": true
             }
         ]
@@ -296,7 +585,9 @@
         "tests": [
             {
                 "description": "allows null elements",
-                "data": [ null ],
+                "data": [
+                    null
+                ],
                 "valid": true
             }
         ]

--- a/tests/v1/maxContains.json
+++ b/tests/v1/maxContains.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "maxContains without contains is ignored",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxContains": 1
@@ -8,21 +9,29 @@
         "tests": [
             {
                 "description": "one item valid against lone maxContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "two items still valid against lone maxContains",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "maxContains with contains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "maxContains": 1
         },
         "tests": [
@@ -33,51 +42,74 @@
             },
             {
                 "description": "all elements match, valid maxContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "all elements match, invalid maxContains",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "some elements match, valid maxContains",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "some elements match, invalid maxContains",
-                "data": [1, 2, 1],
+                "data": [
+                    1,
+                    2,
+                    1
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "maxContains with contains, value with a decimal",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": {"const": 1},
+            "contains": {
+                "const": 1
+            },
             "maxContains": 1.0
         },
         "tests": [
             {
                 "description": "one element matches, valid maxContains",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "too many elements match, invalid maxContains",
-                "data": [ 1, 1 ],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "minContains < maxContains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "minContains": 1,
             "maxContains": 3
         },
@@ -89,21 +121,32 @@
             },
             {
                 "description": "array with minContains < actual < maxContains",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "array with minContains < maxContains < actual",
-                "data": [1, 1, 1, 1],
+                "data": [
+                    1,
+                    1,
+                    1,
+                    1
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "maxContains = 0 with minContains = 0",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "minContains": 0,
             "maxContains": 0
         },
@@ -115,7 +158,9 @@
             },
             {
                 "description": "one matching item",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             }
         ]

--- a/tests/v1/maxItems.json
+++ b/tests/v1/maxItems.json
@@ -8,17 +8,26 @@
         "tests": [
             {
                 "description": "shorter is valid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "exact length is valid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "too long is invalid",
-                "data": [1, 2, 3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": false
             },
             {
@@ -30,6 +39,7 @@
     },
     {
         "description": "maxItems validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxItems": 2.0
@@ -37,12 +47,18 @@
         "tests": [
             {
                 "description": "shorter is valid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "too long is invalid",
-                "data": [1, 2, 3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": false
             }
         ]

--- a/tests/v1/maxLength.json
+++ b/tests/v1/maxLength.json
@@ -28,13 +28,14 @@
             },
             {
                 "description": "two graphemes is long enough",
-                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "data": "💩💩",
                 "valid": true
             }
         ]
     },
     {
         "description": "maxLength validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxLength": 2.0

--- a/tests/v1/maxProperties.json
+++ b/tests/v1/maxProperties.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "maxProperties validation",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxProperties": 2
@@ -8,22 +9,35 @@
         "tests": [
             {
                 "description": "shorter is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "exact length is valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "too long is invalid",
-                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "baz": 3
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": [1, 2, 3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
@@ -40,6 +54,7 @@
     },
     {
         "description": "maxProperties validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxProperties": 2.0
@@ -47,18 +62,25 @@
         "tests": [
             {
                 "description": "shorter is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "too long is invalid",
-                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "baz": 3
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "maxProperties = 0 means the object is empty",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "maxProperties": 0
@@ -71,7 +93,9 @@
             },
             {
                 "description": "one property is invalid",
-                "data": { "foo": 1 },
+                "data": {
+                    "foo": 1
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/minContains.json
+++ b/tests/v1/minContains.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "minContains without contains is ignored",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "minContains": 1
@@ -8,7 +9,9 @@
         "tests": [
             {
                 "description": "one item valid against lone minContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
@@ -20,9 +23,12 @@
     },
     {
         "description": "minContains=1 with contains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "minContains": 1
         },
         "tests": [
@@ -33,31 +39,44 @@
             },
             {
                 "description": "no elements match",
-                "data": [2],
+                "data": [
+                    2
+                ],
                 "valid": false
             },
             {
                 "description": "single element matches, valid minContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "some elements match, valid minContains",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "all elements match, valid minContains",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "minContains=2 with contains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "minContains": 2
         },
         "tests": [
@@ -68,56 +87,83 @@
             },
             {
                 "description": "all elements match, invalid minContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "some elements match, invalid minContains",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": false
             },
             {
                 "description": "all elements match, valid minContains (exactly as needed)",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "all elements match, valid minContains (more than needed)",
-                "data": [1, 1, 1],
+                "data": [
+                    1,
+                    1,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "some elements match, valid minContains",
-                "data": [1, 2, 1],
+                "data": [
+                    1,
+                    2,
+                    1
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "minContains=2 with contains with a decimal value",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": {"const": 1},
+            "contains": {
+                "const": 1
+            },
             "minContains": 2.0
         },
         "tests": [
             {
                 "description": "one element matches, invalid minContains",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "both elements match, valid minContains",
-                "data": [ 1, 1 ],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "maxContains = minContains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "maxContains": 2,
             "minContains": 2
         },
@@ -129,26 +175,38 @@
             },
             {
                 "description": "all elements match, invalid minContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "all elements match, invalid maxContains",
-                "data": [1, 1, 1],
+                "data": [
+                    1,
+                    1,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "all elements match, valid maxContains and minContains",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "maxContains < minContains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "maxContains": 1,
             "minContains": 3
         },
@@ -160,26 +218,38 @@
             },
             {
                 "description": "invalid minContains",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "invalid maxContains",
-                "data": [1, 1, 1],
+                "data": [
+                    1,
+                    1,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "invalid maxContains and minContains",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "minContains = 0",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": { "const": 1 },
+            "contains": {
+                "const": 1
+            },
             "minContains": 0
         },
         "tests": [
@@ -190,33 +260,43 @@
             },
             {
                 "description": "minContains = 0 makes contains always pass",
-                "data": [2],
+                "data": [
+                    2
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "minContains = 0 with maxContains",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": {"const": 1},
+            "contains": {
+                "const": 1
+            },
             "minContains": 0,
             "maxContains": 1
         },
         "tests": [
             {
                 "description": "empty data",
-                "data": [ ],
+                "data": [],
                 "valid": true
             },
             {
                 "description": "not more than maxContains",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "too many",
-                "data": [ 1, 1 ],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": false
             }
         ]

--- a/tests/v1/minItems.json
+++ b/tests/v1/minItems.json
@@ -8,12 +8,17 @@
         "tests": [
             {
                 "description": "longer is valid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "exact length is valid",
-                "data": [1],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
@@ -30,6 +35,7 @@
     },
     {
         "description": "minItems validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "minItems": 1.0
@@ -37,7 +43,10 @@
         "tests": [
             {
                 "description": "longer is valid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {

--- a/tests/v1/minLength.json
+++ b/tests/v1/minLength.json
@@ -28,13 +28,14 @@
             },
             {
                 "description": "one grapheme is not long enough",
-                "data": "\uD83D\uDCA9",
+                "data": "💩",
                 "valid": false
             }
         ]
     },
     {
         "description": "minLength validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "minLength": 2.0

--- a/tests/v1/minProperties.json
+++ b/tests/v1/minProperties.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "minProperties validation",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "minProperties": 1
@@ -8,12 +9,17 @@
         "tests": [
             {
                 "description": "longer is valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "exact length is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
@@ -40,6 +46,7 @@
     },
     {
         "description": "minProperties validation with a decimal",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "minProperties": 1.0
@@ -47,7 +54,10 @@
         "tests": [
             {
                 "description": "longer is valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {

--- a/tests/v1/multipleOf.json
+++ b/tests/v1/multipleOf.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "by int",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "multipleOf": 2
@@ -25,6 +26,7 @@
     },
     {
         "description": "by number",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "multipleOf": 1.5
@@ -49,6 +51,7 @@
     },
     {
         "description": "by small number",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "multipleOf": 0.0001
@@ -68,6 +71,7 @@
     },
     {
         "description": "float division = inf",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "integer",
@@ -76,16 +80,18 @@
         "tests": [
             {
                 "description": "always invalid, but naive implementations may raise an overflow error",
-                "data": 1e308,
+                "data": 1e+308,
                 "valid": false
             }
         ]
     },
     {
         "description": "small multiple of large integer",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type": "integer", "multipleOf": 1e-8
+            "type": "integer",
+            "multipleOf": 1e-08
         },
         "tests": [
             {

--- a/tests/v1/not.json
+++ b/tests/v1/not.json
@@ -1,9 +1,12 @@
 [
     {
         "description": "not",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "not": {"type": "integer"}
+            "not": {
+                "type": "integer"
+            }
         },
         "tests": [
             {
@@ -20,9 +23,15 @@
     },
     {
         "description": "not multiple types",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "not": {"type": ["integer", "boolean"]}
+            "not": {
+                "type": [
+                    "integer",
+                    "boolean"
+                ]
+            }
         },
         "tests": [
             {
@@ -44,6 +53,7 @@
     },
     {
         "description": "not more complex schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "not": {
@@ -53,7 +63,7 @@
                         "type": "string"
                     }
                 }
-             }
+            }
         },
         "tests": [
             {
@@ -63,22 +73,27 @@
             },
             {
                 "description": "other match",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "forbidden property",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": { 
+                "foo": {
                     "not": {}
                 }
             }
@@ -86,18 +101,25 @@
         "tests": [
             {
                 "description": "property present",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "property absent",
-                "data": {"bar": 1, "baz": 2},
+                "data": {
+                    "bar": 1,
+                    "baz": 2
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "forbid everything with empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "not": {}
@@ -130,7 +152,9 @@
             },
             {
                 "description": "object is invalid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
@@ -140,7 +164,9 @@
             },
             {
                 "description": "array is invalid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             },
             {
@@ -152,6 +178,7 @@
     },
     {
         "description": "forbid everything with boolean schema true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "not": true
@@ -184,7 +211,9 @@
             },
             {
                 "description": "object is invalid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
@@ -194,7 +223,9 @@
             },
             {
                 "description": "array is invalid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             },
             {
@@ -206,6 +237,7 @@
     },
     {
         "description": "allow everything with boolean schema false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "not": false
@@ -238,7 +270,9 @@
             },
             {
                 "description": "object is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
@@ -248,7 +282,9 @@
             },
             {
                 "description": "array is valid",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
@@ -260,9 +296,12 @@
     },
     {
         "description": "double negation",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "not": { "not": {} }
+            "not": {
+                "not": {}
+            }
         },
         "tests": [
             {
@@ -274,13 +313,18 @@
     },
     {
         "description": "collect annotations inside a 'not', even if collection is disabled",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "not": {
                 "$comment": "this subschema must still produce annotations internally, even though the 'not' will ultimately discard them",
                 "anyOf": [
                     true,
-                    { "properties": { "foo": true } }
+                    {
+                        "properties": {
+                            "foo": true
+                        }
+                    }
                 ],
                 "unevaluatedProperties": false
             }
@@ -288,14 +332,18 @@
         "tests": [
             {
                 "description": "unevaluated property",
-                "data": { "bar": 1 },
+                "data": {
+                    "bar": 1
+                },
                 "valid": true
             },
             {
                 "description": "annotations are still collected inside a 'not'",
-                "data": { "foo": 1 },
+                "data": {
+                    "foo": 1
+                },
                 "valid": false
             }
         ]
-     }
+    }
 ]

--- a/tests/v1/oneOf.json
+++ b/tests/v1/oneOf.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "oneOf",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "oneOf": [
@@ -37,10 +38,11 @@
     },
     {
         "description": "oneOf with base schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
-            "oneOf" : [
+            "oneOf": [
                 {
                     "minLength": 2
                 },
@@ -69,9 +71,14 @@
     },
     {
         "description": "oneOf with boolean schemas, all true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "oneOf": [true, true, true]
+            "oneOf": [
+                true,
+                true,
+                true
+            ]
         },
         "tests": [
             {
@@ -83,9 +90,14 @@
     },
     {
         "description": "oneOf with boolean schemas, one true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "oneOf": [true, false, false]
+            "oneOf": [
+                true,
+                false,
+                false
+            ]
         },
         "tests": [
             {
@@ -97,9 +109,14 @@
     },
     {
         "description": "oneOf with boolean schemas, more than one true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "oneOf": [true, true, false]
+            "oneOf": [
+                true,
+                true,
+                false
+            ]
         },
         "tests": [
             {
@@ -111,9 +128,14 @@
     },
     {
         "description": "oneOf with boolean schemas, all false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "oneOf": [false, false, false]
+            "oneOf": [
+                false,
+                false,
+                false
+            ]
         },
         "tests": [
             {
@@ -125,52 +147,74 @@
     },
     {
         "description": "oneOf complex types",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {
+                            "type": "integer"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "foo": {"type": "string"}
+                        "foo": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "first oneOf valid (complex)",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "second oneOf valid (complex)",
-                "data": {"foo": "baz"},
+                "data": {
+                    "foo": "baz"
+                },
                 "valid": true
             },
             {
                 "description": "both oneOf valid (complex)",
-                "data": {"foo": "baz", "bar": 2},
+                "data": {
+                    "foo": "baz",
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "neither oneOf valid (complex)",
-                "data": {"foo": 2, "bar": "quux"},
+                "data": {
+                    "foo": 2,
+                    "bar": "quux"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "oneOf with empty schema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "oneOf": [
-                { "type": "number" },
+                {
+                    "type": "number"
+                },
                 {}
             ]
         },
@@ -189,39 +233,63 @@
     },
     {
         "description": "oneOf with required",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "oneOf": [
-                { "required": ["foo", "bar"] },
-                { "required": ["foo", "baz"] }
+                {
+                    "required": [
+                        "foo",
+                        "bar"
+                    ]
+                },
+                {
+                    "required": [
+                        "foo",
+                        "baz"
+                    ]
+                }
             ]
         },
         "tests": [
             {
                 "description": "both invalid - invalid",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "first valid - valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "second valid - valid",
-                "data": {"foo": 1, "baz": 3},
+                "data": {
+                    "foo": 1,
+                    "baz": 3
+                },
                 "valid": true
             },
             {
                 "description": "both valid - invalid",
-                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "baz": 3
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "oneOf with missing optional property",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "oneOf": [
@@ -230,41 +298,55 @@
                         "bar": true,
                         "baz": true
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
                         "foo": true
                     },
-                    "required": ["foo"]
+                    "required": [
+                        "foo"
+                    ]
                 }
             ]
         },
         "tests": [
             {
                 "description": "first oneOf valid",
-                "data": {"bar": 8},
+                "data": {
+                    "bar": 8
+                },
                 "valid": true
             },
             {
                 "description": "second oneOf valid",
-                "data": {"foo": "foo"},
+                "data": {
+                    "foo": "foo"
+                },
                 "valid": true
             },
             {
                 "description": "both oneOf valid",
-                "data": {"foo": "foo", "bar": 8},
+                "data": {
+                    "foo": "foo",
+                    "bar": 8
+                },
                 "valid": false
             },
             {
                 "description": "neither oneOf valid",
-                "data": {"baz": "quux"},
+                "data": {
+                    "baz": "quux"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "nested oneOf, to check validation semantics",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "oneOf": [

--- a/tests/v1/optional/anchor.json
+++ b/tests/v1/optional/anchor.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "$anchor inside an enum is not a real identifier",
+        "compatibility": "2019",
         "comment": "the implementation must not be confused by an $anchor buried in the enum",
         "schema": {
             "$schema": "https://json-schema.org/v1",
@@ -25,8 +26,12 @@
                 }
             },
             "anyOf": [
-                { "$ref": "#/$defs/anchor_in_enum" },
-                { "$ref": "#my_anchor" }
+                {
+                    "$ref": "#/$defs/anchor_in_enum"
+                },
+                {
+                    "$ref": "#my_anchor"
+                }
             ]
         },
         "tests": [

--- a/tests/v1/optional/bignum.json
+++ b/tests/v1/optional/bignum.json
@@ -67,14 +67,15 @@
     },
     {
         "description": "float comparison with high precision",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "exclusiveMaximum": 972783798187987123879878123.18878137
+            "exclusiveMaximum": 9.727837981879871e+26
         },
         "tests": [
             {
                 "description": "comparison works for high numbers",
-                "data": 972783798187987123879878123.188781371,
+                "data": 9.727837981879871e+26,
                 "valid": false
             }
         ]
@@ -95,14 +96,15 @@
     },
     {
         "description": "float comparison with high precision on negative numbers",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "exclusiveMinimum": -972783798187987123879878123.18878137
+            "exclusiveMinimum": -9.727837981879871e+26
         },
         "tests": [
             {
                 "description": "comparison works for very negative numbers",
-                "data": -972783798187987123879878123.188781371,
+                "data": -9.727837981879871e+26,
                 "valid": false
             }
         ]

--- a/tests/v1/optional/dependencies-compatibility.json
+++ b/tests/v1/optional/dependencies-compatibility.json
@@ -1,9 +1,14 @@
 [
     {
         "description": "single dependency",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependencies": {"bar": ["foo"]}
+            "dependencies": {
+                "bar": [
+                    "foo"
+                ]
+            }
         },
         "tests": [
             {
@@ -13,22 +18,31 @@
             },
             {
                 "description": "nondependant",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "with dependency",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "missing dependency",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": ["bar"],
+                "data": [
+                    "bar"
+                ],
                 "valid": true
             },
             {
@@ -45,9 +59,12 @@
     },
     {
         "description": "empty dependents",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependencies": {"bar": []}
+            "dependencies": {
+                "bar": []
+            }
         },
         "tests": [
             {
@@ -57,7 +74,9 @@
             },
             {
                 "description": "object with one property",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": true
             },
             {
@@ -69,9 +88,15 @@
     },
     {
         "description": "multiple dependents required",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "dependencies": {"quux": ["foo", "bar"]}
+            "dependencies": {
+                "quux": [
+                    "foo",
+                    "bar"
+                ]
+            }
         },
         "tests": [
             {
@@ -81,38 +106,58 @@
             },
             {
                 "description": "nondependants",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "with dependencies",
-                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "data": {
+                    "foo": 1,
+                    "bar": 2,
+                    "quux": 3
+                },
                 "valid": true
             },
             {
                 "description": "missing dependency",
-                "data": {"foo": 1, "quux": 2},
+                "data": {
+                    "foo": 1,
+                    "quux": 2
+                },
                 "valid": false
             },
             {
                 "description": "missing other dependency",
-                "data": {"bar": 1, "quux": 2},
+                "data": {
+                    "bar": 1,
+                    "quux": 2
+                },
                 "valid": false
             },
             {
                 "description": "missing both dependencies",
-                "data": {"quux": 1},
+                "data": {
+                    "quux": 1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "dependencies with escaped characters",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependencies": {
-                "foo\nbar": ["foo\rbar"],
-                "foo\"bar": ["foo'bar"]
+                "foo\nbar": [
+                    "foo\rbar"
+                ],
+                "foo\"bar": [
+                    "foo'bar"
+                ]
             }
         },
         "tests": [
@@ -151,13 +196,18 @@
     },
     {
         "description": "single schema dependency",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependencies": {
                 "bar": {
                     "properties": {
-                        "foo": {"type": "integer"},
-                        "bar": {"type": "integer"}
+                        "foo": {
+                            "type": "integer"
+                        },
+                        "bar": {
+                            "type": "integer"
+                        }
                     }
                 }
             }
@@ -165,32 +215,48 @@
         "tests": [
             {
                 "description": "valid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": true
             },
             {
                 "description": "no dependency",
-                "data": {"foo": "quux"},
+                "data": {
+                    "foo": "quux"
+                },
                 "valid": true
             },
             {
                 "description": "wrong type",
-                "data": {"foo": "quux", "bar": 2},
+                "data": {
+                    "foo": "quux",
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "wrong type other",
-                "data": {"foo": 2, "bar": "quux"},
+                "data": {
+                    "foo": 2,
+                    "bar": "quux"
+                },
                 "valid": false
             },
             {
                 "description": "wrong type both",
-                "data": {"foo": "quux", "bar": "quux"},
+                "data": {
+                    "foo": "quux",
+                    "bar": "quux"
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": ["bar"],
+                "data": [
+                    "bar"
+                ],
                 "valid": true
             },
             {
@@ -207,6 +273,7 @@
     },
     {
         "description": "boolean subschemas",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependencies": {
@@ -217,17 +284,24 @@
         "tests": [
             {
                 "description": "object with property having schema true is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "object with property having schema false is invalid",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "object with both properties is invalid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             },
             {
@@ -239,11 +313,18 @@
     },
     {
         "description": "schema dependencies with escaped characters",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "dependencies": {
-                "foo\tbar": {"minProperties": 4},
-                "foo'bar": {"required": ["foo\"bar"]}
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {
+                    "required": [
+                        "foo\"bar"
+                    ]
+                }
             }
         },
         "tests": [
@@ -260,7 +341,9 @@
             {
                 "description": "quoted quote",
                 "data": {
-                    "foo'bar": {"foo\"bar": 1}
+                    "foo'bar": {
+                        "foo\"bar": 1
+                    }
                 },
                 "valid": false
             },
@@ -274,7 +357,9 @@
             },
             {
                 "description": "quoted quote invalid under dependent schema",
-                "data": {"foo'bar": 1},
+                "data": {
+                    "foo'bar": 1
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/optional/dynamicRef.json
+++ b/tests/v1/optional/dynamicRef.json
@@ -1,56 +1,66 @@
 [
-  {
-      "description": "$dynamicRef skips over intermediate resources - pointer reference across resource boundary",
-      "schema": {
-          "$schema": "https://json-schema.org/v1",
-          "$id": "https://test.json-schema.org/dynamic-ref-skips-intermediate-resource/optional/main",
-          "type": "object",
-          "properties": {
-              "bar-item": {
-                  "$ref": "bar#/$defs/item"
-              }
-          },
-          "$defs": {
-              "bar": {
-                  "$id": "bar",
-                  "type": "array",
-                  "items": {
-                      "$ref": "item"
-                  },
-                  "$defs": {
-                      "item": {
-                          "$id": "item",
-                          "type": "object",
-                          "properties": {
-                              "content": {
-                                  "$dynamicRef": "#content"
-                              }
-                          },
-                          "$defs": {
-                              "defaultContent": {
-                                  "$dynamicAnchor": "content",
-                                  "type": "integer"
-                              }
-                          }
-                      },
-                      "content": {
-                          "$dynamicAnchor": "content",
-                          "type": "string"
-                      }
-                  }
-              }
-          }
-      },
-      "tests": [
-          {
-              "description": "integer property passes",
-              "data": { "bar-item": { "content": 42 } },
-              "valid": true
-          },
-          {
-              "description": "string property fails",
-              "data": { "bar-item": { "content": "value" } },
-              "valid": false
-          }
-      ]
-  }]
+    {
+        "description": "$dynamicRef skips over intermediate resources - pointer reference across resource boundary",
+        "compatibility": "=2020",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "$id": "https://test.json-schema.org/dynamic-ref-skips-intermediate-resource/optional/main",
+            "type": "object",
+            "properties": {
+                "bar-item": {
+                    "$ref": "bar#/$defs/item"
+                }
+            },
+            "$defs": {
+                "bar": {
+                    "$id": "bar",
+                    "type": "array",
+                    "items": {
+                        "$ref": "item"
+                    },
+                    "$defs": {
+                        "item": {
+                            "$id": "item",
+                            "type": "object",
+                            "properties": {
+                                "content": {
+                                    "$dynamicRef": "#content"
+                                }
+                            },
+                            "$defs": {
+                                "defaultContent": {
+                                    "$dynamicAnchor": "content",
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "content": {
+                            "$dynamicAnchor": "content",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "integer property passes",
+                "data": {
+                    "bar-item": {
+                        "content": 42
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "string property fails",
+                "data": {
+                    "bar-item": {
+                        "content": "value"
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/tests/v1/optional/ecmascript-regex.json
+++ b/tests/v1/optional/ecmascript-regex.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "ECMA 262 regex $ does not match trailing newline",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -21,6 +22,7 @@
     },
     {
         "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -34,13 +36,14 @@
             },
             {
                 "description": "matches",
-                "data": "\u0009",
+                "data": "\t",
                 "valid": true
             }
         ]
     },
     {
         "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -61,6 +64,7 @@
     },
     {
         "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -81,6 +85,7 @@
     },
     {
         "description": "ECMA 262 \\d matches ascii digits only",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -99,13 +104,14 @@
             },
             {
                 "description": "NKO DIGIT ZERO (as \\u escape) does not match",
-                "data": "\u07c0",
+                "data": "߀",
                 "valid": false
             }
         ]
     },
     {
         "description": "ECMA 262 \\D matches everything but ascii digits",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -124,13 +130,14 @@
             },
             {
                 "description": "NKO DIGIT ZERO (as \\u escape) matches",
-                "data": "\u07c0",
+                "data": "߀",
                 "valid": true
             }
         ]
     },
     {
         "description": "ECMA 262 \\w matches ascii letters only",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -151,6 +158,7 @@
     },
     {
         "description": "ECMA 262 \\W matches everything but ascii letters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -171,6 +179,7 @@
     },
     {
         "description": "ECMA 262 \\s matches whitespace",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -194,32 +203,32 @@
             },
             {
                 "description": "Form feed matches",
-                "data": "\u000c",
+                "data": "\f",
                 "valid": true
             },
             {
                 "description": "latin-1 non-breaking-space matches",
-                "data": "\u00a0",
+                "data": " ",
                 "valid": true
             },
             {
                 "description": "zero-width whitespace matches",
-                "data": "\ufeff",
+                "data": "﻿",
                 "valid": true
             },
             {
                 "description": "line feed matches (line terminator)",
-                "data": "\u000a",
+                "data": "\n",
                 "valid": true
             },
             {
                 "description": "paragraph separator matches (line terminator)",
-                "data": "\u2029",
+                "data": " ",
                 "valid": true
             },
             {
                 "description": "EM SPACE matches (Space_Separator)",
-                "data": "\u2003",
+                "data": " ",
                 "valid": true
             },
             {
@@ -229,13 +238,14 @@
             },
             {
                 "description": "Non-whitespace does not match",
-                "data": "\u2013",
+                "data": "–",
                 "valid": false
             }
         ]
     },
     {
         "description": "ECMA 262 \\S matches everything but whitespace",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",
@@ -259,32 +269,32 @@
             },
             {
                 "description": "Form feed does not match",
-                "data": "\u000c",
+                "data": "\f",
                 "valid": false
             },
             {
                 "description": "latin-1 non-breaking-space does not match",
-                "data": "\u00a0",
+                "data": " ",
                 "valid": false
             },
             {
                 "description": "zero-width whitespace does not match",
-                "data": "\ufeff",
+                "data": "﻿",
                 "valid": false
             },
             {
                 "description": "line feed does not match (line terminator)",
-                "data": "\u000a",
+                "data": "\n",
                 "valid": false
             },
             {
                 "description": "paragraph separator does not match (line terminator)",
-                "data": "\u2029",
+                "data": " ",
                 "valid": false
             },
             {
                 "description": "EM SPACE does not match (Space_Separator)",
-                "data": "\u2003",
+                "data": " ",
                 "valid": false
             },
             {
@@ -294,13 +304,14 @@
             },
             {
                 "description": "Non-whitespace matches",
-                "data": "\u2013",
+                "data": "–",
                 "valid": true
             }
         ]
     },
     {
         "description": "patterns always use unicode semantics with pattern",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "pattern": "\\p{Letter}cole"
@@ -318,7 +329,7 @@
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
                 "valid": true
             },
             {
@@ -330,6 +341,7 @@
     },
     {
         "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "pattern": "\\wcole"
@@ -347,7 +359,7 @@
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
                 "valid": false
             },
             {
@@ -359,6 +371,7 @@
     },
     {
         "description": "pattern with ASCII ranges",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "pattern": "[a-z]cole"
@@ -371,7 +384,7 @@
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
                 "valid": false
             },
             {
@@ -383,6 +396,7 @@
     },
     {
         "description": "\\d in pattern matches [0-9], not unicode digits",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "pattern": "^\\d+$"
@@ -407,6 +421,7 @@
     },
     {
         "description": "pattern with non-ASCII digits",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "pattern": "^\\p{digit}+$"
@@ -431,6 +446,7 @@
     },
     {
         "description": "patterns always use unicode semantics with patternProperties",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -442,28 +458,37 @@
         "tests": [
             {
                 "description": "ascii character in json string",
-                "data": { "l'ecole": "pas de vraie vie" },
+                "data": {
+                    "l'ecole": "pas de vraie vie"
+                },
                 "valid": true
             },
             {
                 "description": "literal unicode character in json string",
-                "data": { "l'école": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": true
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": true
             },
             {
                 "description": "unicode matching is case-sensitive",
-                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "data": {
+                    "L'ÉCOLE": "PAS DE VRAIE VIE"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -475,28 +500,37 @@
         "tests": [
             {
                 "description": "ascii character in json string",
-                "data": { "l'ecole": "pas de vraie vie" },
+                "data": {
+                    "l'ecole": "pas de vraie vie"
+                },
                 "valid": true
             },
             {
                 "description": "literal unicode character in json string",
-                "data": { "l'école": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": false
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": false
             },
             {
                 "description": "unicode matching is case-sensitive",
-                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "data": {
+                    "L'ÉCOLE": "PAS DE VRAIE VIE"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "patternProperties with ASCII ranges",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -508,23 +542,30 @@
         "tests": [
             {
                 "description": "literal unicode character in json string",
-                "data": { "l'école": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": false
             },
             {
                 "description": "unicode character in hex format in string",
-                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "data": {
+                    "l'école": "pas de vraie vie"
+                },
                 "valid": false
             },
             {
                 "description": "ascii characters match",
-                "data": { "l'ecole": "pas de vraie vie" },
+                "data": {
+                    "l'ecole": "pas de vraie vie"
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -536,23 +577,30 @@
         "tests": [
             {
                 "description": "ascii digits",
-                "data": { "42": "life, the universe, and everything" },
+                "data": {
+                    "42": "life, the universe, and everything"
+                },
                 "valid": true
             },
             {
                 "description": "ascii non-digits",
-                "data": { "-%#": "spending the year dead for tax reasons" },
+                "data": {
+                    "-%#": "spending the year dead for tax reasons"
+                },
                 "valid": false
             },
             {
                 "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
-                "data": { "৪২": "khajit has wares if you have coin" },
+                "data": {
+                    "৪২": "khajit has wares if you have coin"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "patternProperties with non-ASCII digits",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -564,17 +612,23 @@
         "tests": [
             {
                 "description": "ascii digits",
-                "data": { "42": "life, the universe, and everything" },
+                "data": {
+                    "42": "life, the universe, and everything"
+                },
                 "valid": true
             },
             {
                 "description": "ascii non-digits",
-                "data": { "-%#": "spending the year dead for tax reasons" },
+                "data": {
+                    "-%#": "spending the year dead for tax reasons"
+                },
                 "valid": false
             },
             {
                 "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
-                "data": { "৪২": "khajit has wares if you have coin" },
+                "data": {
+                    "৪২": "khajit has wares if you have coin"
+                },
                 "valid": true
             }
         ]

--- a/tests/v1/optional/float-overflow.json
+++ b/tests/v1/optional/float-overflow.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "all integers are multiples of 0.5, if overflow is handled",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "integer",
@@ -9,7 +10,7 @@
         "tests": [
             {
                 "description": "valid if optional overflow handling is implemented",
-                "data": 1e308,
+                "data": 1e+308,
                 "valid": true
             }
         ]

--- a/tests/v1/optional/format-annotation.json
+++ b/tests/v1/optional/format-annotation.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "email format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "email"
@@ -45,6 +46,7 @@
     },
     {
         "description": "idn-email format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "idn-email"
@@ -89,6 +91,7 @@
     },
     {
         "description": "regex format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "regex"
@@ -133,6 +136,7 @@
     },
     {
         "description": "ipv4 format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "ipv4"
@@ -177,6 +181,7 @@
     },
     {
         "description": "ipv6 format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "ipv6"
@@ -221,6 +226,7 @@
     },
     {
         "description": "idn-hostname format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "idn-hostname"
@@ -265,6 +271,7 @@
     },
     {
         "description": "hostname format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "hostname"
@@ -309,6 +316,7 @@
     },
     {
         "description": "date format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "date"
@@ -353,6 +361,7 @@
     },
     {
         "description": "date-time format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "date-time"
@@ -397,6 +406,7 @@
     },
     {
         "description": "time format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "time"
@@ -441,6 +451,7 @@
     },
     {
         "description": "json-pointer format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "json-pointer"
@@ -485,6 +496,7 @@
     },
     {
         "description": "relative-json-pointer format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "relative-json-pointer"
@@ -529,6 +541,7 @@
     },
     {
         "description": "iri format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "iri"
@@ -573,6 +586,7 @@
     },
     {
         "description": "iri-reference format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "iri-reference"
@@ -617,6 +631,7 @@
     },
     {
         "description": "uri format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uri"
@@ -661,6 +676,7 @@
     },
     {
         "description": "uri-reference format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uri-reference"
@@ -705,6 +721,7 @@
     },
     {
         "description": "uri-template format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uri-template"
@@ -749,6 +766,7 @@
     },
     {
         "description": "uuid format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "uuid"
@@ -793,6 +811,7 @@
     },
     {
         "description": "duration format",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "format": "duration"

--- a/tests/v1/optional/id.json
+++ b/tests/v1/optional/id.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "$id inside an enum is not a real identifier",
+        "compatibility": "2019",
         "comment": "the implementation must not be confused by an $id buried in the enum",
         "schema": {
             "$schema": "https://json-schema.org/v1",
@@ -8,8 +9,8 @@
                 "id_in_enum": {
                     "enum": [
                         {
-                          "$id": "https://localhost:1234/v1/id/my_identifier.json",
-                          "type": "null"
+                            "$id": "https://localhost:1234/v1/id/my_identifier.json",
+                            "type": "null"
                         }
                     ]
                 },
@@ -25,8 +26,12 @@
                 }
             },
             "anyOf": [
-                { "$ref": "#/$defs/id_in_enum" },
-                { "$ref": "https://localhost:1234/v1/id/my_identifier.json" }
+                {
+                    "$ref": "#/$defs/id_in_enum"
+                },
+                {
+                    "$ref": "https://localhost:1234/v1/id/my_identifier.json"
+                }
             ]
         },
         "tests": [

--- a/tests/v1/optional/refOfUnknownKeyword.json
+++ b/tests/v1/optional/refOfUnknownKeyword.json
@@ -1,77 +1,109 @@
 [
     {
         "description": "reference of a root arbitrary keyword ",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "unknown-keyword": {"type": "integer"},
+            "unknown-keyword": {
+                "type": "integer"
+            },
             "properties": {
-                "bar": {"$ref": "#/unknown-keyword"}
+                "bar": {
+                    "$ref": "#/unknown-keyword"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "reference of a root arbitrary keyword with encoded ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "unknown/keyword": {"type": "integer"},
+            "unknown/keyword": {
+                "type": "integer"
+            },
             "properties": {
-                "bar": {"$ref": "#/unknown~1keyword"}
+                "bar": {
+                    "$ref": "#/unknown~1keyword"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "reference of an arbitrary keyword of a sub-schema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"unknown-keyword": {"type": "integer"}},
-                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+                "foo": {
+                    "unknown-keyword": {
+                        "type": "integer"
+                    }
+                },
+                "bar": {
+                    "$ref": "#/properties/foo/unknown-keyword"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "reference internals of known non-applicator",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "/base",
             "examples": [
-              { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "$ref": "#/examples/0"
         },
@@ -90,22 +122,33 @@
     },
     {
         "description": "reference of an arbitrary keyword of a sub-schema with encoded ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"unknown/keyword": {"type": "integer"}},
-                "bar": {"$ref": "#/properties/foo/unknown~1keyword"}
+                "foo": {
+                    "unknown/keyword": {
+                        "type": "integer"
+                    }
+                },
+                "bar": {
+                    "$ref": "#/properties/foo/unknown~1keyword"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/optional/unknownKeyword.json
+++ b/tests/v1/optional/unknownKeyword.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "$id inside an unknown keyword is not a real identifier",
+        "compatibility": "6",
         "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
         "schema": {
             "$schema": "https://json-schema.org/v1",
@@ -9,8 +10,8 @@
                     "not": {
                         "array_of_schemas": [
                             {
-                              "$id": "https://localhost:1234/v1/unknownKeyword/my_identifier.json",
-                              "type": "null"
+                                "$id": "https://localhost:1234/v1/unknownKeyword/my_identifier.json",
+                                "type": "null"
                             }
                         ]
                     }
@@ -23,17 +24,23 @@
                     "not": {
                         "object_of_schemas": {
                             "foo": {
-                              "$id": "https://localhost:1234/v1/unknownKeyword/my_identifier.json",
-                              "type": "integer"
+                                "$id": "https://localhost:1234/v1/unknownKeyword/my_identifier.json",
+                                "type": "integer"
                             }
                         }
                     }
                 }
             },
             "anyOf": [
-                { "$ref": "#/$defs/id_in_unknown0" },
-                { "$ref": "#/$defs/id_in_unknown1" },
-                { "$ref": "https://localhost:1234/v1/unknownKeyword/my_identifier.json" }
+                {
+                    "$ref": "#/$defs/id_in_unknown0"
+                },
+                {
+                    "$ref": "#/$defs/id_in_unknown1"
+                },
+                {
+                    "$ref": "https://localhost:1234/v1/unknownKeyword/my_identifier.json"
+                }
             ]
         },
         "tests": [

--- a/tests/v1/optional/unknownKeyword.json
+++ b/tests/v1/optional/unknownKeyword.json
@@ -1,7 +1,7 @@
 [
     {
         "description": "$id inside an unknown keyword is not a real identifier",
-        "compatibility": "6",
+        "compatibility": "2019",
         "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
         "schema": {
             "$schema": "https://json-schema.org/v1",

--- a/tests/v1/pattern.json
+++ b/tests/v1/pattern.json
@@ -64,6 +64,7 @@
     },
     {
         "description": "pattern with Unicode property escape",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "string",

--- a/tests/v1/patternProperties.json
+++ b/tests/v1/patternProperties.json
@@ -1,37 +1,51 @@
 [
     {
-        "description":
-            "patternProperties validates properties matching a regex",
+        "description": "patternProperties validates properties matching a regex",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "patternProperties": {
-                "f.*o": {"type": "integer"}
+                "f.*o": {
+                    "type": "integer"
+                }
             }
         },
         "tests": [
             {
                 "description": "a single valid match is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "multiple valid matches is valid",
-                "data": {"foo": 1, "foooooo" : 2},
+                "data": {
+                    "foo": 1,
+                    "foooooo": 2
+                },
                 "valid": true
             },
             {
                 "description": "a single invalid match is invalid",
-                "data": {"foo": "bar", "fooooo": 2},
+                "data": {
+                    "foo": "bar",
+                    "fooooo": 2
+                },
                 "valid": false
             },
             {
                 "description": "multiple invalid matches is invalid",
-                "data": {"foo": "bar", "foooooo" : "baz"},
+                "data": {
+                    "foo": "bar",
+                    "foooooo": "baz"
+                },
                 "valid": false
             },
             {
                 "description": "ignores arrays",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
@@ -51,39 +65,57 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "patternProperties": {
-                "a*": {"type": "integer"},
-                "aaa*": {"maximum": 20}
+                "a*": {
+                    "type": "integer"
+                },
+                "aaa*": {
+                    "maximum": 20
+                }
             }
         },
         "tests": [
             {
                 "description": "a single valid match is valid",
-                "data": {"a": 21},
+                "data": {
+                    "a": 21
+                },
                 "valid": true
             },
             {
                 "description": "a simultaneous match is valid",
-                "data": {"aaaa": 18},
+                "data": {
+                    "aaaa": 18
+                },
                 "valid": true
             },
             {
                 "description": "multiple matches is valid",
-                "data": {"a": 21, "aaaa": 18},
+                "data": {
+                    "a": 21,
+                    "aaaa": 18
+                },
                 "valid": true
             },
             {
                 "description": "an invalid due to one is invalid",
-                "data": {"a": "bar"},
+                "data": {
+                    "a": "bar"
+                },
                 "valid": false
             },
             {
                 "description": "an invalid due to the other is invalid",
-                "data": {"aaaa": 31},
+                "data": {
+                    "aaaa": 31
+                },
                 "valid": false
             },
             {
                 "description": "an invalid due to both is invalid",
-                "data": {"aaa": "foo", "aaaa": 31},
+                "data": {
+                    "aaa": "foo",
+                    "aaaa": 31
+                },
                 "valid": false
             }
         ]
@@ -93,35 +125,48 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "patternProperties": {
-                "[0-9]{2,}": { "type": "boolean" },
-                "X_": { "type": "string" }
+                "[0-9]{2,}": {
+                    "type": "boolean"
+                },
+                "X_": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "non recognized members are ignored",
-                "data": { "answer 1": "42" },
+                "data": {
+                    "answer 1": "42"
+                },
                 "valid": true
             },
             {
                 "description": "recognized members are accounted for",
-                "data": { "a31b": null },
+                "data": {
+                    "a31b": null
+                },
                 "valid": false
             },
             {
                 "description": "regexes are case sensitive",
-                "data": { "a_x_3": 3 },
+                "data": {
+                    "a_x_3": 3
+                },
                 "valid": true
             },
             {
                 "description": "regexes are case sensitive, 2",
-                "data": { "a_X_3": 3 },
+                "data": {
+                    "a_X_3": 3
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "patternProperties with boolean schemas",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "patternProperties": {
@@ -132,22 +177,31 @@
         "tests": [
             {
                 "description": "object with property matching schema true is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "object with property matching schema false is invalid",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "object with both properties is invalid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "object with a property matching both true and false is invalid",
-                "data": {"foobar":1},
+                "data": {
+                    "foobar": 1
+                },
                 "valid": false
             },
             {
@@ -162,40 +216,53 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "patternProperties": {
-                "^.*bar$": {"type": "null"}
+                "^.*bar$": {
+                    "type": "null"
+                }
             }
         },
         "tests": [
             {
                 "description": "allows null values",
-                "data": {"foobar": null},
+                "data": {
+                    "foobar": null
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "patternProperties with Unicode property escape",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "patternProperties": {
-                "^\\p{Letter}+$": {"type": "number"}
+                "^\\p{Letter}+$": {
+                    "type": "number"
+                }
             }
         },
         "tests": [
             {
                 "description": "Unicode letter property name matches",
-                "data": {"π": 1},
+                "data": {
+                    "π": 1
+                },
                 "valid": true
             },
             {
                 "description": "Unicode letter property name matches but value type is incorrect",
-                "data": {"π": "1"},
+                "data": {
+                    "π": "1"
+                },
                 "valid": false
             },
             {
                 "description": "Non-letter property name does not match pattern",
-                "data": {"123": 1},
+                "data": {
+                    "123": 1
+                },
                 "valid": true
             }
         ]

--- a/tests/v1/prefixItems.json
+++ b/tests/v1/prefixItems.json
@@ -1,37 +1,54 @@
 [
     {
         "description": "a schema given for prefixItems",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                {"type": "integer"},
-                {"type": "string"}
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
             ]
         },
         "tests": [
             {
                 "description": "correct types",
-                "data": [ 1, "foo" ],
+                "data": [
+                    1,
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "wrong types",
-                "data": [ "foo", 1 ],
+                "data": [
+                    "foo",
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "incomplete array of items",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "array with additional items",
-                "data": [ 1, "foo", true ],
+                "data": [
+                    1,
+                    "foo",
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "empty array",
-                "data": [ ],
+                "data": [],
                 "valid": true
             },
             {
@@ -47,19 +64,28 @@
     },
     {
         "description": "prefixItems with boolean schemas",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [true, false]
+            "prefixItems": [
+                true,
+                false
+            ]
         },
         "tests": [
             {
                 "description": "array with one item is valid",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "array with two items is invalid",
-                "data": [ 1, "foo" ],
+                "data": [
+                    1,
+                    "foo"
+                ],
                 "valid": false
             },
             {
@@ -71,20 +97,30 @@
     },
     {
         "description": "additional items are allowed by default",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{"type": "integer"}]
+            "prefixItems": [
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "tests": [
             {
                 "description": "only the first item is validated",
-                "data": [1, "foo", false],
+                "data": [
+                    1,
+                    "foo",
+                    false
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "prefixItems with null instance elements",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -96,7 +132,9 @@
         "tests": [
             {
                 "description": "allows null elements",
-                "data": [ null ],
+                "data": [
+                    null
+                ],
                 "valid": true
             }
         ]

--- a/tests/v1/properties.json
+++ b/tests/v1/properties.json
@@ -4,29 +4,44 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"type": "integer"},
-                "bar": {"type": "string"}
+                "foo": {
+                    "type": "integer"
+                },
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "both properties present and valid is valid",
-                "data": {"foo": 1, "bar": "baz"},
+                "data": {
+                    "foo": 1,
+                    "bar": "baz"
+                },
                 "valid": true
             },
             {
                 "description": "one property invalid is invalid",
-                "data": {"foo": 1, "bar": {}},
+                "data": {
+                    "foo": 1,
+                    "bar": {}
+                },
                 "valid": false
             },
             {
                 "description": "both properties invalid is invalid",
-                "data": {"foo": [], "bar": {}},
+                "data": {
+                    "foo": [],
+                    "bar": {}
+                },
                 "valid": false
             },
             {
                 "description": "doesn't invalidate other properties",
-                "data": {"quux": []},
+                "data": {
+                    "quux": []
+                },
                 "valid": true
             },
             {
@@ -42,62 +57,100 @@
         ]
     },
     {
-        "description":
-            "properties, patternProperties, additionalProperties interaction",
+        "description": "properties, patternProperties, additionalProperties interaction",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"type": "array", "maxItems": 3},
-                "bar": {"type": "array"}
+                "foo": {
+                    "type": "array",
+                    "maxItems": 3
+                },
+                "bar": {
+                    "type": "array"
+                }
             },
-            "patternProperties": {"f.o": {"minItems": 2}},
-            "additionalProperties": {"type": "integer"}
+            "patternProperties": {
+                "f.o": {
+                    "minItems": 2
+                }
+            },
+            "additionalProperties": {
+                "type": "integer"
+            }
         },
         "tests": [
             {
                 "description": "property validates property",
-                "data": {"foo": [1, 2]},
+                "data": {
+                    "foo": [
+                        1,
+                        2
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "property invalidates property",
-                "data": {"foo": [1, 2, 3, 4]},
+                "data": {
+                    "foo": [
+                        1,
+                        2,
+                        3,
+                        4
+                    ]
+                },
                 "valid": false
             },
             {
                 "description": "patternProperty invalidates property",
-                "data": {"foo": []},
+                "data": {
+                    "foo": []
+                },
                 "valid": false
             },
             {
                 "description": "patternProperty validates nonproperty",
-                "data": {"fxo": [1, 2]},
+                "data": {
+                    "fxo": [
+                        1,
+                        2
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "patternProperty invalidates nonproperty",
-                "data": {"fxo": []},
+                "data": {
+                    "fxo": []
+                },
                 "valid": false
             },
             {
                 "description": "additionalProperty ignores property",
-                "data": {"bar": []},
+                "data": {
+                    "bar": []
+                },
                 "valid": true
             },
             {
                 "description": "additionalProperty validates others",
-                "data": {"quux": 3},
+                "data": {
+                    "quux": 3
+                },
                 "valid": true
             },
             {
                 "description": "additionalProperty invalidates others",
-                "data": {"quux": "foo"},
+                "data": {
+                    "quux": "foo"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "properties with boolean schema",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -113,32 +166,52 @@
             },
             {
                 "description": "only 'true' property present is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "only 'false' property present is invalid",
-                "data": {"bar": 2},
+                "data": {
+                    "bar": 2
+                },
                 "valid": false
             },
             {
                 "description": "both properties present is invalid",
-                "data": {"foo": 1, "bar": 2},
+                "data": {
+                    "foo": 1,
+                    "bar": 2
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "properties with escaped characters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo\nbar": {"type": "number"},
-                "foo\"bar": {"type": "number"},
-                "foo\\bar": {"type": "number"},
-                "foo\rbar": {"type": "number"},
-                "foo\tbar": {"type": "number"},
-                "foo\fbar": {"type": "number"}
+                "foo\nbar": {
+                    "type": "number"
+                },
+                "foo\"bar": {
+                    "type": "number"
+                },
+                "foo\\bar": {
+                    "type": "number"
+                },
+                "foo\rbar": {
+                    "type": "number"
+                },
+                "foo\tbar": {
+                    "type": "number"
+                },
+                "foo\fbar": {
+                    "type": "number"
+                }
             }
         },
         "tests": [
@@ -173,28 +246,41 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"type": "null"}
+                "foo": {
+                    "type": "null"
+                }
             }
         },
         "tests": [
             {
                 "description": "allows null values",
-                "data": {"foo": null},
+                "data": {
+                    "foo": null
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "properties whose names are Javascript object property names",
+        "compatibility": "4",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "__proto__": {"type": "number"},
-                "toString": {
-                    "properties": { "length": { "type": "string" } }
+                "__proto__": {
+                    "type": "number"
                 },
-                "constructor": {"type": "number"}
+                "toString": {
+                    "properties": {
+                        "length": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "constructor": {
+                    "type": "number"
+                }
             }
         },
         "tests": [
@@ -215,24 +301,36 @@
             },
             {
                 "description": "__proto__ not valid",
-                "data": { "__proto__": "foo" },
+                "data": {
+                    "__proto__": "foo"
+                },
                 "valid": false
             },
             {
                 "description": "toString not valid",
-                "data": { "toString": { "length": 37 } },
+                "data": {
+                    "toString": {
+                        "length": 37
+                    }
+                },
                 "valid": false
             },
             {
                 "description": "constructor not valid",
-                "data": { "constructor": { "length": 37 } },
+                "data": {
+                    "constructor": {
+                        "length": 37
+                    }
+                },
                 "valid": false
             },
             {
                 "description": "all present and valid",
-                "data": { 
+                "data": {
                     "__proto__": 12,
-                    "toString": { "length": "foo" },
+                    "toString": {
+                        "length": "foo"
+                    },
                     "constructor": 37
                 },
                 "valid": true

--- a/tests/v1/propertyNames.json
+++ b/tests/v1/propertyNames.json
@@ -1,9 +1,12 @@
 [
     {
         "description": "propertyNames validation",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "propertyNames": {"maxLength": 3}
+            "propertyNames": {
+                "maxLength": 3
+            }
         },
         "tests": [
             {
@@ -29,7 +32,12 @@
             },
             {
                 "description": "ignores arrays",
-                "data": [1, 2, 3, 4],
+                "data": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
                 "valid": true
             },
             {
@@ -46,6 +54,7 @@
     },
     {
         "description": "propertyNames with boolean schema true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "propertyNames": true
@@ -53,7 +62,9 @@
         "tests": [
             {
                 "description": "object with any properties is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
@@ -65,6 +76,7 @@
     },
     {
         "description": "propertyNames with boolean schema false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "propertyNames": false
@@ -72,7 +84,9 @@
         "tests": [
             {
                 "description": "object with any properties is invalid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": false
             },
             {

--- a/tests/v1/proposals/propertyDependencies/additionalProperties.json
+++ b/tests/v1/proposals/propertyDependencies/additionalProperties.json
@@ -1,11 +1,14 @@
 [
     {
         "description": "propertyDependencies with additionalProperties",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties" : {"foo2" : {}},
+            "properties": {
+                "foo2": {}
+            },
             "propertyDependencies": {
-                "foo" : {},
+                "foo": {},
                 "foo2": {
                     "bar": {
                         "properties": {
@@ -18,18 +21,25 @@
         },
         "tests": [
             {
-                "description": "additionalProperties doesn't consider propertyDependencies properties" , 
-                "data": {"foo": ""},
+                "description": "additionalProperties doesn't consider propertyDependencies properties",
+                "data": {
+                    "foo": ""
+                },
                 "valid": false
             },
             {
                 "description": "additionalProperties can't see buz even when foo2 is present",
-                "data": {"foo2": "bar", "buz": ""},
+                "data": {
+                    "foo2": "bar",
+                    "buz": ""
+                },
                 "valid": false
             },
             {
                 "description": "additionalProperties can't see buz",
-                "data": {"buz": ""},
+                "data": {
+                    "buz": ""
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/proposals/propertyDependencies/dynamicRef.json
+++ b/tests/v1/proposals/propertyDependencies/dynamicRef.json
@@ -1,13 +1,18 @@
 [
     {
         "description": "multiple dynamic paths to the $dynamicRef keyword",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
             "propertyDependencies": {
                 "kindOfList": {
-                    "numbers": { "$ref": "numberList" },
-                    "strings": { "$ref": "stringList" }
+                    "numbers": {
+                        "$ref": "numberList"
+                    },
+                    "strings": {
+                        "$ref": "stringList"
+                    }
                 }
             },
             "$defs": {
@@ -15,7 +20,9 @@
                     "$id": "genericList",
                     "properties": {
                         "list": {
-                            "items": { "$dynamicRef": "#itemType" }
+                            "items": {
+                                "$dynamicRef": "#itemType"
+                            }
                         }
                     }
                 },
@@ -46,7 +53,9 @@
                 "description": "number list with number values",
                 "data": {
                     "kindOfList": "numbers",
-                    "list": [1.1]
+                    "list": [
+                        1.1
+                    ]
                 },
                 "valid": true
             },
@@ -54,7 +63,9 @@
                 "description": "number list with string values",
                 "data": {
                     "kindOfList": "numbers",
-                    "list": ["foo"]
+                    "list": [
+                        "foo"
+                    ]
                 },
                 "valid": false
             },
@@ -62,7 +73,9 @@
                 "description": "string list with number values",
                 "data": {
                     "kindOfList": "strings",
-                    "list": [1.1]
+                    "list": [
+                        1.1
+                    ]
                 },
                 "valid": false
             },
@@ -70,7 +83,9 @@
                 "description": "string list with string values",
                 "data": {
                     "kindOfList": "strings",
-                    "list": ["foo"]
+                    "list": [
+                        "foo"
+                    ]
                 },
                 "valid": true
             }
@@ -78,6 +93,7 @@
     },
     {
         "description": "$dynamicAnchor inside propertyDependencies",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/dynamicanchor-in-propertydependencies.json",

--- a/tests/v1/proposals/propertyDependencies/propertyDependencies.json
+++ b/tests/v1/proposals/propertyDependencies/propertyDependencies.json
@@ -1,9 +1,12 @@
 [
     {
         "description": "propertyDependencies doesn't act on non-objects",
+        "compatibility": "=2020",
         "schema": {
             "propertyDependencies": {
-                "foo": {"bar": false}
+                "foo": {
+                    "bar": false
+                }
             }
         },
         "tests": [
@@ -41,56 +44,80 @@
     },
     {
         "description": "propertyDependencies doesn't act on non-string property values",
+        "compatibility": "=2020",
         "schema": {
             "propertyDependencies": {
-                "foo": {"bar": false}
+                "foo": {
+                    "bar": false
+                }
             }
         },
         "tests": [
             {
                 "description": "ignores booleans",
-                "data": {"foo": false},
+                "data": {
+                    "foo": false
+                },
                 "valid": true
             },
             {
                 "description": "ignores integers",
-                "data": {"foo": 2},
+                "data": {
+                    "foo": 2
+                },
                 "valid": true
             },
             {
                 "description": "ignores floats",
-                "data": {"foo": 1.1},
+                "data": {
+                    "foo": 1.1
+                },
                 "valid": true
             },
             {
                 "description": "ignores objects",
-                "data": {"foo": {}},
+                "data": {
+                    "foo": {}
+                },
                 "valid": true
             },
             {
                 "description": "ignores objects wth a key of the expected value",
-                "data": {"foo": {"bar": "baz"}},
+                "data": {
+                    "foo": {
+                        "bar": "baz"
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "ignores objects with the expected value nested in structure",
-                "data": {"foo": {"baz": "bar"}},
+                "data": {
+                    "foo": {
+                        "baz": "bar"
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "ignores arrays",
-                "data": {"foo": []},
+                "data": {
+                    "foo": []
+                },
                 "valid": true
             },
             {
                 "description": "ignores null",
-                "data": {"foo": null},
+                "data": {
+                    "foo": null
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "multiple options selects the right one",
+        "compatibility": "=2020",
         "schema": {
             "propertyDependencies": {
                 "foo": {
@@ -98,7 +125,9 @@
                         "minProperties": 2,
                         "maxProperties": 2
                     },
-                    "baz": {"maxProperties": 1},
+                    "baz": {
+                        "maxProperties": 1
+                    },
                     "qux": true,
                     "quux": false
                 }
@@ -124,12 +153,16 @@
             },
             {
                 "description": "bar with fewer than 2 properties is invalid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
                 "description": "baz alone is valid",
-                "data": {"foo": "baz"},
+                "data": {
+                    "foo": "baz"
+                },
                 "valid": true
             },
             {
@@ -144,7 +177,9 @@
                 "description": "anything allowed with qux",
                 "data": {
                     "foo": "qux",
-                    "blah": ["some other property"],
+                    "blah": [
+                        "some other property"
+                    ],
                     "more": "properties"
                 },
                 "valid": true

--- a/tests/v1/proposals/propertyDependencies/unevaluatedProperties.json
+++ b/tests/v1/proposals/propertyDependencies/unevaluatedProperties.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "unevaluatedProperties can see inside propertyDependencies",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -46,12 +47,15 @@
         ]
     },
     {
-        "description": "propertyDependencies with unevaluatedProperties" ,
-        "schema" : {
+        "description": "propertyDependencies with unevaluatedProperties",
+        "compatibility": "=2020",
+        "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties" : {"foo2" : {}},
+            "properties": {
+                "foo2": {}
+            },
             "propertyDependencies": {
-                "foo" : {},
+                "foo": {},
                 "foo2": {
                     "bar": {
                         "properties": {
@@ -62,21 +66,27 @@
             },
             "unevaluatedProperties": false
         },
-
         "tests": [
             {
-                "description": "unevaluatedProperties doesn't consider propertyDependencies" , 
-                "data": {"foo": "bar"},
+                "description": "unevaluatedProperties doesn't consider propertyDependencies",
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": false
             },
             {
                 "description": "unevaluatedProperties sees buz when foo2 is present",
-                "data": {"foo2": "bar", "buz": ""},
+                "data": {
+                    "foo2": "bar",
+                    "buz": ""
+                },
                 "valid": true
             },
             {
                 "description": "unevaluatedProperties doesn't see buz when foo2 is absent",
-                "data": {"buz": ""},
+                "data": {
+                    "buz": ""
+                },
                 "valid": false
             }
         ]

--- a/tests/v1/ref.json
+++ b/tests/v1/ref.json
@@ -77,6 +77,7 @@
     },
     {
         "description": "relative pointer ref to array",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -109,6 +110,7 @@
     },
     {
         "description": "escaped pointer ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -181,6 +183,7 @@
     },
     {
         "description": "nested refs",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -307,6 +310,7 @@
     },
     {
         "description": "property named $ref, containing an actual $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -339,7 +343,7 @@
     },
     {
         "description": "$ref to boolean schema true",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bool",
@@ -357,7 +361,7 @@
     },
     {
         "description": "$ref to boolean schema false",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bool",
@@ -375,7 +379,7 @@
     },
     {
         "description": "Recursive references between schemas",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/tree",
@@ -494,7 +498,7 @@
     },
     {
         "description": "refs with quote",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -554,6 +558,7 @@
     },
     {
         "description": "naive replacement of $ref with its destination is not correct",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -591,7 +596,7 @@
     },
     {
         "description": "refs with relative uris and defs",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/schema-relative-uri-defs1.json",
@@ -647,7 +652,7 @@
     },
     {
         "description": "relative refs with absolute uris and defs",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
@@ -703,7 +708,7 @@
     },
     {
         "description": "$id must be resolved against nearest parent, not just immediate parent",
-        "compatibility": "7",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/a.json",
@@ -875,7 +880,7 @@
     },
     {
         "description": "simple URN base URI with JSON pointer",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "URIs do not have to have HTTP(s) schemes",
@@ -910,7 +915,7 @@
     },
     {
         "description": "URN base URI with NSS",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.2",
@@ -945,7 +950,7 @@
     },
     {
         "description": "URN base URI with r-component",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.3.1",
@@ -980,7 +985,7 @@
     },
     {
         "description": "URN base URI with q-component",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.3.2",
@@ -1033,7 +1038,7 @@
     },
     {
         "description": "URN base URI with URN and JSON pointer ref",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
@@ -1067,7 +1072,7 @@
     },
     {
         "description": "URN base URI with URN and anchor ref",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
@@ -1205,7 +1210,7 @@
     },
     {
         "description": "ref with absolute-path-reference",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/ref/absref.json",
@@ -1236,7 +1241,7 @@
     },
     {
         "description": "$id with file URI still resolves pointers - *nix",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "file:///folder/file.json",
@@ -1262,7 +1267,7 @@
     },
     {
         "description": "$id with file URI still resolves pointers - windows",
-        "compatibility": "6",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "file:///c:/folder/file.json",
@@ -1288,7 +1293,7 @@
     },
     {
         "description": "empty tokens in $ref json-pointer",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {

--- a/tests/v1/ref.json
+++ b/tests/v1/ref.json
@@ -4,29 +4,43 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"$ref": "#"}
+                "foo": {
+                    "$ref": "#"
+                }
             },
             "additionalProperties": false
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"foo": false},
+                "data": {
+                    "foo": false
+                },
                 "valid": true
             },
             {
                 "description": "recursive match",
-                "data": {"foo": {"foo": false}},
+                "data": {
+                    "foo": {
+                        "foo": false
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": false},
+                "data": {
+                    "bar": false
+                },
                 "valid": false
             },
             {
                 "description": "recursive mismatch",
-                "data": {"foo": {"bar": false}},
+                "data": {
+                    "foo": {
+                        "bar": false
+                    }
+                },
                 "valid": false
             }
         ]
@@ -36,19 +50,27 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo": {"type": "integer"},
-                "bar": {"$ref": "#/properties/foo"}
+                "foo": {
+                    "type": "integer"
+                },
+                "bar": {
+                    "$ref": "#/properties/foo"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]
@@ -58,19 +80,29 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                {"type": "integer"},
-                {"$ref": "#/prefixItems/0"}
+                {
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/prefixItems/0"
+                }
             ]
         },
         "tests": [
             {
                 "description": "match array",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "mismatch array",
-                "data": [1, "foo"],
+                "data": [
+                    1,
+                    "foo"
+                ],
                 "valid": false
             }
         ]
@@ -80,45 +112,69 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
-                "tilde~field": {"type": "integer"},
-                "slash/field": {"type": "integer"},
-                "percent%field": {"type": "integer"}
+                "tilde~field": {
+                    "type": "integer"
+                },
+                "slash/field": {
+                    "type": "integer"
+                },
+                "percent%field": {
+                    "type": "integer"
+                }
             },
             "properties": {
-                "tilde": {"$ref": "#/$defs/tilde~0field"},
-                "slash": {"$ref": "#/$defs/slash~1field"},
-                "percent": {"$ref": "#/$defs/percent%25field"}
+                "tilde": {
+                    "$ref": "#/$defs/tilde~0field"
+                },
+                "slash": {
+                    "$ref": "#/$defs/slash~1field"
+                },
+                "percent": {
+                    "$ref": "#/$defs/percent%25field"
+                }
             }
         },
         "tests": [
             {
                 "description": "slash invalid",
-                "data": {"slash": "aoeu"},
+                "data": {
+                    "slash": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "tilde invalid",
-                "data": {"tilde": "aoeu"},
+                "data": {
+                    "tilde": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "percent invalid",
-                "data": {"percent": "aoeu"},
+                "data": {
+                    "percent": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "slash valid",
-                "data": {"slash": 123},
+                "data": {
+                    "slash": 123
+                },
                 "valid": true
             },
             {
                 "description": "tilde valid",
-                "data": {"tilde": 123},
+                "data": {
+                    "tilde": 123
+                },
                 "valid": true
             },
             {
                 "description": "percent valid",
-                "data": {"percent": 123},
+                "data": {
+                    "percent": 123
+                },
                 "valid": true
             }
         ]
@@ -128,9 +184,15 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
-                "a": {"type": "integer"},
-                "b": {"$ref": "#/$defs/a"},
-                "c": {"$ref": "#/$defs/b"}
+                "a": {
+                    "type": "integer"
+                },
+                "b": {
+                    "$ref": "#/$defs/a"
+                },
+                "c": {
+                    "$ref": "#/$defs/b"
+                }
             },
             "$ref": "#/$defs/c"
         },
@@ -149,6 +211,7 @@
     },
     {
         "description": "ref applies alongside sibling keywords",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -166,17 +229,27 @@
         "tests": [
             {
                 "description": "ref valid, maxItems valid",
-                "data": { "foo": [] },
+                "data": {
+                    "foo": []
+                },
                 "valid": true
             },
             {
                 "description": "ref valid, maxItems invalid",
-                "data": { "foo": [1, 2, 3] },
+                "data": {
+                    "foo": [
+                        1,
+                        2,
+                        3
+                    ]
+                },
                 "valid": false
             },
             {
                 "description": "ref invalid",
-                "data": { "foo": "string" },
+                "data": {
+                    "foo": "string"
+                },
                 "valid": false
             }
         ]
@@ -190,33 +263,44 @@
         "tests": [
             {
                 "description": "remote ref valid",
-                "data": {"minLength": 1},
+                "data": {
+                    "minLength": 1
+                },
                 "valid": true
             },
             {
                 "description": "remote ref invalid",
-                "data": {"minLength": -1},
+                "data": {
+                    "minLength": -1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "property named $ref that is not a reference",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "$ref": {"type": "string"}
+                "$ref": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "property named $ref valid",
-                "data": {"$ref": "a"},
+                "data": {
+                    "$ref": "a"
+                },
                 "valid": true
             },
             {
                 "description": "property named $ref invalid",
-                "data": {"$ref": 2},
+                "data": {
+                    "$ref": 2
+                },
                 "valid": false
             }
         ]
@@ -226,7 +310,9 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "$ref": {"$ref": "#/$defs/is-string"}
+                "$ref": {
+                    "$ref": "#/$defs/is-string"
+                }
             },
             "$defs": {
                 "is-string": {
@@ -237,18 +323,23 @@
         "tests": [
             {
                 "description": "property named $ref valid",
-                "data": {"$ref": "a"},
+                "data": {
+                    "$ref": "a"
+                },
                 "valid": true
             },
             {
                 "description": "property named $ref invalid",
-                "data": {"$ref": 2},
+                "data": {
+                    "$ref": 2
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "$ref to boolean schema true",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bool",
@@ -266,6 +357,7 @@
     },
     {
         "description": "$ref to boolean schema false",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bool",
@@ -283,29 +375,43 @@
     },
     {
         "description": "Recursive references between schemas",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/tree",
             "description": "tree of nodes",
             "type": "object",
             "properties": {
-                "meta": {"type": "string"},
+                "meta": {
+                    "type": "string"
+                },
                 "nodes": {
                     "type": "array",
-                    "items": {"$ref": "node"}
+                    "items": {
+                        "$ref": "node"
+                    }
                 }
             },
-            "required": ["meta", "nodes"],
+            "required": [
+                "meta",
+                "nodes"
+            ],
             "$defs": {
                 "node": {
                     "$id": "http://localhost:1234/v1/node",
                     "description": "node",
                     "type": "object",
                     "properties": {
-                        "value": {"type": "number"},
-                        "subtree": {"$ref": "tree"}
+                        "value": {
+                            "type": "number"
+                        },
+                        "subtree": {
+                            "$ref": "tree"
+                        }
                     },
-                    "required": ["value"]
+                    "required": [
+                        "value"
+                    ]
                 }
             }
         },
@@ -320,8 +426,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 1.1},
-                                    {"value": 1.2}
+                                    {
+                                        "value": 1.1
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
                                 ]
                             }
                         },
@@ -330,8 +440,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 2.1},
-                                    {"value": 2.2}
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
                                 ]
                             }
                         }
@@ -349,8 +463,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": "string is invalid"},
-                                    {"value": 1.2}
+                                    {
+                                        "value": "string is invalid"
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
                                 ]
                             }
                         },
@@ -359,8 +477,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 2.1},
-                                    {"value": 2.2}
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
                                 ]
                             }
                         }
@@ -372,13 +494,18 @@
     },
     {
         "description": "refs with quote",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
-                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+                "foo\"bar": {
+                    "$ref": "#/$defs/foo%22bar"
+                }
             },
             "$defs": {
-                "foo\"bar": {"type": "number"}
+                "foo\"bar": {
+                    "type": "number"
+                }
             }
         },
         "tests": [
@@ -400,6 +527,7 @@
     },
     {
         "description": "ref creates new scope when adjacent to keywords",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
@@ -429,10 +557,14 @@
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
-                "a_string": { "type": "string" }
+                "a_string": {
+                    "type": "string"
+                }
             },
             "enum": [
-                { "$ref": "#/$defs/a_string" }
+                {
+                    "$ref": "#/$defs/a_string"
+                }
             ]
         },
         "tests": [
@@ -443,18 +575,23 @@
             },
             {
                 "description": "do not evaluate the $ref inside the enum, definition exact match",
-                "data": { "type": "string" },
+                "data": {
+                    "type": "string"
+                },
                 "valid": false
             },
             {
                 "description": "match the enum exactly",
-                "data": { "$ref": "#/$defs/a_string" },
+                "data": {
+                    "$ref": "#/$defs/a_string"
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "refs with relative uris and defs",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/schema-relative-uri-defs1.json",
@@ -464,7 +601,9 @@
                     "$defs": {
                         "inner": {
                             "properties": {
-                                "bar": { "type": "string" }
+                                "bar": {
+                                    "type": "string"
+                                }
                             }
                         }
                     },
@@ -508,6 +647,7 @@
     },
     {
         "description": "relative refs with absolute uris and defs",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
@@ -517,7 +657,9 @@
                     "$defs": {
                         "inner": {
                             "properties": {
-                                "bar": { "type": "string" }
+                                "bar": {
+                                    "type": "string"
+                                }
                             }
                         }
                     },
@@ -561,6 +703,7 @@
     },
     {
         "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/a.json",
@@ -598,6 +741,7 @@
     },
     {
         "description": "order of evaluation: $id and $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
@@ -631,6 +775,7 @@
     },
     {
         "description": "order of evaluation: $id and $anchor and $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
@@ -665,6 +810,7 @@
     },
     {
         "description": "order of evaluation: $id and $ref on nested schema",
+        "compatibility": "2019",
         "schema": {
             "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
             "$schema": "https://json-schema.org/v1",
@@ -698,134 +844,178 @@
     },
     {
         "description": "simple URN base URI with $ref via the URN",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
             "minimum": 30,
             "properties": {
-                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"
+                }
             }
         },
         "tests": [
             {
                 "description": "valid under the URN IDed schema",
-                "data": {"foo": 37},
+                "data": {
+                    "foo": 37
+                },
                 "valid": true
             },
             {
                 "description": "invalid under the URN IDed schema",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "simple URN base URI with JSON pointer",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "URIs do not have to have HTTP(s) schemes",
             "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
             "properties": {
-                "foo": {"$ref": "#/$defs/bar"}
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
             },
             "$defs": {
-                "bar": {"type": "string"}
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with NSS",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.2",
             "$id": "urn:example:1/406/47452/2",
             "properties": {
-                "foo": {"$ref": "#/$defs/bar"}
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
             },
             "$defs": {
-                "bar": {"type": "string"}
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with r-component",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.3.1",
             "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
             "properties": {
-                "foo": {"$ref": "#/$defs/bar"}
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
             },
             "$defs": {
-                "bar": {"type": "string"}
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with q-component",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.3.2",
             "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
             "properties": {
-                "foo": {"$ref": "#/$defs/bar"}
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
             },
             "$defs": {
-                "bar": {"type": "string"}
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with f-component",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
@@ -834,43 +1024,57 @@
         "tests": [
             {
                 "description": "is invalid",
-                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "data": {
+                    "$id": "urn:example:foo-bar-baz-qux#somepart"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with URN and JSON pointer ref",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
             "properties": {
-                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"
+                }
             },
             "$defs": {
-                "bar": {"type": "string"}
+                "bar": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN base URI with URN and anchor ref",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
             "properties": {
-                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"
+                }
             },
             "$defs": {
                 "bar": {
@@ -882,25 +1086,34 @@
         "tests": [
             {
                 "description": "a string is valid",
-                "data": {"foo": "bar"},
+                "data": {
+                    "foo": "bar"
+                },
                 "valid": true
             },
             {
                 "description": "a non-string is invalid",
-                "data": {"foo": 12},
+                "data": {
+                    "foo": 12
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "URN ref with nested pointer ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
             "$defs": {
                 "foo": {
                     "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
-                    "$defs": {"bar": {"type": "string"}},
+                    "$defs": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
                     "$ref": "#/$defs/bar"
                 }
             }
@@ -920,6 +1133,7 @@
     },
     {
         "description": "ref to if",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://example.com/ref/if",
@@ -943,6 +1157,7 @@
     },
     {
         "description": "ref to then",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://example.com/ref/then",
@@ -966,6 +1181,7 @@
     },
     {
         "description": "ref to else",
+        "compatibility": "7",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://example.com/ref/else",
@@ -989,6 +1205,7 @@
     },
     {
         "description": "ref with absolute-path-reference",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://example.com/ref/absref.json",
@@ -1019,6 +1236,7 @@
     },
     {
         "description": "$id with file URI still resolves pointers - *nix",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "file:///folder/file.json",
@@ -1044,6 +1262,7 @@
     },
     {
         "description": "$id with file URI still resolves pointers - windows",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "file:///c:/folder/file.json",
@@ -1066,17 +1285,20 @@
                 "valid": false
             }
         ]
-    }, 
+    },
     {
         "description": "empty tokens in $ref json-pointer",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
                 "": {
                     "$defs": {
-                        "": { "type": "number" }
+                        "": {
+                            "type": "number"
+                        }
                     }
-                } 
+                }
             },
             "allOf": [
                 {

--- a/tests/v1/refRemote.json
+++ b/tests/v1/refRemote.json
@@ -112,7 +112,7 @@
     },
     {
         "description": "base URI change - change folder",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/scope_change_defs1.json",
@@ -155,7 +155,7 @@
     },
     {
         "description": "base URI change - change folder in subschema",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/scope_change_defs2.json",

--- a/tests/v1/refRemote.json
+++ b/tests/v1/refRemote.json
@@ -38,23 +38,24 @@
         ]
     },
     {
-         "description": "anchor within remote ref",
-         "schema": {
-             "$schema": "https://json-schema.org/v1",
-             "$ref": "http://localhost:1234/v1/locationIndependentIdentifier.json#foo"
-         },
-         "tests": [
-             {
-                 "description": "remote anchor valid",
-                 "data": 1,
-                 "valid": true
-             },
-             {
-                 "description": "remote anchor invalid",
-                 "data": "a",
-                 "valid": false
-             }
-         ]
+        "description": "anchor within remote ref",
+        "compatibility": "2019",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "$ref": "http://localhost:1234/v1/locationIndependentIdentifier.json#foo"
+        },
+        "tests": [
+            {
+                "description": "remote anchor valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote anchor invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
     },
     {
         "description": "ref within remote ref",
@@ -77,69 +78,102 @@
     },
     {
         "description": "base URI change",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/",
             "items": {
                 "$id": "baseUriChange/",
-                "items": {"$ref": "folderInteger.json"}
+                "items": {
+                    "$ref": "folderInteger.json"
+                }
             }
         },
         "tests": [
             {
                 "description": "base URI change ref valid",
-                "data": [[1]],
+                "data": [
+                    [
+                        1
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "base URI change ref invalid",
-                "data": [["a"]],
+                "data": [
+                    [
+                        "a"
+                    ]
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "base URI change - change folder",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/scope_change_defs1.json",
-            "type" : "object",
-            "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
+            "type": "object",
+            "properties": {
+                "list": {
+                    "$ref": "baseUriChangeFolder/"
+                }
+            },
             "$defs": {
                 "baz": {
                     "$id": "baseUriChangeFolder/",
                     "type": "array",
-                    "items": {"$ref": "folderInteger.json"}
+                    "items": {
+                        "$ref": "folderInteger.json"
+                    }
                 }
             }
         },
         "tests": [
             {
                 "description": "number is valid",
-                "data": {"list": [1]},
+                "data": {
+                    "list": [
+                        1
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "string is invalid",
-                "data": {"list": ["a"]},
+                "data": {
+                    "list": [
+                        "a"
+                    ]
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "base URI change - change folder in subschema",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/scope_change_defs2.json",
-            "type" : "object",
-            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
+            "type": "object",
+            "properties": {
+                "list": {
+                    "$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"
+                }
+            },
             "$defs": {
                 "baz": {
                     "$id": "baseUriChangeFolderInSubschema/",
                     "$defs": {
                         "bar": {
                             "type": "array",
-                            "items": {"$ref": "folderInteger.json"}
+                            "items": {
+                                "$ref": "folderInteger.json"
+                            }
                         }
                     }
                 }
@@ -148,24 +182,35 @@
         "tests": [
             {
                 "description": "number is valid",
-                "data": {"list": [1]},
+                "data": {
+                    "list": [
+                        1
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "string is invalid",
-                "data": {"list": ["a"]},
+                "data": {
+                    "list": [
+                        "a"
+                    ]
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "root ref in remote ref",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name-defs.json#/$defs/orNull"}
+                "name": {
+                    "$ref": "name-defs.json#/$defs/orNull"
+                }
             }
         },
         "tests": [
@@ -196,6 +241,7 @@
     },
     {
         "description": "remote ref with ref to defs",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/schema-remote-ref-ref-defs1.json",
@@ -220,6 +266,7 @@
     },
     {
         "description": "Location-independent identifier in remote ref",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/locationIndependentIdentifier.json#/$defs/refToInteger"
@@ -239,25 +286,32 @@
     },
     {
         "description": "retrieved nested refs resolve relative to their URI not $id",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/some-id",
             "properties": {
-                "name": {"$ref": "nested/foo-ref-string.json"}
+                "name": {
+                    "$ref": "nested/foo-ref-string.json"
+                }
             }
         },
         "tests": [
             {
                 "description": "number is invalid",
                 "data": {
-                    "name": {"foo":  1}
+                    "name": {
+                        "foo": 1
+                    }
                 },
                 "valid": false
             },
             {
                 "description": "string is valid",
                 "data": {
-                    "name": {"foo":  "a"}
+                    "name": {
+                        "foo": "a"
+                    }
                 },
                 "valid": true
             }
@@ -265,6 +319,7 @@
     },
     {
         "description": "remote HTTP ref with different $id",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/different-id-ref-string.json"
@@ -284,6 +339,7 @@
     },
     {
         "description": "remote HTTP ref with different URN $id",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/urn-ref-string.json"
@@ -303,6 +359,7 @@
     },
     {
         "description": "remote HTTP ref with nested absolute ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/nested-absolute-ref-to-string.json"
@@ -321,7 +378,8 @@
         ]
     },
     {
-       "description": "$ref to $ref finds detached $anchor",
+        "description": "$ref to $ref finds detached $anchor",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "http://localhost:1234/v1/detached-ref.json#/$defs/foo"

--- a/tests/v1/refRemote.json
+++ b/tests/v1/refRemote.json
@@ -202,7 +202,7 @@
     },
     {
         "description": "root ref in remote ref",
-        "compatibility": "4",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "http://localhost:1234/v1/object",

--- a/tests/v1/required.json
+++ b/tests/v1/required.json
@@ -7,17 +7,23 @@
                 "foo": {},
                 "bar": {}
             },
-            "required": ["foo"]
+            "required": [
+                "foo"
+            ]
         },
         "tests": [
             {
                 "description": "present required property is valid",
-                "data": {"foo": 1},
+                "data": {
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "non-present required property is invalid",
-                "data": {"bar": 1},
+                "data": {
+                    "bar": 1
+                },
                 "valid": false
             },
             {
@@ -65,6 +71,7 @@
     },
     {
         "description": "required with empty array",
+        "compatibility": "6",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -82,6 +89,7 @@
     },
     {
         "description": "required with escaped characters",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "required": [
@@ -118,10 +126,15 @@
     },
     {
         "description": "required properties whose names are Javascript object property names",
+        "compatibility": "4",
         "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "required": ["__proto__", "toString", "constructor"]
+            "required": [
+                "__proto__",
+                "toString",
+                "constructor"
+            ]
         },
         "tests": [
             {
@@ -141,24 +154,36 @@
             },
             {
                 "description": "__proto__ present",
-                "data": { "__proto__": "foo" },
+                "data": {
+                    "__proto__": "foo"
+                },
                 "valid": false
             },
             {
                 "description": "toString present",
-                "data": { "toString": { "length": 37 } },
+                "data": {
+                    "toString": {
+                        "length": 37
+                    }
+                },
                 "valid": false
             },
             {
                 "description": "constructor present",
-                "data": { "constructor": { "length": 37 } },
+                "data": {
+                    "constructor": {
+                        "length": 37
+                    }
+                },
                 "valid": false
             },
             {
                 "description": "all present",
-                "data": { 
+                "data": {
                     "__proto__": 12,
-                    "toString": { "length": "foo" },
+                    "toString": {
+                        "length": "foo"
+                    },
                     "constructor": 37
                 },
                 "valid": true

--- a/tests/v1/required.json
+++ b/tests/v1/required.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "required validation",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {

--- a/tests/v1/type.json
+++ b/tests/v1/type.json
@@ -371,7 +371,10 @@
         "description": "multiple types can be specified in an array",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type": ["integer", "string"]
+            "type": [
+                "integer",
+                "string"
+            ]
         },
         "tests": [
             {
@@ -413,9 +416,12 @@
     },
     {
         "description": "type as array with one item",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type": ["string"]
+            "type": [
+                "string"
+            ]
         },
         "tests": [
             {
@@ -432,19 +438,29 @@
     },
     {
         "description": "type: array or object",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type": ["array", "object"]
+            "type": [
+                "array",
+                "object"
+            ]
         },
         "tests": [
             {
                 "description": "array is valid",
-                "data": [1,2,3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
                 "description": "object is valid",
-                "data": {"foo": 123},
+                "data": {
+                    "foo": 123
+                },
                 "valid": true
             },
             {
@@ -466,19 +482,30 @@
     },
     {
         "description": "type: array, object or null",
+        "compatibility": "4",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "type": ["array", "object", "null"]
+            "type": [
+                "array",
+                "object",
+                "null"
+            ]
         },
         "tests": [
             {
                 "description": "array is valid",
-                "data": [1,2,3],
+                "data": [
+                    1,
+                    2,
+                    3
+                ],
                 "valid": true
             },
             {
                 "description": "object is valid",
-                "data": {"foo": 123},
+                "data": {
+                    "foo": 123
+                },
                 "valid": true
             },
             {

--- a/tests/v1/unevaluatedItems.json
+++ b/tests/v1/unevaluatedItems.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "unevaluatedItems true",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": true
@@ -13,13 +14,16 @@
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems false",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": false
@@ -32,16 +36,21 @@
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems as schema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "unevaluatedItems": { "type": "string" }
+            "unevaluatedItems": {
+                "type": "string"
+            }
         },
         "tests": [
             {
@@ -51,59 +60,80 @@
             },
             {
                 "description": "with valid unevaluated items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "with invalid unevaluated items",
-                "data": [42],
+                "data": [
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with uniform items",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "items": { "type": "string" },
+            "items": {
+                "type": "string"
+            },
             "unevaluatedItems": false
         },
         "tests": [
             {
                 "description": "unevaluatedItems doesn't apply",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems with tuple",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "unevaluatedItems": false
         },
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with items and prefixItems",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "items": true,
             "unevaluatedItems": false
@@ -111,44 +141,66 @@
         "tests": [
             {
                 "description": "unevaluatedItems doesn't apply",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems with items",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "items": {"type": "number"},
-            "unevaluatedItems": {"type": "string"}
+            "items": {
+                "type": "number"
+            },
+            "unevaluatedItems": {
+                "type": "string"
+            }
         },
         "tests": [
             {
                 "description": "valid under items",
                 "comment": "no elements are considered by unevaluatedItems",
-                "data": [5, 6, 7, 8],
+                "data": [
+                    5,
+                    6,
+                    7,
+                    8
+                ],
                 "valid": true
             },
             {
                 "description": "invalid under items",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with nested tuple",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "allOf": [
                 {
                     "prefixItems": [
                         true,
-                        { "type": "number" }
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             ],
@@ -157,52 +209,78 @@
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo", 42],
+                "data": [
+                    "foo",
+                    42
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", 42, true],
+                "data": [
+                    "foo",
+                    42,
+                    true
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with nested items",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "unevaluatedItems": {"type": "boolean"},
+            "unevaluatedItems": {
+                "type": "boolean"
+            },
             "anyOf": [
-                { "items": {"type": "string"} },
+                {
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 true
             ]
         },
         "tests": [
             {
                 "description": "with only (valid) additional items",
-                "data": [true, false],
+                "data": [
+                    true,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "with no additional items",
-                "data": ["yes", "no"],
+                "data": [
+                    "yes",
+                    "no"
+                ],
                 "valid": true
             },
             {
                 "description": "with invalid additional item",
-                "data": ["yes", false],
+                "data": [
+                    "yes",
+                    false
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with nested prefixItems and items",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
                 {
                     "prefixItems": [
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ],
                     "items": true
                 }
@@ -212,62 +290,86 @@
         "tests": [
             {
                 "description": "with no additional items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "with additional items",
-                "data": ["foo", 42, true],
+                "data": [
+                    "foo",
+                    42,
+                    true
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems with nested unevaluatedItems",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
                 {
                     "prefixItems": [
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
-                { "unevaluatedItems": true }
+                {
+                    "unevaluatedItems": true
+                }
             ],
             "unevaluatedItems": false
         },
         "tests": [
             {
                 "description": "with no additional items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "with additional items",
-                "data": ["foo", 42, true],
+                "data": [
+                    "foo",
+                    42,
+                    true
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems with anyOf",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "const": "foo" }
+                {
+                    "const": "foo"
+                }
             ],
             "anyOf": [
                 {
                     "prefixItems": [
                         true,
-                        { "const": "bar" }
+                        {
+                            "const": "bar"
+                        }
                     ]
                 },
                 {
                     "prefixItems": [
                         true,
                         true,
-                        { "const": "baz" }
+                        {
+                            "const": "baz"
+                        }
                     ]
                 }
             ],
@@ -276,44 +378,67 @@
         "tests": [
             {
                 "description": "when one schema matches and has no unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "when one schema matches and has unevaluated items",
-                "data": ["foo", "bar", 42],
+                "data": [
+                    "foo",
+                    "bar",
+                    42
+                ],
                 "valid": false
             },
             {
                 "description": "when two schemas match and has no unevaluated items",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": true
             },
             {
                 "description": "when two schemas match and has unevaluated items",
-                "data": ["foo", "bar", "baz", 42],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with oneOf",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "const": "foo" }
+                {
+                    "const": "foo"
+                }
             ],
             "oneOf": [
                 {
                     "prefixItems": [
                         true,
-                        { "const": "bar" }
+                        {
+                            "const": "bar"
+                        }
                     ]
                 },
                 {
                     "prefixItems": [
                         true,
-                        { "const": "baz" }
+                        {
+                            "const": "baz"
+                        }
                     ]
                 }
             ],
@@ -322,28 +447,40 @@
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar", 42],
+                "data": [
+                    "foo",
+                    "bar",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with not",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "const": "foo" }
+                {
+                    "const": "foo"
+                }
             ],
             "not": {
                 "not": {
                     "prefixItems": [
                         true,
-                        { "const": "bar" }
+                        {
+                            "const": "bar"
+                        }
                     ]
                 }
             },
@@ -352,29 +489,39 @@
         "tests": [
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with if/then/else",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
-                { "const": "foo" }
+                {
+                    "const": "foo"
+                }
             ],
             "if": {
                 "prefixItems": [
                     true,
-                    { "const": "bar" }
+                    {
+                        "const": "bar"
+                    }
                 ]
             },
             "then": {
                 "prefixItems": [
                     true,
                     true,
-                    { "const": "then" }
+                    {
+                        "const": "then"
+                    }
                 ]
             },
             "else": {
@@ -382,7 +529,9 @@
                     true,
                     true,
                     true,
-                    { "const": "else" }
+                    {
+                        "const": "else"
+                    }
                 ]
             },
             "unevaluatedItems": false
@@ -390,31 +539,54 @@
         "tests": [
             {
                 "description": "when if matches and it has no unevaluated items",
-                "data": ["foo", "bar", "then"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "then"
+                ],
                 "valid": true
             },
             {
                 "description": "when if matches and it has unevaluated items",
-                "data": ["foo", "bar", "then", "else"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "then",
+                    "else"
+                ],
                 "valid": false
             },
             {
                 "description": "when if doesn't match and it has no unevaluated items",
-                "data": ["foo", 42, 42, "else"],
+                "data": [
+                    "foo",
+                    42,
+                    42,
+                    "else"
+                ],
                 "valid": true
             },
             {
                 "description": "when if doesn't match and it has unevaluated items",
-                "data": ["foo", 42, 42, "else", 42],
+                "data": [
+                    "foo",
+                    42,
+                    42,
+                    "else",
+                    42
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with boolean schemas",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "allOf": [true],
+            "allOf": [
+                true
+            ],
             "unevaluatedItems": false
         },
         "tests": [
@@ -425,97 +597,125 @@
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo"],
+                "data": [
+                    "foo"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bar",
             "prefixItems": [
-                { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "unevaluatedItems": false,
             "$defs": {
-              "bar": {
-                  "prefixItems": [
-                      true,
-                      { "type": "string" }
-                  ]
-              }
+                "bar": {
+                    "prefixItems": [
+                        true,
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
             }
         },
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems before $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": false,
             "prefixItems": [
-                { "type": "string" }
+                {
+                    "type": "string"
+                }
             ],
             "$ref": "#/$defs/bar",
             "$defs": {
-              "bar": {
-                  "prefixItems": [
-                      true,
-                      { "type": "string" }
-                  ]
-              }
+                "bar": {
+                    "prefixItems": [
+                        true,
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
             }
         },
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems with $dynamicRef",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://example.com/unevaluated-items-with-dynamic-ref/derived",
-
             "$ref": "./baseSchema",
-
             "$defs": {
                 "derived": {
                     "$dynamicAnchor": "addons",
                     "prefixItems": [
                         true,
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ]
                 },
                 "baseSchema": {
                     "$id": "./baseSchema",
-
                     "$comment": "unevaluatedItems comes first so it's more likely to catch bugs with implementations that are sensitive to keyword ordering",
                     "unevaluatedItems": false,
                     "type": "array",
                     "prefixItems": [
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ],
                     "$dynamicRef": "#addons"
                 }
@@ -524,46 +724,63 @@
         "tests": [
             {
                 "description": "with no unevaluated items",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "with unevaluated items",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems can't see inside cousins",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
                 {
-                    "prefixItems": [ true ]
+                    "prefixItems": [
+                        true
+                    ]
                 },
-                { "unevaluatedItems": false }
+                {
+                    "unevaluatedItems": false
+                }
             ]
         },
         "tests": [
             {
                 "description": "always fails",
-                "data": [ 1 ],
+                "data": [
+                    1
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "item is evaluated in an uncle schema to unevaluatedItems",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
                 "foo": {
                     "prefixItems": [
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ],
                     "unevaluatedItems": false
-                  }
+                }
             },
             "anyOf": [
                 {
@@ -571,7 +788,9 @@
                         "foo": {
                             "prefixItems": [
                                 true,
-                                { "type": "string" }
+                                {
+                                    "type": "string"
+                                }
                             ]
                         }
                     }
@@ -602,67 +821,112 @@
     },
     {
         "description": "unevaluatedItems depends on adjacent contains",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [true],
-            "contains": {"type": "string"},
+            "prefixItems": [
+                true
+            ],
+            "contains": {
+                "type": "string"
+            },
             "unevaluatedItems": false
         },
         "tests": [
             {
                 "description": "second item is evaluated by contains",
-                "data": [ 1, "foo" ],
+                "data": [
+                    1,
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "contains fails, second item is not evaluated",
-                "data": [ 1, 2 ],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": false
             },
             {
                 "description": "contains passes, second item is not evaluated",
-                "data": [ 1, 2, "foo" ],
+                "data": [
+                    1,
+                    2,
+                    "foo"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems depends on multiple nested contains",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
-                { "contains": { "multipleOf": 2 } },
-                { "contains": { "multipleOf": 3 } }
+                {
+                    "contains": {
+                        "multipleOf": 2
+                    }
+                },
+                {
+                    "contains": {
+                        "multipleOf": 3
+                    }
+                }
             ],
-            "unevaluatedItems": { "multipleOf": 5 }
+            "unevaluatedItems": {
+                "multipleOf": 5
+            }
         },
         "tests": [
             {
                 "description": "5 not evaluated, passes unevaluatedItems",
-                "data": [ 2, 3, 4, 5, 6 ],
+                "data": [
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
                 "valid": true
             },
             {
                 "description": "7 not evaluated, fails unevaluatedItems",
-                "data": [ 2, 3, 4, 7, 8 ],
+                "data": [
+                    2,
+                    3,
+                    4,
+                    7,
+                    8
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedItems and contains interact to control item dependency relationship",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
-                "contains": {"const": "a"}
+                "contains": {
+                    "const": "a"
+                }
             },
             "then": {
                 "if": {
-                    "contains": {"const": "b"}
+                    "contains": {
+                        "const": "b"
+                    }
                 },
                 "then": {
                     "if": {
-                        "contains": {"const": "c"}
+                        "contains": {
+                            "const": "c"
+                        }
                     }
                 }
             },
@@ -676,50 +940,87 @@
             },
             {
                 "description": "only a's are valid",
-                "data": [ "a", "a" ],
+                "data": [
+                    "a",
+                    "a"
+                ],
                 "valid": true
             },
             {
                 "description": "a's and b's are valid",
-                "data": [ "a", "b", "a", "b", "a" ],
+                "data": [
+                    "a",
+                    "b",
+                    "a",
+                    "b",
+                    "a"
+                ],
                 "valid": true
             },
             {
                 "description": "a's, b's and c's are valid",
-                "data": [ "c", "a", "c", "c", "b", "a" ],
+                "data": [
+                    "c",
+                    "a",
+                    "c",
+                    "c",
+                    "b",
+                    "a"
+                ],
                 "valid": true
             },
             {
                 "description": "only b's are invalid",
-                "data": [ "b", "b" ],
+                "data": [
+                    "b",
+                    "b"
+                ],
                 "valid": false
             },
             {
                 "description": "only c's are invalid",
-                "data": [ "c", "c" ],
+                "data": [
+                    "c",
+                    "c"
+                ],
                 "valid": false
             },
             {
                 "description": "only b's and c's are invalid",
-                "data": [ "c", "b", "c", "b", "c" ],
+                "data": [
+                    "c",
+                    "b",
+                    "c",
+                    "b",
+                    "c"
+                ],
                 "valid": false
             },
             {
                 "description": "only a's and c's are invalid",
-                "data": [ "c", "a", "c", "a", "c" ],
+                "data": [
+                    "c",
+                    "a",
+                    "c",
+                    "a",
+                    "c"
+                ],
                 "valid": false
             }
         ]
     },
     {
-        "description" : "unevaluatedItems with minContains = 0",
-        "schema" : {
+        "description": "unevaluatedItems with minContains = 0",
+        "compatibility": "=2020",
+        "schema": {
             "$schema": "https://json-schema.org/v1",
-            "contains": {"type": "string"},
+            "contains": {
+                "type": "string"
+            },
             "minContains": 0,
             "unevaluatedItems": false
         },
-        "tests" : [
+        "tests": [
             {
                 "description": "empty array is valid",
                 "data": [],
@@ -727,23 +1028,32 @@
             },
             {
                 "description": "no items evaluated by contains",
-                "data": [0],
+                "data": [
+                    0
+                ],
                 "valid": false
             },
             {
                 "description": "some but not all items evaluated by contains",
-                "data": ["foo", 0],
+                "data": [
+                    "foo",
+                    0
+                ],
                 "valid": false
             },
             {
                 "description": "all items evaluated by contains",
-                "data": ["foo", "bar"],
+                "data": [
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "non-array instances are valid",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": false
@@ -783,6 +1093,7 @@
     },
     {
         "description": "unevaluatedItems with null instance elements",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": {
@@ -792,43 +1103,56 @@
         "tests": [
             {
                 "description": "allows null elements",
-                "data": [ null ],
+                "data": [
+                    null
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedItems can see annotations from if without then and else",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
-                "prefixItems": [{"const": "a"}]
+                "prefixItems": [
+                    {
+                        "const": "a"
+                    }
+                ]
             },
             "unevaluatedItems": false
         },
         "tests": [
             {
                 "description": "valid in case if is evaluated",
-                "data": [ "a" ],
+                "data": [
+                    "a"
+                ],
                 "valid": true
             },
             {
                 "description": "invalid in case if is evaluated",
-                "data": [ "b" ],
+                "data": [
+                    "b"
+                ],
                 "valid": false
             }
-
         ]
     },
     {
         "description": "Evaluated items collection needs to consider instance location",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
                 {
                     "prefixItems": [
                         true,
-                        { "type": "string" }
+                        {
+                            "type": "string"
+                        }
                     ]
                 }
             ],
@@ -838,7 +1162,10 @@
             {
                 "description": "with an unevaluated item that exists at another location",
                 "data": [
-                    ["foo", "bar"],
+                    [
+                        "foo",
+                        "bar"
+                    ],
                     "bar"
                 ],
                 "valid": false

--- a/tests/v1/unevaluatedItems.json
+++ b/tests/v1/unevaluatedItems.json
@@ -97,7 +97,7 @@
     },
     {
         "description": "unevaluatedItems with tuple",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -186,7 +186,7 @@
     },
     {
         "description": "unevaluatedItems with nested tuple",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -308,7 +308,7 @@
     },
     {
         "description": "unevaluatedItems with nested unevaluatedItems",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -346,7 +346,7 @@
     },
     {
         "description": "unevaluatedItems with anyOf",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -416,7 +416,7 @@
     },
     {
         "description": "unevaluatedItems with oneOf",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -466,7 +466,7 @@
     },
     {
         "description": "unevaluatedItems with not",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -499,7 +499,7 @@
     },
     {
         "description": "unevaluatedItems with if/then/else",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [
@@ -606,7 +606,7 @@
     },
     {
         "description": "unevaluatedItems with $ref",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$ref": "#/$defs/bar",
@@ -649,7 +649,7 @@
     },
     {
         "description": "unevaluatedItems before $ref",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedItems": false,
@@ -743,7 +743,7 @@
     },
     {
         "description": "unevaluatedItems can't see inside cousins",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -769,7 +769,7 @@
     },
     {
         "description": "item is evaluated in an uncle schema to unevaluatedItems",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
@@ -1112,7 +1112,7 @@
     },
     {
         "description": "unevaluatedItems can see annotations from if without then and else",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -1143,7 +1143,7 @@
     },
     {
         "description": "Evaluated items collection needs to consider instance location",
-        "compatibility": "2019",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "prefixItems": [

--- a/tests/v1/unevaluatedProperties.json
+++ b/tests/v1/unevaluatedProperties.json
@@ -1,6 +1,7 @@
 [
     {
         "description": "unevaluatedProperties true",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -23,6 +24,7 @@
     },
     {
         "description": "unevaluatedProperties schema",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -55,6 +57,7 @@
     },
     {
         "description": "unevaluatedProperties false",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -77,11 +80,14 @@
     },
     {
         "description": "unevaluatedProperties with adjacent properties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "unevaluatedProperties": false
         },
@@ -105,11 +111,14 @@
     },
     {
         "description": "unevaluatedProperties with adjacent patternProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "patternProperties": {
-                "^foo": { "type": "string" }
+                "^foo": {
+                    "type": "string"
+                }
             },
             "unevaluatedProperties": false
         },
@@ -133,11 +142,14 @@
     },
     {
         "description": "unevaluatedProperties with adjacent bool additionalProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "additionalProperties": true,
             "unevaluatedProperties": false
@@ -162,13 +174,18 @@
     },
     {
         "description": "unevaluatedProperties with adjacent non-bool additionalProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+                "type": "string"
+            },
             "unevaluatedProperties": false
         },
         "tests": [
@@ -191,16 +208,21 @@
     },
     {
         "description": "unevaluatedProperties with nested properties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
                 {
                     "properties": {
-                        "bar": { "type": "string" }
+                        "bar": {
+                            "type": "string"
+                        }
                     }
                 }
             ],
@@ -228,18 +250,23 @@
     },
     {
         "description": "unevaluatedProperties with nested patternProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
-              {
-                  "patternProperties": {
-                      "^bar": { "type": "string" }
-                  }
-              }
+                {
+                    "patternProperties": {
+                        "^bar": {
+                            "type": "string"
+                        }
+                    }
+                }
             ],
             "unevaluatedProperties": false
         },
@@ -265,11 +292,14 @@
     },
     {
         "description": "unevaluatedProperties with nested additionalProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
                 {
@@ -298,11 +328,14 @@
     },
     {
         "description": "unevaluatedProperties with nested unevaluatedProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
                 {
@@ -334,30 +367,45 @@
     },
     {
         "description": "unevaluatedProperties with anyOf",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "anyOf": [
                 {
                     "properties": {
-                        "bar": { "const": "bar" }
+                        "bar": {
+                            "const": "bar"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "baz": { "const": "baz" }
+                        "baz": {
+                            "const": "baz"
+                        }
                     },
-                    "required": ["baz"]
+                    "required": [
+                        "baz"
+                    ]
                 },
                 {
                     "properties": {
-                        "quux": { "const": "quux" }
+                        "quux": {
+                            "const": "quux"
+                        }
                     },
-                    "required": ["quux"]
+                    "required": [
+                        "quux"
+                    ]
                 }
             ],
             "unevaluatedProperties": false
@@ -403,24 +451,35 @@
     },
     {
         "description": "unevaluatedProperties with oneOf",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "oneOf": [
                 {
                     "properties": {
-                        "bar": { "const": "bar" }
+                        "bar": {
+                            "const": "bar"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 },
                 {
                     "properties": {
-                        "baz": { "const": "baz" }
+                        "baz": {
+                            "const": "baz"
+                        }
                     },
-                    "required": ["baz"]
+                    "required": [
+                        "baz"
+                    ]
                 }
             ],
             "unevaluatedProperties": false
@@ -447,18 +506,25 @@
     },
     {
         "description": "unevaluatedProperties with not",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "not": {
                 "not": {
                     "properties": {
-                        "bar": { "const": "bar" }
+                        "bar": {
+                            "const": "bar"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 }
             },
             "unevaluatedProperties": false
@@ -476,26 +542,39 @@
     },
     {
         "description": "unevaluatedProperties with if/then/else",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "if": {
                 "properties": {
-                    "foo": { "const": "then" }
+                    "foo": {
+                        "const": "then"
+                    }
                 },
-                "required": ["foo"]
+                "required": [
+                    "foo"
+                ]
             },
             "then": {
                 "properties": {
-                    "bar": { "type": "string" }
+                    "bar": {
+                        "type": "string"
+                    }
                 },
-                "required": ["bar"]
+                "required": [
+                    "bar"
+                ]
             },
             "else": {
                 "properties": {
-                    "baz": { "type": "string" }
+                    "baz": {
+                        "type": "string"
+                    }
                 },
-                "required": ["baz"]
+                "required": [
+                    "baz"
+                ]
             },
             "unevaluatedProperties": false
         },
@@ -536,20 +615,29 @@
     },
     {
         "description": "unevaluatedProperties with if/then/else, then not defined",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "if": {
                 "properties": {
-                    "foo": { "const": "then" }
+                    "foo": {
+                        "const": "then"
+                    }
                 },
-                "required": ["foo"]
+                "required": [
+                    "foo"
+                ]
             },
             "else": {
                 "properties": {
-                    "baz": { "type": "string" }
+                    "baz": {
+                        "type": "string"
+                    }
                 },
-                "required": ["baz"]
+                "required": [
+                    "baz"
+                ]
             },
             "unevaluatedProperties": false
         },
@@ -588,20 +676,29 @@
     },
     {
         "description": "unevaluatedProperties with if/then/else, else not defined",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "if": {
                 "properties": {
-                    "foo": { "const": "then" }
+                    "foo": {
+                        "const": "then"
+                    }
                 },
-                "required": ["foo"]
+                "required": [
+                    "foo"
+                ]
             },
             "then": {
                 "properties": {
-                    "bar": { "type": "string" }
+                    "bar": {
+                        "type": "string"
+                    }
                 },
-                "required": ["bar"]
+                "required": [
+                    "bar"
+                ]
             },
             "unevaluatedProperties": false
         },
@@ -642,18 +739,25 @@
     },
     {
         "description": "unevaluatedProperties with dependentSchemas",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "dependentSchemas": {
                 "foo": {
                     "properties": {
-                        "bar": { "const": "bar" }
+                        "bar": {
+                            "const": "bar"
+                        }
                     },
-                    "required": ["bar"]
+                    "required": [
+                        "bar"
+                    ]
                 }
             },
             "unevaluatedProperties": false
@@ -678,13 +782,18 @@
     },
     {
         "description": "unevaluatedProperties with boolean schemas",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
-            "allOf": [true],
+            "allOf": [
+                true
+            ],
             "unevaluatedProperties": false
         },
         "tests": [
@@ -706,18 +815,23 @@
     },
     {
         "description": "unevaluatedProperties with $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "$ref": "#/$defs/bar",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "unevaluatedProperties": false,
             "$defs": {
                 "bar": {
                     "properties": {
-                        "bar": { "type": "string" }
+                        "bar": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -744,18 +858,23 @@
     },
     {
         "description": "unevaluatedProperties before $ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "unevaluatedProperties": false,
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "$ref": "#/$defs/bar",
             "$defs": {
                 "bar": {
                     "properties": {
-                        "bar": { "type": "string" }
+                        "bar": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -782,27 +901,29 @@
     },
     {
         "description": "unevaluatedProperties with $dynamicRef",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$id": "https://example.com/unevaluated-properties-with-dynamic-ref/derived",
-
             "$ref": "./baseSchema",
-
             "$defs": {
                 "derived": {
                     "$dynamicAnchor": "addons",
                     "properties": {
-                        "bar": { "type": "string" }
+                        "bar": {
+                            "type": "string"
+                        }
                     }
                 },
                 "baseSchema": {
                     "$id": "./baseSchema",
-
                     "$comment": "unevaluatedProperties comes first so it's more likely to catch bugs with implementations that are sensitive to keyword ordering",
                     "unevaluatedProperties": false,
                     "type": "object",
                     "properties": {
-                        "foo": { "type": "string" }
+                        "foo": {
+                            "type": "string"
+                        }
                     },
                     "$dynamicRef": "#addons"
                 }
@@ -830,6 +951,7 @@
     },
     {
         "description": "unevaluatedProperties can't see inside cousins",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -855,6 +977,7 @@
     },
     {
         "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "allOf": [
@@ -880,11 +1003,14 @@
     },
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
                 {
@@ -913,13 +1039,16 @@
     },
     {
         "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "allOf": [
                 {
                     "properties": {
-                        "foo": { "type": "string" }
+                        "foo": {
+                            "type": "string"
+                        }
                     },
                     "unevaluatedProperties": true
                 }
@@ -946,11 +1075,14 @@
     },
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "foo": { "type": "string" }
+                "foo": {
+                    "type": "string"
+                }
             },
             "allOf": [
                 {
@@ -979,13 +1111,16 @@
     },
     {
         "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "allOf": [
                 {
                     "properties": {
-                        "foo": { "type": "string" }
+                        "foo": {
+                            "type": "string"
+                        }
                     },
                     "unevaluatedProperties": false
                 }
@@ -1012,13 +1147,16 @@
     },
     {
         "description": "cousin unevaluatedProperties, true and false, true with properties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "allOf": [
                 {
                     "properties": {
-                        "foo": { "type": "string" }
+                        "foo": {
+                            "type": "string"
+                        }
                     },
                     "unevaluatedProperties": true
                 },
@@ -1047,6 +1185,7 @@
     },
     {
         "description": "cousin unevaluatedProperties, true and false, false with properties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -1056,7 +1195,9 @@
                 },
                 {
                     "properties": {
-                        "foo": { "type": "string" }
+                        "foo": {
+                            "type": "string"
+                        }
                     },
                     "unevaluatedProperties": false
                 }
@@ -1082,6 +1223,7 @@
     },
     {
         "description": "property is evaluated in an uncle schema to unevaluatedProperties",
+        "compatibility": "2019",
         "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
         "schema": {
             "$schema": "https://json-schema.org/v1",
@@ -1095,7 +1237,7 @@
                         }
                     },
                     "unevaluatedProperties": false
-                  }
+                }
             },
             "anyOf": [
                 {
@@ -1135,6 +1277,7 @@
     },
     {
         "description": "in-place applicator siblings, allOf has unevaluated",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -1181,6 +1324,7 @@
     },
     {
         "description": "in-place applicator siblings, anyOf has unevaluated",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
@@ -1227,11 +1371,14 @@
     },
     {
         "description": "unevaluatedProperties + single cyclic ref",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "type": "object",
             "properties": {
-                "x": { "$ref": "#" }
+                "x": {
+                    "$ref": "#"
+                }
             },
             "unevaluatedProperties": false
         },
@@ -1243,58 +1390,104 @@
             },
             {
                 "description": "Single is valid",
-                "data": { "x": {} },
+                "data": {
+                    "x": {}
+                },
                 "valid": true
             },
             {
                 "description": "Unevaluated on 1st level is invalid",
-                "data": { "x": {}, "y": {} },
+                "data": {
+                    "x": {},
+                    "y": {}
+                },
                 "valid": false
             },
             {
                 "description": "Nested is valid",
-                "data": { "x": { "x": {} } },
+                "data": {
+                    "x": {
+                        "x": {}
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "Unevaluated on 2nd level is invalid",
-                "data": { "x": { "x": {}, "y": {} } },
+                "data": {
+                    "x": {
+                        "x": {},
+                        "y": {}
+                    }
+                },
                 "valid": false
             },
             {
                 "description": "Deep nested is valid",
-                "data": { "x": { "x": { "x": {} } } },
+                "data": {
+                    "x": {
+                        "x": {
+                            "x": {}
+                        }
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "Unevaluated on 3rd level is invalid",
-                "data": { "x": { "x": { "x": {}, "y": {} } } },
+                "data": {
+                    "x": {
+                        "x": {
+                            "x": {},
+                            "y": {}
+                        }
+                    }
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedProperties + ref inside allOf / oneOf",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
                 "one": {
-                    "properties": { "a": true }
+                    "properties": {
+                        "a": true
+                    }
                 },
                 "two": {
-                    "required": ["x"],
-                    "properties": { "x": true }
+                    "required": [
+                        "x"
+                    ],
+                    "properties": {
+                        "x": true
+                    }
                 }
             },
             "allOf": [
-                { "$ref": "#/$defs/one" },
-                { "properties": { "b": true } },
+                {
+                    "$ref": "#/$defs/one"
+                },
+                {
+                    "properties": {
+                        "b": true
+                    }
+                },
                 {
                     "oneOf": [
-                        { "$ref": "#/$defs/two" },
                         {
-                            "required": ["y"],
-                            "properties": { "y": true }
+                            "$ref": "#/$defs/two"
+                        },
+                        {
+                            "required": [
+                                "y"
+                            ],
+                            "properties": {
+                                "y": true
+                            }
                         }
                     ]
                 }
@@ -1309,64 +1502,134 @@
             },
             {
                 "description": "a and b are invalid (no x or y)",
-                "data": { "a": 1, "b": 1 },
+                "data": {
+                    "a": 1,
+                    "b": 1
+                },
                 "valid": false
             },
             {
                 "description": "x and y are invalid",
-                "data": { "x": 1, "y": 1 },
+                "data": {
+                    "x": 1,
+                    "y": 1
+                },
                 "valid": false
             },
             {
                 "description": "a and x are valid",
-                "data": { "a": 1, "x": 1 },
+                "data": {
+                    "a": 1,
+                    "x": 1
+                },
                 "valid": true
             },
             {
                 "description": "a and y are valid",
-                "data": { "a": 1, "y": 1 },
+                "data": {
+                    "a": 1,
+                    "y": 1
+                },
                 "valid": true
             },
             {
                 "description": "a and b and x are valid",
-                "data": { "a": 1, "b": 1, "x": 1 },
+                "data": {
+                    "a": 1,
+                    "b": 1,
+                    "x": 1
+                },
                 "valid": true
             },
             {
                 "description": "a and b and y are valid",
-                "data": { "a": 1, "b": 1, "y": 1 },
+                "data": {
+                    "a": 1,
+                    "b": 1,
+                    "y": 1
+                },
                 "valid": true
             },
             {
                 "description": "a and b and x and y are invalid",
-                "data": { "a": 1, "b": 1, "x": 1, "y": 1 },
+                "data": {
+                    "a": 1,
+                    "b": 1,
+                    "x": 1,
+                    "y": 1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "dynamic evaluation inside nested refs",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "$defs": {
                 "one": {
                     "oneOf": [
-                        { "$ref": "#/$defs/two" },
-                        { "required": ["b"], "properties": { "b": true } },
-                        { "required": ["xx"], "patternProperties": { "x": true } },
-                        { "required": ["all"], "unevaluatedProperties": true }
+                        {
+                            "$ref": "#/$defs/two"
+                        },
+                        {
+                            "required": [
+                                "b"
+                            ],
+                            "properties": {
+                                "b": true
+                            }
+                        },
+                        {
+                            "required": [
+                                "xx"
+                            ],
+                            "patternProperties": {
+                                "x": true
+                            }
+                        },
+                        {
+                            "required": [
+                                "all"
+                            ],
+                            "unevaluatedProperties": true
+                        }
                     ]
                 },
                 "two": {
                     "oneOf": [
-                        { "required": ["c"], "properties": { "c": true } },
-                        { "required": ["d"], "properties": { "d": true } }
+                        {
+                            "required": [
+                                "c"
+                            ],
+                            "properties": {
+                                "c": true
+                            }
+                        },
+                        {
+                            "required": [
+                                "d"
+                            ],
+                            "properties": {
+                                "d": true
+                            }
+                        }
                     ]
                 }
             },
             "oneOf": [
-                { "$ref": "#/$defs/one" },
-                { "required": ["a"], "properties": { "a": true } }
+                {
+                    "$ref": "#/$defs/one"
+                },
+                {
+                    "required": [
+                        "a"
+                    ],
+                    "properties": {
+                        "a": true
+                    }
+                }
             ],
             "unevaluatedProperties": false
         },
@@ -1378,108 +1641,163 @@
             },
             {
                 "description": "a is valid",
-                "data": { "a": 1 },
+                "data": {
+                    "a": 1
+                },
                 "valid": true
             },
             {
                 "description": "b is valid",
-                "data": { "b": 1 },
+                "data": {
+                    "b": 1
+                },
                 "valid": true
             },
             {
                 "description": "c is valid",
-                "data": { "c": 1 },
+                "data": {
+                    "c": 1
+                },
                 "valid": true
             },
             {
                 "description": "d is valid",
-                "data": { "d": 1 },
+                "data": {
+                    "d": 1
+                },
                 "valid": true
             },
             {
                 "description": "a + b is invalid",
-                "data": { "a": 1, "b": 1 },
+                "data": {
+                    "a": 1,
+                    "b": 1
+                },
                 "valid": false
             },
             {
                 "description": "a + c is invalid",
-                "data": { "a": 1, "c": 1 },
+                "data": {
+                    "a": 1,
+                    "c": 1
+                },
                 "valid": false
             },
             {
                 "description": "a + d is invalid",
-                "data": { "a": 1, "d": 1 },
+                "data": {
+                    "a": 1,
+                    "d": 1
+                },
                 "valid": false
             },
             {
                 "description": "b + c is invalid",
-                "data": { "b": 1, "c": 1 },
+                "data": {
+                    "b": 1,
+                    "c": 1
+                },
                 "valid": false
             },
             {
                 "description": "b + d is invalid",
-                "data": { "b": 1, "d": 1 },
+                "data": {
+                    "b": 1,
+                    "d": 1
+                },
                 "valid": false
             },
             {
                 "description": "c + d is invalid",
-                "data": { "c": 1, "d": 1 },
+                "data": {
+                    "c": 1,
+                    "d": 1
+                },
                 "valid": false
             },
             {
                 "description": "xx is valid",
-                "data": { "xx": 1 },
+                "data": {
+                    "xx": 1
+                },
                 "valid": true
             },
             {
                 "description": "xx + foox is valid",
-                "data": { "xx": 1, "foox": 1 },
+                "data": {
+                    "xx": 1,
+                    "foox": 1
+                },
                 "valid": true
             },
             {
                 "description": "xx + foo is invalid",
-                "data": { "xx": 1, "foo": 1 },
+                "data": {
+                    "xx": 1,
+                    "foo": 1
+                },
                 "valid": false
             },
             {
                 "description": "xx + a is invalid",
-                "data": { "xx": 1, "a": 1 },
+                "data": {
+                    "xx": 1,
+                    "a": 1
+                },
                 "valid": false
             },
             {
                 "description": "xx + b is invalid",
-                "data": { "xx": 1, "b": 1 },
+                "data": {
+                    "xx": 1,
+                    "b": 1
+                },
                 "valid": false
             },
             {
                 "description": "xx + c is invalid",
-                "data": { "xx": 1, "c": 1 },
+                "data": {
+                    "xx": 1,
+                    "c": 1
+                },
                 "valid": false
             },
             {
                 "description": "xx + d is invalid",
-                "data": { "xx": 1, "d": 1 },
+                "data": {
+                    "xx": 1,
+                    "d": 1
+                },
                 "valid": false
             },
             {
                 "description": "all is valid",
-                "data": { "all": 1 },
+                "data": {
+                    "all": 1
+                },
                 "valid": true
             },
             {
                 "description": "all + foo is valid",
-                "data": { "all": 1, "foo": 1 },
+                "data": {
+                    "all": 1,
+                    "foo": 1
+                },
                 "valid": true
             },
             {
                 "description": "all + a is invalid",
-                "data": { "all": 1, "a": 1 },
+                "data": {
+                    "all": 1,
+                    "a": 1
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "non-object instances are valid",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedProperties": false
@@ -1519,6 +1837,7 @@
     },
     {
         "description": "unevaluatedProperties with null valued instance properties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "unevaluatedProperties": {
@@ -1528,16 +1847,21 @@
         "tests": [
             {
                 "description": "allows null valued properties",
-                "data": {"foo": null},
+                "data": {
+                    "foo": null
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "unevaluatedProperties not affected by propertyNames",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "propertyNames": {"maxLength": 1},
+            "propertyNames": {
+                "maxLength": 1
+            },
             "unevaluatedProperties": {
                 "type": "number"
             }
@@ -1545,18 +1869,23 @@
         "tests": [
             {
                 "description": "allows only number properties",
-                "data": {"a": 1},
+                "data": {
+                    "a": 1
+                },
                 "valid": true
             },
             {
                 "description": "string property is invalid",
-                "data": {"a": "b"},
+                "data": {
+                    "a": "b"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "unevaluatedProperties can see annotations from if without then and else",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "if": {
@@ -1587,14 +1916,17 @@
     },
     {
         "description": "dependentSchemas with unevaluatedProperties",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "properties": {"foo2": {}},
+            "properties": {
+                "foo2": {}
+            },
             "dependentSchemas": {
-                "foo" : {},
+                "foo": {},
                 "foo2": {
                     "properties": {
-                        "bar":{}
+                        "bar": {}
                     }
                 }
             },
@@ -1603,29 +1935,39 @@
         "tests": [
             {
                 "description": "unevaluatedProperties doesn't consider dependentSchemas",
-                "data": {"foo": ""},
+                "data": {
+                    "foo": ""
+                },
                 "valid": false
             },
             {
                 "description": "unevaluatedProperties doesn't see bar when foo2 is absent",
-                "data": {"bar": ""},
+                "data": {
+                    "bar": ""
+                },
                 "valid": false
             },
             {
                 "description": "unevaluatedProperties sees bar when foo2 is present",
-                "data": {"foo2": "", "bar": ""},
+                "data": {
+                    "foo2": "",
+                    "bar": ""
+                },
                 "valid": true
             }
         ]
     },
     {
         "description": "Evaluated properties collection needs to consider instance location",
+        "compatibility": "2019",
         "schema": {
             "$schema": "https://json-schema.org/v1",
             "properties": {
                 "foo": {
                     "properties": {
-                        "bar": { "type": "string" }
+                        "bar": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -1635,7 +1977,9 @@
             {
                 "description": "with an unevaluated property that exists at another location",
                 "data": {
-                    "foo": { "bar": "foo" },
+                    "foo": {
+                        "bar": "foo"
+                    },
                     "bar": "bar"
                 },
                 "valid": false

--- a/tests/v1/uniqueItems.json
+++ b/tests/v1/uniqueItems.json
@@ -8,234 +8,493 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is invalid",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "non-unique array of more than two integers is invalid",
-                "data": [1, 2, 1],
+                "data": [
+                    1,
+                    2,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "numbers are unique if mathematically unequal",
-                "data": [1.0, 1.00, 1],
+                "data": [
+                    1.0,
+                    1.0,
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "false is not equal to zero",
-                "data": [0, false],
+                "data": [
+                    0,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "true is not equal to one",
-                "data": [1, true],
+                "data": [
+                    1,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "unique array of strings is valid",
-                "data": ["foo", "bar", "baz"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of strings is invalid",
-                "data": ["foo", "bar", "foo"],
+                "data": [
+                    "foo",
+                    "bar",
+                    "foo"
+                ],
                 "valid": false
             },
             {
                 "description": "unique array of objects is valid",
-                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "data": [
+                    {
+                        "foo": "bar"
+                    },
+                    {
+                        "foo": "baz"
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of objects is invalid",
-                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "data": [
+                    {
+                        "foo": "bar"
+                    },
+                    {
+                        "foo": "bar"
+                    }
+                ],
                 "valid": false
             },
             {
                 "description": "property order of array of objects is ignored",
-                "data": [{"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}],
+                "data": [
+                    {
+                        "foo": "bar",
+                        "bar": "foo"
+                    },
+                    {
+                        "bar": "foo",
+                        "foo": "bar"
+                    }
+                ],
                 "valid": false
             },
             {
                 "description": "unique array of nested objects is valid",
                 "data": [
-                    {"foo": {"bar" : {"baz" : true}}},
-                    {"foo": {"bar" : {"baz" : false}}}
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    },
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": false
+                            }
+                        }
+                    }
                 ],
                 "valid": true
             },
             {
                 "description": "non-unique array of nested objects is invalid",
                 "data": [
-                    {"foo": {"bar" : {"baz" : true}}},
-                    {"foo": {"bar" : {"baz" : true}}}
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    },
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    }
                 ],
                 "valid": false
             },
             {
                 "description": "unique array of arrays is valid",
-                "data": [["foo"], ["bar"]],
+                "data": [
+                    [
+                        "foo"
+                    ],
+                    [
+                        "bar"
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of arrays is invalid",
-                "data": [["foo"], ["foo"]],
+                "data": [
+                    [
+                        "foo"
+                    ],
+                    [
+                        "foo"
+                    ]
+                ],
                 "valid": false
             },
             {
                 "description": "non-unique array of more than two arrays is invalid",
-                "data": [["foo"], ["bar"], ["foo"]],
+                "data": [
+                    [
+                        "foo"
+                    ],
+                    [
+                        "bar"
+                    ],
+                    [
+                        "foo"
+                    ]
+                ],
                 "valid": false
             },
             {
                 "description": "1 and true are unique",
-                "data": [1, true],
+                "data": [
+                    1,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "0 and false are unique",
-                "data": [0, false],
+                "data": [
+                    0,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[1] and [true] are unique",
-                "data": [[1], [true]],
+                "data": [
+                    [
+                        1
+                    ],
+                    [
+                        true
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "[0] and [false] are unique",
-                "data": [[0], [false]],
+                "data": [
+                    [
+                        0
+                    ],
+                    [
+                        false
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "nested [1] and [true] are unique",
-                "data": [[[1], "foo"], [[true], "foo"]],
+                "data": [
+                    [
+                        [
+                            1
+                        ],
+                        "foo"
+                    ],
+                    [
+                        [
+                            true
+                        ],
+                        "foo"
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "nested [0] and [false] are unique",
-                "data": [[[0], "foo"], [[false], "foo"]],
+                "data": [
+                    [
+                        [
+                            0
+                        ],
+                        "foo"
+                    ],
+                    [
+                        [
+                            false
+                        ],
+                        "foo"
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1, "{}"],
+                "data": [
+                    {},
+                    [
+                        1
+                    ],
+                    true,
+                    null,
+                    1,
+                    "{}"
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are invalid",
-                "data": [{}, [1], true, null, {}, 1],
+                "data": [
+                    {},
+                    [
+                        1
+                    ],
+                    true,
+                    null,
+                    {},
+                    1
+                ],
                 "valid": false
             },
             {
                 "description": "different objects are unique",
-                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "data": [
+                    {
+                        "a": 1,
+                        "b": 2
+                    },
+                    {
+                        "a": 2,
+                        "b": 1
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "objects are non-unique despite key order",
-                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "data": [
+                    {
+                        "a": 1,
+                        "b": 2
+                    },
+                    {
+                        "b": 2,
+                        "a": 1
+                    }
+                ],
                 "valid": false
             },
             {
                 "description": "{\"a\": false} and {\"a\": 0} are unique",
-                "data": [{"a": false}, {"a": 0}],
+                "data": [
+                    {
+                        "a": false
+                    },
+                    {
+                        "a": 0
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "{\"a\": true} and {\"a\": 1} are unique",
-                "data": [{"a": true}, {"a": 1}],
+                "data": [
+                    {
+                        "a": true
+                    },
+                    {
+                        "a": 1
+                    }
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "uniqueItems with an array of items",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "prefixItems": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
             "uniqueItems": true
         },
         "tests": [
             {
                 "description": "[false, true] from items array is valid",
-                "data": [false, true],
+                "data": [
+                    false,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[true, false] from items array is valid",
-                "data": [true, false],
+                "data": [
+                    true,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[false, false] from items array is not valid",
-                "data": [false, false],
+                "data": [
+                    false,
+                    false
+                ],
                 "valid": false
             },
             {
                 "description": "[true, true] from items array is not valid",
-                "data": [true, true],
+                "data": [
+                    true,
+                    true
+                ],
                 "valid": false
             },
             {
                 "description": "unique array extended from [false, true] is valid",
-                "data": [false, true, "foo", "bar"],
+                "data": [
+                    false,
+                    true,
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "unique array extended from [true, false] is valid",
-                "data": [true, false, "foo", "bar"],
+                "data": [
+                    true,
+                    false,
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array extended from [false, true] is not valid",
-                "data": [false, true, "foo", "foo"],
+                "data": [
+                    false,
+                    true,
+                    "foo",
+                    "foo"
+                ],
                 "valid": false
             },
             {
                 "description": "non-unique array extended from [true, false] is not valid",
-                "data": [true, false, "foo", "foo"],
+                "data": [
+                    true,
+                    false,
+                    "foo",
+                    "foo"
+                ],
                 "valid": false
             }
         ]
     },
     {
         "description": "uniqueItems with an array of items and additionalItems=false",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "prefixItems": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
             "uniqueItems": true,
             "items": false
         },
         "tests": [
             {
                 "description": "[false, true] from items array is valid",
-                "data": [false, true],
+                "data": [
+                    false,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[true, false] from items array is valid",
-                "data": [true, false],
+                "data": [
+                    true,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[false, false] from items array is not valid",
-                "data": [false, false],
+                "data": [
+                    false,
+                    false
+                ],
                 "valid": false
             },
             {
                 "description": "[true, true] from items array is not valid",
-                "data": [true, true],
+                "data": [
+                    true,
+                    true
+                ],
                 "valid": false
             },
             {
                 "description": "extra items are invalid even if unique",
-                "data": [false, true, null],
+                "data": [
+                    false,
+                    true,
+                    null
+                ],
                 "valid": false
             }
         ]
@@ -249,169 +508,324 @@
         "tests": [
             {
                 "description": "unique array of integers is valid",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of integers is valid",
-                "data": [1, 1],
+                "data": [
+                    1,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "numbers are unique if mathematically unequal",
-                "data": [1.0, 1.00, 1],
+                "data": [
+                    1.0,
+                    1.0,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "false is not equal to zero",
-                "data": [0, false],
+                "data": [
+                    0,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "true is not equal to one",
-                "data": [1, true],
+                "data": [
+                    1,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "unique array of objects is valid",
-                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "data": [
+                    {
+                        "foo": "bar"
+                    },
+                    {
+                        "foo": "baz"
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of objects is valid",
-                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "data": [
+                    {
+                        "foo": "bar"
+                    },
+                    {
+                        "foo": "bar"
+                    }
+                ],
                 "valid": true
             },
             {
                 "description": "unique array of nested objects is valid",
                 "data": [
-                    {"foo": {"bar" : {"baz" : true}}},
-                    {"foo": {"bar" : {"baz" : false}}}
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    },
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": false
+                            }
+                        }
+                    }
                 ],
                 "valid": true
             },
             {
                 "description": "non-unique array of nested objects is valid",
                 "data": [
-                    {"foo": {"bar" : {"baz" : true}}},
-                    {"foo": {"bar" : {"baz" : true}}}
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    },
+                    {
+                        "foo": {
+                            "bar": {
+                                "baz": true
+                            }
+                        }
+                    }
                 ],
                 "valid": true
             },
             {
                 "description": "unique array of arrays is valid",
-                "data": [["foo"], ["bar"]],
+                "data": [
+                    [
+                        "foo"
+                    ],
+                    [
+                        "bar"
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array of arrays is valid",
-                "data": [["foo"], ["foo"]],
+                "data": [
+                    [
+                        "foo"
+                    ],
+                    [
+                        "foo"
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "1 and true are unique",
-                "data": [1, true],
+                "data": [
+                    1,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "0 and false are unique",
-                "data": [0, false],
+                "data": [
+                    0,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, 1],
+                "data": [
+                    {},
+                    [
+                        1
+                    ],
+                    true,
+                    null,
+                    1
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique heterogeneous types are valid",
-                "data": [{}, [1], true, null, {}, 1],
+                "data": [
+                    {},
+                    [
+                        1
+                    ],
+                    true,
+                    null,
+                    {},
+                    1
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "uniqueItems=false with an array of items",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "prefixItems": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
             "uniqueItems": false
         },
         "tests": [
             {
                 "description": "[false, true] from items array is valid",
-                "data": [false, true],
+                "data": [
+                    false,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[true, false] from items array is valid",
-                "data": [true, false],
+                "data": [
+                    true,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[false, false] from items array is valid",
-                "data": [false, false],
+                "data": [
+                    false,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[true, true] from items array is valid",
-                "data": [true, true],
+                "data": [
+                    true,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "unique array extended from [false, true] is valid",
-                "data": [false, true, "foo", "bar"],
+                "data": [
+                    false,
+                    true,
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "unique array extended from [true, false] is valid",
-                "data": [true, false, "foo", "bar"],
+                "data": [
+                    true,
+                    false,
+                    "foo",
+                    "bar"
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array extended from [false, true] is valid",
-                "data": [false, true, "foo", "foo"],
+                "data": [
+                    false,
+                    true,
+                    "foo",
+                    "foo"
+                ],
                 "valid": true
             },
             {
                 "description": "non-unique array extended from [true, false] is valid",
-                "data": [true, false, "foo", "foo"],
+                "data": [
+                    true,
+                    false,
+                    "foo",
+                    "foo"
+                ],
                 "valid": true
             }
         ]
     },
     {
         "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "compatibility": "=2020",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "prefixItems": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
             "uniqueItems": false,
             "items": false
         },
         "tests": [
             {
                 "description": "[false, true] from items array is valid",
-                "data": [false, true],
+                "data": [
+                    false,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "[true, false] from items array is valid",
-                "data": [true, false],
+                "data": [
+                    true,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[false, false] from items array is valid",
-                "data": [false, false],
+                "data": [
+                    false,
+                    false
+                ],
                 "valid": true
             },
             {
                 "description": "[true, true] from items array is valid",
-                "data": [true, true],
+                "data": [
+                    true,
+                    true
+                ],
                 "valid": true
             },
             {
                 "description": "extra items are invalid even if unique",
-                "data": [false, true, null],
+                "data": [
+                    false,
+                    true,
+                    null
+                ],
                 "valid": false
             }
         ]


### PR DESCRIPTION
## Summary
- add `compatibility` support to the validation suite schema
- teach `bin/jsonschema_suite` to filter and rewrite `tests/v1` for a concrete dialect
- annotate the unified `tests/v1` cases with compatibility metadata
- document the new runner expectations for the unified suite
- fix the suite checker to read JSON files as UTF-8 on Windows

## Verification
- `python bin/jsonschema_suite check`
- `python bin/jsonschema_suite flatten --dialect draft7 tests/v1/pattern.json`
- `python bin/jsonschema_suite flatten --dialect draft2020-12 tests/v1/optional/format-annotation.json`

## Notes
- this keeps the legacy per-draft directories in place for now while making `tests/v1` consumable by runners
- the compatibility metadata was inferred in bulk from the existing per-draft files, with targeted overrides for renamed or unified-only cases
