### PR TITLE
multipleOf: support negative values

### DIFF
--- a/tests/draft2019-09/multipleOf.json
+++ b/tests/draft2019-09/multipleOf.json
@@ -41,6 +41,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/draft2020-12/multipleOf.json
+++ b/tests/draft2020-12/multipleOf.json
@@ -41,6 +41,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/draft3/divisibleBy.json
+++ b/tests/draft3/divisibleBy.json
@@ -35,6 +35,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is divisible by 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not divisible by 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/draft4/multipleOf.json
+++ b/tests/draft4/multipleOf.json
@@ -35,6 +35,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/draft6/multipleOf.json
+++ b/tests/draft6/multipleOf.json
@@ -35,6 +35,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/draft7/multipleOf.json
+++ b/tests/draft7/multipleOf.json
@@ -35,6 +35,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false

--- a/tests/v1/multipleOf.json
+++ b/tests/v1/multipleOf.json
@@ -41,6 +41,11 @@
                 "valid": true
             },
             {
+                "description": "-4.5 is multiple of 1.5",
+                "data": -4.5,
+                "valid": true
+            },
+            {
                 "description": "35 is not multiple of 1.5",
                 "data": 35,
                 "valid": false


### PR DESCRIPTION
According to the spec, it's perfectly valid for a negative number to be a multipleOf a positive one:

https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.1

```
[6.2.1.](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.1) multipleOf
The value of "multipleOf" MUST be a number, strictly greater than 0.

A numeric instance is valid only if division by this keyword's value results in an integer.
```

-4.5/1.5 = -3, which is an integer!

I found this because https://github.com/Stranger6667/jsonschema only admits positive multiples, which I don't think is correct per the spec, but has a 100% pass rate.