### PR TITLE
refOfUnknownKeyword.json rm unused $id

### DIFF
--- a/tests/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/tests/draft2019-09/optional/refOfUnknownKeyword.json
@@ -69,7 +69,6 @@
         "description": "reference internals of known non-applicator",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "/base",
             "examples": [
               { "type": "string" }
             ],

--- a/tests/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/tests/draft2020-12/optional/refOfUnknownKeyword.json
@@ -69,7 +69,6 @@
         "description": "reference internals of known non-applicator",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "/base",
             "examples": [
               { "type": "string" }
             ],

--- a/tests/v1/optional/refOfUnknownKeyword.json
+++ b/tests/v1/optional/refOfUnknownKeyword.json
@@ -69,7 +69,6 @@
         "description": "reference internals of known non-applicator",
         "schema": {
             "$schema": "https://json-schema.org/v1",
-            "$id": "/base",
             "examples": [
               { "type": "string" }
             ],


### PR DESCRIPTION
This $id is not referenced. Since it's relative, this showed up in my linting as an error, that it could not be resolved without a base URI. (I could instead add a base URI in my linting but since the id is unused seems simplest to remove it.)