### PR TITLE
test(hostname): move XN-- positions-3-4 test to A-label group

### DIFF
--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -102,12 +102,6 @@
                 "valid": false
             },
             {
-                "description": "contains \"--\" in the 3rd and 4th position",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
-                "data": "XN--aa---o47jg78q",
-                "valid": false
-            },
-            {
                 "description": "contains underscore",
                 "data": "host_name",
                 "valid": false
@@ -355,6 +349,12 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "xn--ngba5hb2804a",
                 "valid": true
+            },
+            {
+                "description": "contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -102,12 +102,6 @@
                 "valid": false
             },
             {
-                "description": "contains \"--\" in the 3rd and 4th position",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
-                "data": "XN--aa---o47jg78q",
-                "valid": false
-            },
-            {
                 "description": "contains underscore",
                 "data": "host_name",
                 "valid": false
@@ -355,6 +349,12 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "xn--ngba5hb2804a",
                 "valid": true
+            },
+            {
+                "description": "contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -99,12 +99,6 @@
                 "valid": false
             },
             {
-                "description": "contains \"--\" in the 3rd and 4th position",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
-                "data": "XN--aa---o47jg78q",
-                "valid": false
-            },
-            {
                 "description": "contains underscore",
                 "data": "host_name",
                 "valid": false
@@ -349,6 +343,12 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "xn--ngba5hb2804a",
                 "valid": true
+            },
+            {
+                "description": "contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -102,12 +102,6 @@
                 "valid": false
             },
             {
-                "description": "contains \"--\" in the 3rd and 4th position",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
-                "data": "XN--aa---o47jg78q",
-                "valid": false
-            },
-            {
                 "description": "contains underscore",
                 "data": "host_name",
                 "valid": false
@@ -355,6 +349,12 @@
                 "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
                 "data": "xn--ngba5hb2804a",
                 "valid": true
+            },
+            {
+                "description": "contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
## Description:

**Problem:**
Test 20 in Group 1 ("validation of host names") marks `XN--aa---o47jg78q` as `valid: false` citing [RFC 5891 §4.2.3.1](https://tools.ietf.org/html/rfc5891#section-4.2.3.1) and [RFC 5890 §2.3.2.1.](https://tools.ietf.org/html/rfc5890#section-2.3.2.1) These are IDNA2008 RFCs. Group 1 is scoped to RFC 1123 §2.1 which has no positions-3-4 rule.

**Evidence of inconsistency:**
draft4 accepts `xn--4gbwdl.xn--wgbh1c` in Group 1 as `valid: true` - same structural pattern (xn-- prefix with -- at positions 3-4). draft4 has no Group 2 so no IDNA2008 tests exist there at all.

**Fix:**
Move `XN--aa---o47jg78q` from Group 1 to Group 2 ("validation of A-label (punycode) host names") in draft7, draft2019-09, draft2020-12, and v1. Group 2 already contains all other RFC 5891/5892 tests - this test belongs there.

draft4 and draft6 have no Group 2 so no changes needed for those drafts.

**Result:**
Group 1 becomes purely RFC 1123 §2.1 scope across all drafts. Group 2 contains all IDNA2008 tests including this one.

