### PR TITLE
Do not use `definitions` sibling to `$ref` in `ref.json` for Draft 3

### DIFF
--- a/tests/draft3/ref.json
+++ b/tests/draft3/ref.json
@@ -127,7 +127,9 @@
                 "b": {"$ref": "#/definitions/a"},
                 "c": {"$ref": "#/definitions/b"}
             },
-            "$ref": "#/definitions/c"
+            "extends": {
+                "$ref": "#/definitions/c"
+            }    
         },
         "tests": [
             {


### PR DESCRIPTION
I'm extending Blaze to support Draft 3. As per the spec (applies to all drafts up to 7), a `$ref` overrides any sibling keyword. This seems to be the only case in the test suite where we do this.