### PR TITLE
test(format/date): remove duplicate cases and expand full-date boundary coverage

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {
@@ -292,6 +272,71 @@
                 "description": "invalid: day 00 is not valid per date-mday minimum of 01",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#section-5.6 — date-mday = 2DIGIT ; 01-28/29/30/31",
                 "data": "2024-01-00",
+                "valid": false
+            },
+            {
+                "description": "invalid: empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "invalid: embedded whitespace between year and month",
+                "data": "2020 -01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing character after valid full-date",
+                "data": "2020-01-01X",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing Z after full-date",
+                "data": "2020-01-01Z",
+                "valid": false
+            },
+            {
+                "description": "invalid: full-date followed by space and time component",
+                "data": "2020-01-01 00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "valid: four-digit year 0001",
+                "data": "0001-01-01",
+                "valid": true
+            },
+            {
+                "description": "invalid: two-digit year (N-2 digits)",
+                "data": "20-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit year (N-1 digits)",
+                "data": "998-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: five-digit year (N+1 digits)",
+                "data": "12020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: positive sign prefix on year",
+                "data": "+2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: negative sign prefix on year",
+                "data": "-2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII Bengali digit in year field",
+                "data": "২020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in year field",
+                "data": "YYYY-01-01",
                 "valid": false
             }
         ]

--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {
@@ -292,6 +272,71 @@
                 "description": "invalid: day 00 is not valid per date-mday minimum of 01",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#section-5.6 — date-mday = 2DIGIT ; 01-28/29/30/31",
                 "data": "2024-01-00",
+                "valid": false
+            },
+            {
+                "description": "invalid: empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "invalid: embedded whitespace between year and month",
+                "data": "2020 -01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing character after valid full-date",
+                "data": "2020-01-01X",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing Z after full-date",
+                "data": "2020-01-01Z",
+                "valid": false
+            },
+            {
+                "description": "invalid: full-date followed by space and time component",
+                "data": "2020-01-01 00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "valid: four-digit year 0001",
+                "data": "0001-01-01",
+                "valid": true
+            },
+            {
+                "description": "invalid: two-digit year (N-2 digits)",
+                "data": "20-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit year (N-1 digits)",
+                "data": "998-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: five-digit year (N+1 digits)",
+                "data": "12020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: positive sign prefix on year",
+                "data": "+2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: negative sign prefix on year",
+                "data": "-2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII Bengali digit in year field",
+                "data": "২020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in year field",
+                "data": "YYYY-01-01",
                 "valid": false
             }
         ]

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -54,16 +54,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -169,11 +159,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -196,11 +181,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -54,16 +54,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -169,11 +159,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -196,11 +181,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {
@@ -289,6 +269,71 @@
                 "description": "invalid: day 00 is not valid per date-mday minimum of 01",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#section-5.6 — date-mday = 2DIGIT ; 01-28/29/30/31",
                 "data": "2024-01-00",
+                "valid": false
+            },
+            {
+                "description": "invalid: empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "invalid: embedded whitespace between year and month",
+                "data": "2020 -01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing character after valid full-date",
+                "data": "2020-01-01X",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing Z after full-date",
+                "data": "2020-01-01Z",
+                "valid": false
+            },
+            {
+                "description": "invalid: full-date followed by space and time component",
+                "data": "2020-01-01 00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "valid: four-digit year 0001",
+                "data": "0001-01-01",
+                "valid": true
+            },
+            {
+                "description": "invalid: two-digit year (N-2 digits)",
+                "data": "20-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit year (N-1 digits)",
+                "data": "998-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: five-digit year (N+1 digits)",
+                "data": "12020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: positive sign prefix on year",
+                "data": "+2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: negative sign prefix on year",
+                "data": "-2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII Bengali digit in year field",
+                "data": "২020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in year field",
+                "data": "YYYY-01-01",
                 "valid": false
             }
         ]

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {
@@ -292,6 +272,71 @@
                 "description": "invalid: day 00 is not valid per date-mday minimum of 01",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#section-5.6 — date-mday = 2DIGIT ; 01-28/29/30/31",
                 "data": "2024-01-00",
+                "valid": false
+            },
+            {
+                "description": "invalid: empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "invalid: embedded whitespace between year and month",
+                "data": "2020 -01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing character after valid full-date",
+                "data": "2020-01-01X",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing Z after full-date",
+                "data": "2020-01-01Z",
+                "valid": false
+            },
+            {
+                "description": "invalid: full-date followed by space and time component",
+                "data": "2020-01-01 00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "valid: four-digit year 0001",
+                "data": "0001-01-01",
+                "valid": true
+            },
+            {
+                "description": "invalid: two-digit year (N-2 digits)",
+                "data": "20-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit year (N-1 digits)",
+                "data": "998-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: five-digit year (N+1 digits)",
+                "data": "12020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: positive sign prefix on year",
+                "data": "+2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: negative sign prefix on year",
+                "data": "-2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII Bengali digit in year field",
+                "data": "২020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in year field",
+                "data": "YYYY-01-01",
                 "valid": false
             }
         ]

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {


### PR DESCRIPTION
Applies to: draft-04, draft-07, draft/2019-09, draft/2020-12

Removes 4 duplicate cases and adds 13 new cases across two related character-level categories: string-level boundaries and year-field format. 

Removed:
- "2020-13-01" duplicates "1998-13-01"
- "1998-04-31" duplicates "2020-04-31"
- "2021-02-29" and "2020-02-29" in the per-month block duplicate the standalone leap year cases

Added (string-level boundaries):
- Empty string
- Embedded whitespace between year and month
- Trailing character, trailing Z, and space-separated datetime suffix

Added (year-field format):
- Valid four-digit year 0001 (lower bound)
- Two-digit, three-digit, and five-digit year
- Positive and negative sign prefix on year
- Non-ASCII Bengali digit in year field
- Alphabetic characters in year field

@jviotti @jdesrosiers @karenetheridge Ready for review. I've grouped these two character-level categories (boundaries and year-format) into this single PR.