### PR TITLE
test: remove date format cases

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -54,16 +54,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -169,11 +159,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -196,11 +181,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -57,16 +57,6 @@
                 "valid": true
             },
             {
-                "description": "a invalid date string with 29 days in February (normal)",
-                "data": "2021-02-29",
-                "valid": false
-            },
-            {
-                "description": "a valid date string with 29 days in February (leap)",
-                "data": "2020-02-29",
-                "valid": true
-            },
-            {
                 "description": "a invalid date string with 30 days in February (leap)",
                 "data": "2020-02-30",
                 "valid": false
@@ -172,11 +162,6 @@
                 "valid": false
             },
             {
-                "description": "a invalid date string with invalid month",
-                "data": "2020-13-01",
-                "valid": false
-            },
-            {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
                 "valid": false
@@ -199,11 +184,6 @@
             {
                 "description": "invalid month",
                 "data": "1998-13-01",
-                "valid": false
-            },
-            {
-                "description": "invalid month-day combination",
-                "data": "1998-04-31",
                 "valid": false
             },
             {


### PR DESCRIPTION
## Summary

This PR removes four duplicate date tests in draft-v1, draft-07, draft/2019-09, and draft/2020-12. These tests are already covered by other cases in the suite.

## Changes

* **Remove 2021-02-29:** This is already tested by "2021 is not a leap year".
* **Remove 2020-02-29:** This is already tested by "2020 is a leap year".
* **Remove 2020-13-01:** This is already tested by "invalid month".
* **Remove 1998-04-31:** This is already tested by "31 days in April".

## Notes

@jviotti @jdesrosiers @karenetheridge This PR only handles the removal of duplicates. 