### PR TITLE
Add null and boolean tests for object-only keywords

### DIFF
--- a/tests/draft2019-09/minProperties.json
+++ b/tests/draft2019-09/minProperties.json
@@ -35,6 +35,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft2019-09/propertyNames.json
+++ b/tests/draft2019-09/propertyNames.json
@@ -41,6 +41,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft2020-12/minProperties.json
+++ b/tests/draft2020-12/minProperties.json
@@ -35,6 +35,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft2020-12/propertyNames.json
+++ b/tests/draft2020-12/propertyNames.json
@@ -41,6 +41,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft4/minProperties.json
+++ b/tests/draft4/minProperties.json
@@ -32,6 +32,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/minProperties.json
+++ b/tests/draft6/minProperties.json
@@ -32,6 +32,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft6/propertyNames.json
+++ b/tests/draft6/propertyNames.json
@@ -40,6 +40,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft7/minProperties.json
+++ b/tests/draft7/minProperties.json
@@ -32,6 +32,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/draft7/propertyNames.json
+++ b/tests/draft7/propertyNames.json
@@ -40,6 +40,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/v1/minProperties.json
+++ b/tests/v1/minProperties.json
@@ -35,6 +35,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },

--- a/tests/v1/propertyNames.json
+++ b/tests/v1/propertyNames.json
@@ -41,6 +41,16 @@
                 "description": "ignores other non-objects",
                 "data": 12,
                 "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
## Description

Following #827, this adds `null` and boolean tests to `minProperties` and `propertyNames`.

Both keywords apply only to objects. A JavaScript implementation that checks `typeof data === "object"` can accidentally apply these keywords to `null`, because `typeof null === "object"`.

The existing numeric non-object tests do not catch this issue, since `typeof 12 === "number"` correctly bypasses object-only validation.

## Changes

- Added `"ignores null"` test cases.
- Added `"ignores booleans"` test cases.
- Applied across affected drafts for `minProperties` and `propertyNames`.

## Verification

- Confirmed all touched JSON files parse successfully.
- Ran `bin/jsonschema_suite check`; it fails on unrelated existing checker failures around `default` being treated as an unknown keyword in older drafts.