### PR TITLE
test(format/date): expand full-date boundary coverage

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -337,6 +342,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -337,6 +342,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -199,6 +199,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -334,6 +339,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -337,6 +342,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]


### PR DESCRIPTION
Applies to: draft-v1, draft-07, draft/2019-09, draft/2020-12

Adds 9 new cases covering field-level character and range validation for the month and day fields. Kept in one PR as all cases target the same two adjacent fields in the RFC 3339 section 5.6 full-date grammar.

Added (date-month field):
- Three-digit month (N+1 digits)
- Non-ASCII Bengali digit in month field
- Alphabetic characters in month field
- Month 99 far above ceiling

Added (date-mday field):
- Three-digit day (N+1 digits)
- Non-ASCII Arabic-Indic digit in day field
- Alphabetic characters in day field
- Valid day at floor 01 in January
- Day 99 far above any month ceiling

@jviotti @jdesrosiers @karenetheridge Ready for review.