### PR TITLE
Add unevaluatedProperties instance location coverage

### DIFF
--- a/tests/draft2019-09/unevaluatedProperties.json
+++ b/tests/draft2019-09/unevaluatedProperties.json
@@ -1651,5 +1651,65 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {
+                    "patternProperties": {
+                        "^bar$": { "type": "string" }
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/unevaluatedProperties.json
+++ b/tests/draft2020-12/unevaluatedProperties.json
@@ -1617,5 +1617,65 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "patternProperties": {
+                        "^bar$": { "type": "string" }
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
     }
 ]

--- a/tests/v1/unevaluatedProperties.json
+++ b/tests/v1/unevaluatedProperties.json
@@ -1641,5 +1641,65 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "properties": {
+                "foo": {
+                    "patternProperties": {
+                        "^bar$": { "type": "string" }
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Evaluated properties collection needs to consider instance location with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "properties": {
+                "foo": {
+                    "additionalProperties": { "type": "string" }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with only the nested evaluated property",
+                "data": {
+                    "foo": { "bar": "foo" }
+                },
+                "valid": true
+            },
+            {
+                "description": "with an unevaluated property that exists at another location",
+                "data": {
+                    "foo": { "bar": "foo" },
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Resolves #889 

Adds additional coverage for evaluated property collection respecting instance location.

This extends the existing unevaluatedProperties test coverage for draft 2019-09 and draft 2020-12 with related cases for:

- patternProperties
- additionalProperties

Each case verifies that a property evaluated inside a nested object does not cause a same-named property at another instance location to be treated as evaluated.

Validation:
- Edited JSON files parse successfully
- git diff --check passes

Note: Full bin/jsonschema_suite check currently fails locally on unrelated older-draft sanity checks involving `default` as an unknown keyword.