### PR TITLE
Fix Draft 3 `ecmascript-regex` look-behind test

### DIFF
--- a/tests/draft3/optional/format/ecmascript-regex.json
+++ b/tests/draft3/optional/format/ecmascript-regex.json
@@ -9,8 +9,13 @@
                 "valid": true
             },
             {
-                "description": "ECMA 262 has no support for lookbehind",
+                "description": "ECMA 262 supports lookbehind since ES2018",
                 "data": "(?<=foo)bar",
+                "valid": true
+            },
+            {
+                "description": "ECMA 262 does not support Python-style named groups",
+                "data": "(?P<name>x)",
                 "valid": false
             }
         ]


### PR DESCRIPTION
Lookbehind assertions were added to ECMA-262 in ES2018 and are accepted by every modern JavaScript engine, so `(?<=foo)bar` is in fact a valid ECMA 262 regex (try it in Node.js). The existing test asserting no longer reflects the specification.

I know we discourage work on older drafts but bear with me! I need good Draft 3 support for my auto-upgrades :)