### PR TITLE
test(ipv4): add fullwidth and astral non-ASCII digit octets

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -73,6 +73,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -73,6 +73,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -70,6 +70,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -70,6 +70,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -70,6 +70,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -73,6 +73,16 @@
                 "valid": false
             },
             {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
+                "valid": false
+            },
+            {
                 "description": "netmask is not a part of ipv4 address",
                 "data": "192.168.1.0/24",
                 "valid": false


### PR DESCRIPTION
Adds two non-ASCII digit forms for ipv4, complementing the existing Bengali-digit case. Both invalid per RFC 2673 / RFC 5234 (DIGIT is %x30-39, ASCII only):

- fullwidth digits: １９２.１６８.１.１
- mathematical bold digits, outside the BMP: 𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏

Unlike the existing Bengali case, both normalise toward ASCII under NFKC, so they catch implementations that normalise or use Unicode-aware digit parsing before validating. Added across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.