### PR TITLE
test(ipv4): add inet_aton shorthand and 3-part fold forms

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false


### PR DESCRIPTION
Adds two cases where `inet_aton` accepts an input that `RFC 2673 section 3.2` marks invalid (dotted-quad requires exactly four decbytes), and where the accepted value resolves to localhost:

- `127.1 `resolves to `127.0.0.1` via 2-part fold
- `127.0.1 `resolves to `127.0.0.1 `via 3-part fold

The existing 127.0 test covers "too few parts" but resolves to `0.0.0.127` (unroutable). These two cover the localhost SSRF surface. Both rejected by inet_pton (strict) and by all standard JSON Schema validators. Added across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.



