### PR TITLE
test(ipv4): add embedded NUL and CRLF cases with trailing content

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -168,11 +168,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -163,6 +163,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -168,11 +168,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -163,6 +163,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -160,6 +160,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -165,11 +165,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -160,6 +160,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -165,11 +165,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -160,6 +160,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -165,11 +165,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -168,11 +168,6 @@
                 "valid": false
             },
             {
-                "description": "additional content after a trailing CRLF",
-                "data": "192.168.0.1\r\nHost: evil",
-                "valid": false
-            },
-            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -163,6 +163,16 @@
                 "valid": false
             },
             {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
+                "valid": false
+            },
+            {
+                "description": "additional content after a trailing CRLF",
+                "data": "192.168.0.1\r\nHost: evil",
+                "valid": false
+            },
+            {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
                 "valid": false


### PR DESCRIPTION
Adds two cases that catch implementations relying on **C-string parsers** for the ipv4 format. Both are invalid per `RFC 2673 section 3.2 `(dotted-quad admits only ASCII digits and the literal dot; NUL and CR/LF are not in the grammar).

- `192.168.0.1\u0000.evil.com` - inet_aton and inet_pton truncate at the NUL byte and accept the prefix, dropping the ".evil.com" suffix silently.
- `192.168.0.1\r\nHost: evil` - inet_aton truncates at the CR and accepts the prefix, dropping the injected header content.

The existing tests cover bare trailing whitespace (\n, \t). These cover the distinct case of an injected-content-after-truncation pattern that naive C-string-based validators miss. Added across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.