### PR TITLE
test(uuid): add URN-prefixed UUID as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -115,6 +115,11 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -115,6 +115,11 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -115,6 +115,11 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4, I read [RFC 4122 section 3](https://www.rfc-editor.org/rfc/rfc4122#section-3) (and [RFC 9562 section 4](https://www.rfc-editor.org/rfc/rfc9562#section-4), which carries the same text representation) and the `uuid` format definition in the validation spec, and found the current uuid.json has no test for a URN-prefixed UUID.

The spec is explicit that the `uuid` format is for plain UUIDs only. From [draft 2020-12 validation, section 7.3.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-7.3.5): "Note also that the 'uuid' format is for plain UUIDs, not UUIDs in URNs. [...] For UUIDs as URNs, use the 'uri' format". The RFC grammar (`UUID = time-low "-" time-mid "-" ...`) also has no place for a `urn:uuid:` prefix.

## Changes

- Added 1 test case across draft2019-09, draft2020-12, and v1 (the drafts where the uuid format exists).
- `urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380` is invalid (a URN-wrapped UUID, not a plain UUID).

## Ecosystem Impact

1. **ajv-formats 3.0.1**: FAILS this case.
   Its regex is `/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i` - the `(?:urn:uuid:)?` group accepts the prefix, and the `/i` flag makes it match `URN:UUID:` too.

2. **python-jsonschema 4.x**: PASSES.
   Its position check `all(instance[p] == "-" for p in (8, 13, 18, 23))` runs on the original string, so the prefix shifts position 8 to `:` and the check fails.

## RFC References

- RFC 4122 section 3 (string representation grammar): https://www.rfc-editor.org/rfc/rfc4122#section-3
- RFC 9562 section 4 (same grammar, current standard): https://www.rfc-editor.org/rfc/rfc9562#section-4
- Validation spec section 7.3.5 (uuid format, URN note): https://json-schema.org/draft/2020-12/json-schema-validation#section-7.3.5

Reproduction commands and the wider uuid cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
