### PR TITLE
test(uuid): add trailing hyphen after a complete UUID as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -120,6 +120,11 @@
                 "description": "URN prefixed UUID is invalid",
                 "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -120,6 +120,11 @@
                 "description": "URN prefixed UUID is invalid",
                 "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -120,6 +120,11 @@
                 "description": "URN prefixed UUID is invalid",
                 "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and for the URN-prefix uuid test (#913), I read [RFC 4122 section 3](https://www.rfc-editor.org/rfc/rfc4122#section-3) (and [RFC 9562 section 4](https://www.rfc-editor.org/rfc/rfc9562#section-4), the current standard) and found the current uuid.json has no test for a complete UUID followed by a trailing hyphen.

The grammar (`UUID = time-low "-" time-mid "-" ...`) produces exactly 32 hex digits and 4 hyphens at fixed positions. A 37-character string that is a complete UUID plus one extra trailing hyphen is not a valid string representation.

## Changes

- Added 1 test case across draft2019-09, draft2020-12, and v1 (the drafts where the uuid format exists).
- `2eb8aa08-aa98-11ea-b4aa-73b441d16380-` (37 chars) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: FAILS this case (accepts it).
   `is_uuid` calls `uuid.UUID(s)` and then checks only that positions 8, 13, 18, 23 are `-`. `uuid.UUID()` strips all hyphens before checking that 32 hex digits remain, so the trailing hyphen disappears and the constructor succeeds. The position check never inspects index 36, and there is no length check, so the extra hyphen passes unnoticed.

2. **ajv-formats 3.0.1**: PASSES.
   Its regex ends with `$`, so the trailing hyphen after the 12th group fails to match.

This is distinct from the existing "too many dashes" test (`2eb8-aa08-aa98-11ea-b4aa73b44-1d16380`), which python-jsonschema correctly rejects because the interior hyphens shift positions 13/18/23 off the `-` checkpoints. The trailing-hyphen case keeps all four checkpoints intact, which is why it slips through.

## RFC References

- RFC 4122 section 3 (string representation grammar): https://www.rfc-editor.org/rfc/rfc4122#section-3
- RFC 9562 section 4 (same grammar, current standard): https://www.rfc-editor.org/rfc/rfc9562#section-4

Reproduction commands are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
