### PR TITLE
test(uuid): add non-ASCII digit in UUID as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -125,6 +125,11 @@
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -125,6 +125,11 @@
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -125,6 +125,11 @@
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and the earlier uuid tests (#913), I read [RFC 4122 section 3](https://www.rfc-editor.org/rfc/rfc4122#section-3) (and [RFC 9562 section 4](https://www.rfc-editor.org/rfc/rfc9562#section-4)) and found the current uuid.json has no test for a non-ASCII Unicode digit in a hex position.

The grammar defines `hexDigit` as ASCII only: `"0"-"9"` plus `"a"-"f"`/`"A"-"F"`. A Unicode decimal digit from another script (for example Bengali 2, U+09E8) is not a `hexDigit`, so a UUID with one in place of a hex digit is not a valid string representation. This parallels the merged ipv4 non-ASCII digit test (#907).

## Changes

- Added 1 test case across draft2019-09, draft2020-12, and v1 (the drafts where the uuid format exists).
- `২eb8aa08-aa98-11ea-b4aa-73b441d16380` (Bengali 2 at position 0) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: FAILS this case (accepts it).
   `is_uuid` calls `uuid.UUID(s)`, which strips hyphens and calls `int(hex, 16)`. Python's `int(..., 16)` accepts Unicode decimal digits that it treats as numeric, so `int("২", 16)` returns 2. The constructor parses successfully and the dash positions are intact, so it passes.

2. **ajv-formats 3.0.1**: PASSES.
   Its character class `[0-9a-f]` is ASCII-only, so the Bengali digit fails to match.

The same Unicode-folding behavior is not unique to Python: `java.util.UUID.fromString("২eb8aa08-aa98-11ea-b4aa-73b441d16380")` also accepts it (Java reads the digit with `Character.digit`, which is Unicode-aware). So a string that looks like a UUID to a regex-based validator and to a Unicode-aware constructor differ on this input across two major-language ecosystems.

## RFC References

- RFC 4122 section 3 (hexDigit is ASCII 0-9 / a-f / A-F): https://www.rfc-editor.org/rfc/rfc4122#section-3
- RFC 9562 section 4 (HEXDIG = DIGIT / "A"-"F", current standard): https://www.rfc-editor.org/rfc/rfc9562#section-4

Reproduction commands are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
