### PR TITLE
test(idn-hostname): fullwidth digits are valid under the UTS 46 mapping

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "fullwidth digits are mapped to ASCII digits",
+                "comment": "IdnaMappingTable.txt maps U+FF11 to 0031, so this label maps to 123",
+                "data": "\uff11\uff12\uff13",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "fullwidth digits are mapped to ASCII digits",
+                "comment": "IdnaMappingTable.txt maps U+FF11 to 0031, so this label maps to 123",
+                "data": "\uff11\uff12\uff13",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -330,6 +330,12 @@
                 "valid": false
             },
             {
+                "description": "fullwidth digits are mapped to ASCII digits",
+                "comment": "IdnaMappingTable.txt maps U+FF11 to 0031, so this label maps to 123",
+                "data": "\uff11\uff12\uff13",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "fullwidth digits are mapped to ASCII digits",
+                "comment": "IdnaMappingTable.txt maps U+FF11 to 0031, so this label maps to 123",
+                "data": "\uff11\uff12\uff13",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",


### PR DESCRIPTION
Following the methodology I used for ipv4 (#907) and the earlier idn-hostname tests, I read [RFC 5892 section 2.6](https://www.rfc-editor.org/rfc/rfc5892#section-2.6) and found the current idn-hostname.json has no test for fullwidth digits in a label.

Fullwidth digits U+FF11-U+FF13 have the DISALLOWED property under IDNA2008, so a label made of them is not a valid U-label. UTS46 processors map them to ASCII `123` and accept; strict IDNA2008 rejects. This parallels the merged ipv4 fullwidth/astral digit test (#907).

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `１２３` (U+FF11 U+FF12 U+FF13) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES (rejects it). `is_idn_hostname` calls `idna.encode`, which raises InvalidCodepoint on U+FF11.
2. **libidn2, Go x/net/idna, Node (WHATWG), PHP idn_to_ascii, Rust idna, java.net.IDN, ICU4J, Guava**: FAIL (accept it). UTS46 maps the fullwidth digits to ASCII and validates the mapped form. ICU4J, the reference UTS46 implementation, accepts it even with CHECK_BIDI and CHECK_CONTEXTJ enabled.

## RFC References

- RFC 5892 section 2.6 (DISALLOWED category): https://www.rfc-editor.org/rfc/rfc5892#section-2.6

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
