### PR TITLE
test(idn-hostname): a zero width space is ignored by the UTS 46 mapping

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -344,6 +344,12 @@
                 "valid": true
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -344,6 +344,12 @@
                 "valid": true
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -330,6 +330,12 @@
                 "valid": false
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -336,6 +336,12 @@
                 "valid": true
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -344,6 +344,12 @@
                 "valid": true
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -338,6 +338,12 @@
                 "valid": false
             },
             {
+                "description": "a zero width space is ignored by the mapping",
+                "comment": "IdnaMappingTable.txt lists U+200B as ignored, so this label maps to ab",
+                "data": "a\u200bb",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5892 section 2.6](https://www.rfc-editor.org/rfc/rfc5892#section-2.6) and found the current idn-hostname.json has no test for a zero width space in a label.

U+200B (ZERO WIDTH SPACE) has the DISALLOWED property under IDNA2008. UTS46 processors treat it as ignorable and silently strip it, so `a`+U+200B+`b` becomes `ab` and is accepted - an invisible character that changes the resolved name.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `a` + U+200B + `b` (a zero width space between two letters) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES (rejects it). `idna.encode` raises InvalidCodepoint on U+200B.
2. **libidn2, Go x/net/idna, Node (WHATWG), PHP idn_to_ascii, Rust idna, java.net.IDN, ICU4J, Guava**: FAIL (accept it). They strip U+200B as ignorable under UTS46 and validate `ab`. The silent strip is also GNU libidn2 GitLab issue #136.

## RFC References

- RFC 5892 section 2.6 (DISALLOWED category): https://www.rfc-editor.org/rfc/rfc5892#section-2.6

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
