### PR TITLE
test(idn-hostname): reject A-label that decodes to only ASCII

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -389,6 +389,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5890 section 2.3.2.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1) and found the current idn-hostname.json has no test for an A-label that decodes to pure ASCII.

A U-label must contain at least one non-ASCII character, and a string is only an A-label if it decodes to a valid U-label. `xn--example-` decodes to `example`, which is all ASCII, so it is not a valid A-label. UTS46 added this check in revision 33; it is the root of CVE-2024-12224 (Rust idna), CVE-2026-39821 (Go x/net/idna) and CVE-2026-46644 (PHP symfony polyfill).

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `xn--example-` (an A-label that decodes to the all-ASCII label `example`) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES (rejects it).
2. **Go x/net/idna, Node (WHATWG)**: FAIL (accept it). `ToUnicode("xn--example-")` returns `example` instead of an error - the basis of the three CVEs above (Rust idna and the PHP polyfill were patched for the same input).

## RFC References

- RFC 5890 section 2.3.2.1 (A-label and U-label definitions): https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
