### PR TITLE
Add maxProperties specification links

### DIFF
--- a/tests/draft2020-12/maxProperties.json
+++ b/tests/draft2020-12/maxProperties.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "maxProperties validation",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 2
@@ -40,6 +45,11 @@
     },
     {
         "description": "maxProperties validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 2.0
@@ -59,6 +69,11 @@
     },
     {
         "description": "maxProperties = 0 means the object is empty",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 0


### PR DESCRIPTION
## Summary

Adds `specification` metadata to the draft2020-12 `maxProperties` test cases.

## Reproduction

Issue #699 tracks adding canonical specification references to test cases. The existing `tests/draft2020-12/maxProperties.json` cases did not identify the validation specification section that defines `maxProperties` behavior.

## Root cause

The suite schema supports per-test-case `specification` entries, but this file had not yet been annotated. The canonical draft2020-12 validation section for `maxProperties` is section 6.5.1.

## Changes

- Added `validation: "6.5.1"` to each test case group in `tests/draft2020-12/maxProperties.json`.
- Kept the change scoped to a single existing test file, following the request in #699 for small PRs.

## Tests

- `python3 -m json.tool tests/draft2020-12/maxProperties.json > /tmp/maxProperties.json.checked`
- `git diff --check`
- `bin/jsonschema_suite check`

## Screenshots/Logs

N/A; data-only test metadata change.

Refs #699.
