### PR TITLE
test(format): remove year zero date cases

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -232,12 +232,6 @@
                 "valid": false
             },
             {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
-            },
-            {
                 "description": "century year 0100 is not a leap year",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — 100 % 100 == 0 but 100 % 400 != 0",
                 "data": "0100-02-29",

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -232,12 +232,6 @@
                 "valid": false
             },
             {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
-            },
-            {
                 "description": "century year 0100 is not a leap year",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — 100 % 100 == 0 but 100 % 400 != 0",
                 "data": "0100-02-29",

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -229,12 +229,6 @@
                 "valid": false
             },
             {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
-            },
-            {
                 "description": "century year 0100 is not a leap year",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — 100 % 100 == 0 but 100 % 400 != 0",
                 "data": "0100-02-29",

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -232,12 +232,6 @@
                 "valid": false
             },
             {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
-            },
-            {
                 "description": "century year 0100 is not a leap year",
                 "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — 100 % 100 == 0 but 100 % 400 != 0",
                 "data": "0100-02-29",


### PR DESCRIPTION
Fixes #910

## Summary

Remove the `0000-02-29` date format test case from the drafts where it appears.

## Reproduction

Issue #910 points out that the existing date format suite marks `0000-02-29` as valid, even though there is no year zero in the Gregorian calendar. A maintainer confirmed that the ambiguous case should be removed instead of asserted.

## Root cause

The test was added based on RFC 3339 grammar / appendix wording that can be read as allowing year `0000`, but that conflicts with the Gregorian-calendar interpretation used by common date validators.

## Changes

Removed the `year 0000 is a leap year (0 % 400 == 0)` test case from:

- `tests/v1/format/date.json`
- `tests/draft7/optional/format/date.json`
- `tests/draft2019-09/optional/format/date.json`
- `tests/draft2020-12/optional/format/date.json`

## Tests

- `python3 -m json.tool tests/draft2020-12/optional/format/date.json >/dev/null`
- `python3 -m json.tool tests/draft2019-09/optional/format/date.json >/dev/null`
- `python3 -m json.tool tests/draft7/optional/format/date.json >/dev/null`
- `python3 -m json.tool tests/v1/format/date.json >/dev/null`
- `python3 bin/jsonschema_suite check`
- `git diff --check`
- `rg -n "year 0000|0000-02-29|year zero" tests` returns no matches

## Screenshots/Logs

Not applicable; test data only.
