### PR TITLE
Add minProperties specification links

### DIFF
--- a/tests/draft2020-12/minProperties.json
+++ b/tests/draft2020-12/minProperties.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minProperties validation",
+        "specification": [
+            {
+                "validation": "6.5.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "minProperties": 1
@@ -50,6 +55,11 @@
     },
     {
         "description": "minProperties validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.5.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "minProperties": 1.0


### PR DESCRIPTION
## Summary

Adds `specification` links for the draft 2020-12 `minProperties` test cases.

## Reproduction

Issue #699 tracks adding specification references to individual test cases so readers do not need to re-locate the authoritative specification section manually. The draft 2020-12 `minProperties` tests did not include this metadata.

## Root cause

`tests/draft2020-12/minProperties.json` predated the `specification` metadata field, so both `minProperties` test cases lacked a link to the validation vocabulary section that defines the keyword.

## Changes

- Added `specification: [{ "validation": "6.5.2" }]` to both draft 2020-12 `minProperties` test cases.
- Kept the change limited to one file, following the guidance in #699 to send small PRs.

## Tests

- `python -m tox`
- `bin/annotate-specification-links`
- `git diff --check upstream/main..HEAD`

## Screenshots/Logs

`bin/annotate-specification-links` now emits links for the two updated test cases:

```text
::notice file=tests/draft2020-12/minProperties.json,line=4,title=Specification Link::https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#section-6.5.2
::notice file=tests/draft2020-12/minProperties.json,line=58,title=Specification Link::https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#section-6.5.2
```

Fixes #699 partially.