### PR TITLE
Add exclusiveMaximum specification link

### DIFF
--- a/tests/draft2020-12/exclusiveMaximum.json
+++ b/tests/draft2020-12/exclusiveMaximum.json
@@ -1,6 +1,12 @@
 [
     {
         "description": "exclusiveMaximum validation",
+        "specification": [
+            {
+                "validation": "6.2.3",
+                "quote": "If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) \"exclusiveMaximum\"."
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "exclusiveMaximum": 3.0


### PR DESCRIPTION
Summary
- Add a `specification` entry for the draft 2020-12 `exclusiveMaximum` validation test case.
- Point the test case to JSON Schema Validation section 6.2.3.

Reproduction
- `tests/draft2020-12/exclusiveMaximum.json` had no `specification` metadata for the canonical spec section that defines the tested behavior.
- This is part of #699's incremental effort to add specification references in small PRs.

Root cause
- The test suite schema supports `specification`, but this test case had not yet been annotated.

Changes
- Added a single `validation: "6.2.3"` specification reference with the relevant `exclusiveMaximum` quote.

Tests
- `python3 bin/jsonschema_suite check`
- `git diff --check`

Screenshots/Logs
- Not applicable; this is test metadata only.

Part of #699.
