### PR TITLE
test(idn-hostname): add Bidi rule (RFC 5893) cases

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -339,6 +339,30 @@
                 "valid": false
             },
             {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -339,6 +339,30 @@
                 "valid": false
             },
             {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -331,6 +331,30 @@
                 "valid": false
             },
             {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -339,6 +339,30 @@
                 "valid": false
             },
             {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5893 section 2](https://www.rfc-editor.org/rfc/rfc5893#section-2) and found the current idn-hostname.json has no dedicated tests for the Bidi rule (it tests RTL exception characters, but not the six-condition rule itself).

In a Bidi domain name (any name with a right-to-left label), every label must satisfy the Bidi rule: condition 1 requires the first character to be L, R or AL, and the other conditions constrain direction.

## Changes

- Added 4 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `0a.א` - a digit-first label in a Bidi domain name (condition 1) - invalid.
- `0ا` - a digit before a right-to-left letter (condition 1) - invalid.
- `aא` - a left-to-right label containing a right-to-left letter (condition 5) - invalid.
- `א0٠` - a right-to-left label mixing European and Arabic-Indic digits (condition 4) - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: FAILS `0a.א` (accepts it). The idna package checks the Bidi rule per label; the `0a` label has no RTL character so the check is skipped, missing that the `א` label makes the whole name a Bidi domain name. It correctly rejects the three single-label cases.
2. **Node (WHATWG)**: FAILS all four (accepts them) - it does not apply the Bidi rule by default.
3. **Go x/net/idna**: PASSES all four (rejects them).

## RFC References

- RFC 5893 section 2 (the Bidi rule): https://www.rfc-editor.org/rfc/rfc5893#section-2

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
