### PR TITLE
test(idn-hostname): reject A-labels that decode to an invalid U-label

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -363,6 +363,18 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -363,6 +363,18 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -355,6 +355,18 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -363,6 +363,18 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5890 section 2.3.2.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1) and found the current idn-hostname.json tests Punycode validity but never an A-label that decodes to an invalid U-label.

A string is only an A-label if it decodes to a valid U-label. A validator that accepts any well-formed `xn--` without decoding and re-checking the result will accept labels whose U-label is invalid.

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `xn--7a` decodes to U+00A1, which is DISALLOWED (RFC 5892 section 2.6) - invalid.
- `xn--0ca24w` decodes to a-grave + Hebrew aleph, which violates the Bidi rule (RFC 5893) - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES both (rejects them). `idna.encode` decodes and re-validates.
2. **Go x/net/idna, Node (WHATWG), PHP idn_to_ascii, java.net.IDN**: FAIL `xn--7a` (accept it). Node also FAILS `xn--0ca24w`.

## RFC References

- RFC 5890 section 2.3.2.1 (A-label and U-label definitions): https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1
- RFC 5892 section 2.6 (DISALLOWED category): https://www.rfc-editor.org/rfc/rfc5892#section-2.6
- RFC 5893 (the Bidi rule): https://www.rfc-editor.org/rfc/rfc5893

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
