### PR TITLE
test(idn-hostname): reject A-label longer than 63 octets

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -372,6 +377,12 @@
                 "description": "A-label that decodes to a Bidi rule violation is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
                 "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -372,6 +377,12 @@
                 "description": "A-label that decodes to a Bidi rule violation is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
                 "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -49,8 +49,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -364,6 +369,12 @@
                 "description": "A-label that decodes to a Bidi rule violation is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
                 "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
                 "valid": false
             },
             {

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -372,6 +377,12 @@
                 "description": "A-label that decodes to a Bidi rule violation is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
                 "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
                 "valid": false
             },
             {


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5891 section 4.2.4](https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4) and found the current idn-hostname.json's "component too long" test measures code points, not the A-label octet count.

The 63-octet label limit applies to the A-label (Punycode) form, not the code point count (RFC 5891 section 4.2.4 / RFC 1035 section 2.3.4). A label of 60 `ü` is 60 code points but its A-label exceeds 63 octets, so it is invalid - a case the existing test (over 63 code points) does not catch.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- 60 x `ü` (U+00FC) - 60 code points, but the A-label is over 63 octets - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES (rejects it). `idna.encode` raises "Label too long".
2. **Go x/net/idna, Node (WHATWG)**: FAIL (accept it). They do not enforce the 63-octet A-label limit by default.

## RFC References

- RFC 5891 section 4.2.4 (A-label length): https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4
- RFC 1035 section 2.3.4 (label and name size limits): https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
