### PR TITLE
test(idn-hostname): reject non-canonical Punycode

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -331,6 +331,12 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
+                "valid": false
             }
         ]
     },

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -334,7 +334,7 @@
             },
             {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -331,6 +331,12 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
+                "valid": false
             }
         ]
     },

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -334,7 +334,7 @@
             },
             {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",
                 "valid": false
             }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -326,7 +326,7 @@
             },
             {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",
                 "valid": false
             }

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -323,6 +323,12 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
+                "valid": false
             }
         ]
     },

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -331,6 +331,12 @@
                 "description": "empty string",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
+                "valid": false
             }
         ]
     },

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -334,7 +334,7 @@
             },
             {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
-                "comment": "https://tools.ietf.org/html/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",
                 "valid": false
             }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5891 section 5.4](https://www.rfc-editor.org/rfc/rfc5891#section-5.4) and found the current idn-hostname.json has no test for non-canonical Punycode.

RFC 5891 section 5.4 requires a label decoded from Punycode to be re-encoded, and rejected if the result is not identical to the original A-label. `xn---9uc` decodes to a single Kannada code point whose canonical A-label is `xn--9uc` (no third hyphen), so the round-trip fails and the input is invalid.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `xn---9uc` (a non-canonical Punycode encoding of `xn--9uc`) is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: FAILS (accepts it). It does not enforce the decode/re-encode round-trip.
2. **Node (WHATWG)**: FAILS (accepts it).
3. **Go x/net/idna, PHP idn_to_ascii, Rust idna**: PASS (reject it).

## RFC References

- RFC 5891 section 5.4 (validation, the round-trip requirement): https://www.rfc-editor.org/rfc/rfc5891#section-5.4

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
