### PR TITLE
test(idn-hostname): reject empty label and over-length name

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -386,6 +386,17 @@
                 "valid": false
             },
             {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -386,6 +386,17 @@
                 "valid": false
             },
             {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -378,6 +378,17 @@
                 "valid": false
             },
             {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -386,6 +386,17 @@
                 "valid": false
             },
             {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 1034 section 3.1](https://www.rfc-editor.org/rfc/rfc1034#section-3.1) and found the current idn-hostname.json has no test for an empty label or a name over the length limit.

RFC 1034 section 3.1 limits a domain name to 255 octets in wire format. Each label boundary adds a 1-byte length prefix in wire format, and the name ends with a 1-byte root terminator, so the text-string representation is limited to 253 characters. A name of 255 characters maps to 257 wire-format bytes and is invalid.

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `a..b` (an empty label between two dots) is invalid.
- A 255-character name (four maximum-length labels joined by dots) is invalid - it exceeds the 253-character text limit derived from RFC 1034 section 3.1.

## Ecosystem Impact

1. python-jsonschema 4.x: PASSES both (rejects them).
2. libidn2, Go x/net/idna, Node (WHATWG): FAIL `a..b` (accept it). Go x/net/idna, Node (WHATWG), java.net.IDN: FAIL the over-length name (accept it).

## RFC References

- RFC 1034 section 3.1 (label and name size limits): https://www.rfc-editor.org/rfc/rfc1034#section-3.1

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)