### PR TITLE
test(idn-hostname): reject ZWNJ that fails its rule at any occurrence

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -333,6 +333,12 @@
                 "valid": false
             },
             {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -333,6 +333,12 @@
                 "valid": false
             },
             {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -325,6 +325,12 @@
                 "valid": false
             },
             {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -333,6 +333,12 @@
                 "valid": false
             },
             {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5892 appendix A.1](https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1) and [erratum 3312](https://www.rfc-editor.org/errata/eid3312), and found the current idn-hostname.json tests the ZERO WIDTH NON-JOINER rule in single contexts but not at every occurrence.

RFC 5892 appendix A.1, clarified by erratum 3312, requires the ZWNJ rule to be evaluated for every occurrence in a label, with all passing. A label with one ZWNJ after a Virama (valid context) and a second between two ASCII letters (no valid context) must be rejected.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- A label with two ZWNJ - one valid (post-Virama) and one invalid (between ASCII letters) - is invalid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: PASSES (rejects it).
2. **Node (WHATWG), PHP idn_to_ascii**: FAIL (accept it). Node rejects the single-violation case, so it is specifically missing the per-occurrence check.

## RFC References

- RFC 5892 appendix A.1 (ZERO WIDTH NON-JOINER rule): https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1
- RFC 5892 erratum 3312 (per-occurrence evaluation): https://www.rfc-editor.org/errata/eid3312

Reproduction commands and the idn-hostname cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
