### PR TITLE
test(relative-json-pointer): add multi-digit prefix with interior zero

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -95,6 +95,11 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -95,6 +95,11 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -92,6 +92,11 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -95,6 +95,11 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [draft-handrews-relative-json-pointer-01 section 3](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3) and found the suite has no test for a multi-digit prefix with an interior zero - the spot where a hand-rolled integer scanner can go wrong.

The prefix grammar is `non-negative-integer = %x30 / %x31-39 *( %x30-39 )`, so after the first digit any digits are allowed, zeros included. `100` is valid (it is `1` then `00`); only a leading zero is barred. The suite already has `120/foo/bar` as a valid multi-digit prefix, but there the zero is the last digit, so it does not exercise a zero that is followed by another digit.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `100` - a valid non-negative integer with a zero before another digit - valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1, Go santhosh-tekuri/jsonschema v6, Rust jsonschema 0.46.5**: PASS (accept it).
2. **python-jsonschema 4.x**: FAILS (rejects it). Its `is_relative_json_pointer` walks the string and runs `if i > 0 and int(instance[i - 1]) == 0: return False`. That guard is meant to catch a leading zero, but it fires on any zero followed by another digit, so `100`, `1000`, `205` are wrongly rejected while `120` (zero last) passes.

## RFC References

- draft-handrews-relative-json-pointer-01 section 3 (Syntax): https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3
- RFC 6901 section 3 (JSON Pointer syntax): https://www.rfc-editor.org/rfc/rfc6901#section-3

Reproduction commands and the relative-json-pointer cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/relative-json-pointer.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
