### PR TITLE
test(relative-json-pointer): add non-ASCII digit in prefix as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -69,6 +69,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [draft-handrews-relative-json-pointer-01 section 3](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3) and found the suite has no test for a non-ASCII digit in the integer prefix.

The prefix grammar is `non-negative-integer = %x30 / %x31-39 *( %x30-39 )`, so the digits are ASCII `%x30-39` only. A Unicode decimal digit such as U+0661 ARABIC-INDIC DIGIT ONE is not part of the production, so a string that starts with one is not a Relative JSON Pointer.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `١/foo` - the leading character is U+0661 ARABIC-INDIC DIGIT ONE - invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1, Go santhosh-tekuri/jsonschema v6, Rust jsonschema 0.46.5**: PASS (reject it).
2. **python-jsonschema 4.x**: FAILS (accepts it). Its `is_relative_json_pointer` tests each character with `str.isdigit()`, which is true for every Unicode decimal-digit family, then `int()` parses it, so the non-ASCII digit is treated as a valid prefix integer.

This is the same class as the merged ipv4 ([#907](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/907)) and uuid ([#915](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/915)) non-ASCII digit tests, applied to the relative-json-pointer prefix.

## RFC References

- draft-handrews-relative-json-pointer-01 section 3 (Syntax): https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3
- RFC 6901 section 3 (JSON Pointer syntax): https://www.rfc-editor.org/rfc/rfc6901#section-3

Reproduction commands and the relative-json-pointer cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/relative-json-pointer.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
