### PR TITLE
test(cross-draft): respect $schema when it follows $defs

### DIFF
--- a/tests/draft2020-12/optional/cross-draft.json
+++ b/tests/draft2020-12/optional/cross-draft.json
@@ -14,5 +14,32 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$schema after $defs still sets the dialect for $defs",
+        "comment": "keyword order is insignificant, so the dialect from $schema applies to subschemas in $defs even though $defs appears before $schema; prefixItems is not a keyword in 2019-09 and is therefore ignored",
+        "schema": {
+            "$defs": {
+                "list": {
+                    "prefixItems": [{ "type": "string" }],
+                    "minItems": 2
+                }
+            },
+            "$ref": "#/$defs/list",
+            "$schema": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "non-string first item is valid",
+                "comment": "if $defs is built with the default dialect rather than the one from $schema, prefixItems forces the first item to be a string and this fails",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "too few items is invalid",
+                "data": [1],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Adds a test asserting that the dialect declared by `$schema` is applied to subschemas under `$defs` **even when `$defs` appears before `$schema`** lexically. This covers the "keyword ordering MUST be insignificant" banner raised in the linked issue.

The reported bug: an implementation that builds the `$defs` subschemas before reading `$schema` ends up using its default dialect rather than the one the schema declares.

### How the test detects it

```json
{
    "$defs": { "list": { "prefixItems": [{ "type": "string" }], "minItems": 2 } },
    "$ref": "#/$defs/list",
    "$schema": "https://json-schema.org/draft/2019-09/schema"
}
```

`prefixItems` is not a keyword in 2019-09, so `[1, 2, 3]` is valid only if the implementation read `$schema` (and selected the 2019-09 dialect) before building `$defs`. An implementation that defaulted the dialect would treat `prefixItems` as an assertion and reject the array — failing the `valid: true` test. `minItems` (recognized in both dialects) gives a stable invalid case as well.

The case lives in `optional/cross-draft.json` because detecting the bug inherently requires a root `$schema` that differs from the folder's default dialect, which is the same situation the existing cross-draft cases exercise. `tests/latest` is a symlink to `draft2020-12`, so it is covered automatically.

Verified locally: structurally valid against `test-schema.json`, valid under the 2020-12 metaschema (`check_schema`), and a `$schema`-respecting reference implementation returns the expected `true`/`false`.

### Note for reviewers

I added this only in the 2020-12 → 2019-09 direction. The mirror (an older-draft folder declaring a newer inner `$schema`) trips the suite's `test_arbitrary_schemas_do_not_use_unknown_keywords` guard when the newer keyword appears inline, and the clean older-dialect discriminators tangle with `$ref`-sibling semantics. Happy to add the other direction via remotes if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
