### PR TITLE
test(idn-email): add Unicode NFC normalization cases

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -65,6 +65,16 @@
                 "description": "a local part with a lone UTF-16 surrogate is invalid",
                 "data": "\ud800@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -65,6 +65,16 @@
                 "description": "a local part with a lone UTF-16 surrogate is invalid",
                 "data": "\ud800@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -62,6 +62,16 @@
                 "description": "a local part with a lone UTF-16 surrogate is invalid",
                 "data": "\ud800@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -70,6 +70,16 @@
                 "description": "a local part with a lone UTF-16 surrogate is invalid",
                 "data": "\ud800@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 6531 section 3.3](https://www.rfc-editor.org/rfc/rfc6531#section-3.3) and [RFC 5890 section 2.3.2.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1), and found the suite has no test for Unicode normalization in an idn-email.

RFC 5890 section 2.3.2.1 says a domain U-label is "in Normalization Form C (NFC)", so a decomposed domain label is invalid. RFC 6531 builds the local part on RFC 5321 and adds a UTF8-non-ascii alternative, but it sets no normalization requirement on the local part. So the same decomposed sequence "cafe" + U+0301 (combining acute) is invalid as a domain label but valid as a local part. The existing internationalized test (the Hangul address) is already in NFC, so neither case is covered today.

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `user@cafe<U+0301>.com` - a domain label that is not in NFC - invalid.
- `cafe<U+0301>@example.com` - the same decomposed sequence in the local part - valid.

## Ecosystem Impact

1. **python-jsonschema 4.x**: accepts both. Its `idn-email` check is only `"@" in instance`, so it never looks at normalization - it is wrong on the first case.
2. **ajv-formats 3.x**: has no `idn-email` format at all, so it does not validate the format and accepts both - also wrong on the first case.
3. **A strict IDNA check on the domain** (for example python `idna.encode`): rejects the decomposed domain label, which is the correct verdict. Validators that normalize the domain (UTS-46 / NFC) before checking accept it instead, so the decomposed form passes silently.

## A question on the second case

RFC 6531 does not require the local part to be in NFC - I read every section and there is no normalization rule on the local part, only on the domain U-label (RFC 5890). So I marked the decomposed local part valid. If the intent is that idn-email should normalize or reject a non-NFC local part, this is the one to flip - happy to do that. The domain case is not in question.

## RFC References

- RFC 6531 section 3.3 (Extended Mailbox Address Syntax): https://www.rfc-editor.org/rfc/rfc6531#section-3.3
- RFC 5890 section 2.3.2.1 (A-label and U-label, "in Normalization Form C (NFC)"): https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1

Reproduction and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
