### PR TITLE
test(idn-email): add a lone surrogate in the local part

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -60,6 +60,11 @@
                 "description": "a non-ASCII quoted local part is valid",
                 "data": "\"δοκιμή\"@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part with a lone UTF-16 surrogate is invalid",
+                "data": "\ud800@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -60,6 +60,11 @@
                 "description": "a non-ASCII quoted local part is valid",
                 "data": "\"δοκιμή\"@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part with a lone UTF-16 surrogate is invalid",
+                "data": "\ud800@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -57,6 +57,11 @@
                 "description": "a non-ASCII quoted local part is valid",
                 "data": "\"δοκιμή\"@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part with a lone UTF-16 surrogate is invalid",
+                "data": "\ud800@example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -65,6 +65,11 @@
                 "description": "a non-ASCII quoted local part is valid",
                 "data": "\"δοκιμή\"@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part with a lone UTF-16 surrogate is invalid",
+                "data": "\ud800@example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 6531 section 3.3](https://www.rfc-editor.org/rfc/rfc6531#section-3.3) and [RFC 3629 section 4](https://www.rfc-editor.org/rfc/rfc3629#section-4), and found the suite does not test a local part that is not well-formed UTF-8.

RFC 6531 extends the local part with UTF8-non-ascii, which is UTF8-2 / UTF8-3 / UTF8-4 from RFC 3629 section 4 (via RFC 6532 section 3.1). RFC 3629 excludes UTF-16 surrogates - the UTF8-3 production restricts the bytes after lead byte ED so that D800-DFFF cannot be encoded. So a lone surrogate is not a valid local-part character.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `<U+D800>@example.com` - a lone UTF-16 surrogate in the local part - invalid.

The surrogate is written as the JSON escape `\ud800`. It is valid JSON syntax (RFC 8259 allows the escape) and the suite's own check accepts it. Flagging it because a lone surrogate is unusual in a test file - if you would rather not carry one for consumer compatibility, I am happy to drop this.

## Ecosystem Impact

1. **python-jsonschema 4.x**: accepts it (its idn-email check is only `"@" in instance`) - wrong.
2. **email-validator 2.x (allow_smtputf8)**: rejects it as unsafe - correct.
3. **validator.js 13.x**: throws a URIError on it (it calls `encodeURI` internally, which fails on a lone surrogate) - a crash rather than a verdict.

## RFC References

- RFC 6531 section 3.3 (Extended Mailbox Address Syntax): https://www.rfc-editor.org/rfc/rfc6531#section-3.3
- RFC 6532 section 3.1 (UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4): https://www.rfc-editor.org/rfc/rfc6532#section-3.1
- RFC 3629 section 4 (UTF-8 syntax, surrogates excluded): https://www.rfc-editor.org/rfc/rfc3629#section-4

Reproduction and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
