### PR TITLE
test(idn-email): add non-ASCII local part coverage

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -50,6 +50,16 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -50,6 +50,16 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -47,6 +47,16 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -55,6 +55,16 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 6531 section 3.3](https://www.rfc-editor.org/rfc/rfc6531#section-3.3) and found the suite only tests a non-ASCII address with non-ASCII on both sides (the Hangul case). It does not cover a non-ASCII local part on its own, in either the dot-atom or the quoted form.

RFC 6531 extends atext and qtextSMTP with UTF8-non-ascii, so a local part may contain non-ASCII characters whether or not the domain does, and whether or not it is quoted.

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `δοκιμή@example.com` - a non-ASCII dot-atom local part with an ASCII domain - valid.
- `"δοκιμή"@example.com` - a non-ASCII quoted local part - valid.

## Ecosystem Impact

These are valid per the grammar, and python-jsonschema and ajv-formats both accept them (neither does real idn-email validation), so this is coverage of two local-part branches the suite does not exercise rather than a tripwire. They also document a real divergence: PHP `filter_var(FILTER_VALIDATE_EMAIL)` rejects any non-ASCII local part (no SMTPUTF8 support), and email-validator rejects the quoted non-ASCII form - both wrongly, per RFC 6531.

## RFC References

- RFC 6531 section 3.3 (atext =/ UTF8-non-ascii, qtextSMTP =/ UTF8-non-ascii): https://www.rfc-editor.org/rfc/rfc6531#section-3.3

Reproduction and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
