### PR TITLE
test(format/date): assert hyphen literal separator compliance

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -357,6 +357,36 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -357,6 +357,36 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -354,6 +354,36 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -357,6 +357,36 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-07, draft/2019-09, draft/2020-12

Adds 6 new cases covering separator character validation in the RFC 3339 Section 5.6 full-date grammar. This ensures that parsers strictly reject non-hyphen separators, mixed separators, and duplicated hyphens.

Added:
- Colon separators (2020:01:01)
- Dot separators (2020.01.01)
- Space separators (2020 01 01)
- Mixed slash and hyphen separators (2020-01/01)
- Duplicated first hyphen (2020--01-01)
- Duplicated second hyphen (2020-01--01)

@jviotti @jdesrosiers @karenetheridge Ready for review.