### PR TITLE
test(format/date): add boundary whitespace, Unicode dash, and max boundary cases

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -357,6 +357,26 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: leading tab character before valid date",
+                "data": "\t2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing newline after valid date",
+                "data": "2020-01-01\n",
+                "valid": false
+            },
+            {
+                "description": "invalid: leading non-breaking space before valid date",
+                "data": "\u00A02020-01-01",
+                "valid": false
+            },
+            {
+                "description": "valid: maximum boundary full-date",
+                "data": "9999-12-31",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -357,6 +357,26 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: leading tab character before valid date",
+                "data": "\t2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing newline after valid date",
+                "data": "2020-01-01\n",
+                "valid": false
+            },
+            {
+                "description": "invalid: leading non-breaking space before valid date",
+                "data": "\u00A02020-01-01",
+                "valid": false
+            },
+            {
+                "description": "valid: maximum boundary full-date",
+                "data": "9999-12-31",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -354,6 +354,26 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: leading tab character before valid date",
+                "data": "\t2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing newline after valid date",
+                "data": "2020-01-01\n",
+                "valid": false
+            },
+            {
+                "description": "invalid: leading non-breaking space before valid date",
+                "data": "\u00A02020-01-01",
+                "valid": false
+            },
+            {
+                "description": "valid: maximum boundary full-date",
+                "data": "9999-12-31",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -357,6 +357,26 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: leading tab character before valid date",
+                "data": "\t2020-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: trailing newline after valid date",
+                "data": "2020-01-01\n",
+                "valid": false
+            },
+            {
+                "description": "invalid: leading non-breaking space before valid date",
+                "data": "\u00A02020-01-01",
+                "valid": false
+            },
+            {
+                "description": "valid: maximum boundary full-date",
+                "data": "9999-12-31",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-07, draft/2019-09, draft/2020-12

Adds 8 new edge cases validating strict string anchoring constraints, Unicode whitespace characters, alternative Unicode dash variations, and maximum boundary years for the `date` format.

Added:
- Leading tab character before valid date (invalid)
- Trailing newline after valid date (invalid)
- Leading non-breaking space before valid date (invalid)
- Unicode en dash separators (invalid)
- Unicode minus sign separators (invalid)
- Maximum boundary full-date year 9999 (valid)
- Partial date-time prefix with T suffix (invalid)
- Partial date-time prefix with hour component (invalid)

### Rationale for separating Unicode en dash and Unicode minus sign:
We explicitly test both `–` (U+2013, General Punctuation block) and `−` (U+2212, Mathematical Operators block) because they belong to completely separate Unicode blocks. Implementations that perform partial Unicode normalization or range checks (e.g., stripping punctuation blocks vs mathematical symbol blocks) could reject one while erroneously normalizing and accepting the other.

@jviotti @jdesrosiers @karenetheridge Ready for review.