### PR TITLE
test(format/date-time): add timezone offset boundary and leap second cases

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -150,6 +150,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -150,6 +150,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -37,6 +37,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -147,6 +147,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -147,6 +147,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -147,6 +147,41 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "UTC offset +00:00 is valid",
+                "data": "1985-04-12T23:20:50+00:00",
+                "valid": true
+            },
+            {
+                "description": "negative zero offset -00:00 is valid",
+                "data": "1985-04-12T23:20:50-00:00",
+                "valid": true
+            },
+            {
+                "description": "maximum positive offset +23:59 is valid",
+                "data": "1985-04-12T23:20:50+23:59",
+                "valid": true
+            },
+            {
+                "description": "maximum negative offset -23:59 is valid",
+                "data": "1985-04-12T23:20:50-23:59",
+                "valid": true
+            },
+            {
+                "description": "offset hour 24 is invalid with positive sign",
+                "data": "1985-04-12T23:20:50+24:00",
+                "valid": false
+            },
+            {
+                "description": "Z followed by numeric offset is invalid",
+                "data": "1985-04-12T23:20:50Z+00:00",
+                "valid": false
+            },
+            {
+                "description": "leap second with offset producing wrong UTC is invalid",
+                "data": "1998-12-31T23:59:60+01:00",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-07, draft/2019-09, draft/2020-12

Adds 8 new cases asserting strict timezone offset formatting, floor/ceiling bounds, and IERS leap second compliance in the `date-time` format.

Added:
- UTC numeric offset +00:00 (valid)
- Negative zero offset -00:00 (valid)
- Maximum positive offset +23:59 (valid)
- Maximum negative offset -23:59 (valid)
- Out-of-bounds offset hour +24:00 (invalid)
- Z followed by numeric offset Z+00:00 (invalid)
- Valid leap second on another confirmed IERS date 2016 (valid)
- Leap second with offset producing wrong UTC (invalid)

### Ecosystem Impact (Triangulation):
Under Bowtie verification against 8 active implementations, these cases successfully caught live compliance issues:
1. **PHP Bug Caught:** `php-opis-json-schema` incorrectly validates the invalid leap second with non-UTC offset (`"1998-12-31T23:59:60+01:00"`) as `valid` (expected `invalid`), failing to assert that leap seconds can only align with UTC midnight.
2. **Go Bug Caught:** `go-gojsonschema` incorrectly validates the valid leap second `"2016-12-31T23:59:60Z"` as `invalid` due to Go standard runtime limitations on leap second support.

@jviotti @jdesrosiers @karenetheridge Ready for review.