### PR TITLE
test(format/uri): add strict anchoring, spacing, and delimiter validation cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -224,6 +224,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -224,6 +224,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -224,6 +224,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -227,6 +227,46 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "trailing newline after valid URI",
+                "data": "http://a.com\n",
+                "valid": false
+            },
+            {
+                "description": "embedded newline",
+                "data": "http://a\n.com",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain space",
+                "data": "http://a.com/?a b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain space",
+                "data": "http://a.com/#a b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII emoji in path",
+                "data": "http://a.com/💀",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in query for same reason as in path",
+                "data": "http://a.com/?a{b",
+                "valid": false
+            },
+            {
+                "description": "open brace is invalid in fragment for same reason as in path",
+                "data": "http://a.com/#a{b",
+                "valid": false
+            },
+            {
+                "description": "two at-signs in authority leave trailing @ and make URI invalid",
+                "data": "http://user@pass@a.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-04, draft-06, draft-07, draft/2019-09, draft/2020-12

Adds 9 new cases validating strict string anchoring constraints, disallowed whitespace characters (newlines, spaces), and invalid path/authority delimiters for the `uri` format.

Added:
- Trailing newline after valid URI (invalid)
- Embedded newline inside URI (invalid)
- Space inside query (invalid)
- Space inside fragment (invalid)
- Close brace `}` inside path (invalid)
- Raw non-ASCII emoji inside path (invalid)
- Open brace `{` inside query (invalid)
- Open brace `{` inside fragment (invalid)
- Multiple `@` signs in authority (invalid)

### Ecosystem Impact (Triangulation):
Under Bowtie verification against 8 active implementations, these cases successfully caught live compliance issues:
1. **PHP Bug Caught:** `php-opis-json-schema` incorrectly accepts trailing newlines (`"http://a.com\n"`) and embedded newlines (`"http://a\n.com"`) as valid.
2. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts spaces in query (`"?a b"`) and fragment (`"#a b"`).
3. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts invalid braces (`{` and `}`) in path, query, and fragment.
4. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts multiple `@` signs in authority (`"http://user@pass@a.com"`).

@jviotti @jdesrosiers @karenetheridge Ready for review.