### PR TITLE
test(format/uri): add strict percent-encoding syntax and non-ASCII character cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -224,6 +224,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -224,6 +224,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -224,6 +224,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -227,6 +227,66 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in query",
+                "data": "http://a.com/?q=%2",
+                "valid": false
+            },
+            {
+                "description": "query invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/?q=%G0",
+                "valid": false
+            },
+            {
+                "description": "query lone percent is invalid",
+                "data": "http://a.com/?q=%",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in query is invalid",
+                "data": "http://a.com/?q=é",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain caret",
+                "data": "http://a.com/?a^b",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding in fragment",
+                "data": "http://a.com/#%2",
+                "valid": false
+            },
+            {
+                "description": "fragment invalid percent-encoding with non-hex in first nibble",
+                "data": "http://a.com/#%G0",
+                "valid": false
+            },
+            {
+                "description": "fragment lone percent is invalid",
+                "data": "http://a.com/#%",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain second hash",
+                "data": "http://a.com/#a#b",
+                "valid": false
+            },
+            {
+                "description": "fragment cannot contain caret",
+                "data": "http://a.com/#a^b",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII in fragment is invalid",
+                "data": "http://a.com/#é",
+                "valid": false
+            },
+            {
+                "description": "valid percent-encoding in reg-name",
+                "data": "http://ex%61mple.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-04, draft-06, draft-07, draft/2019-09, draft/2020-12

Adds 12 new cases validating strict percent-encoding syntax triplets, caret/hash delimiters, and non-ASCII character constraints in the `uri` format.

Added:
- Incomplete percent-encoding `%` + 1 digit in query (invalid)
- Invalid hex digit `%G0` in query (invalid)
- Lone percent `%` in query (invalid)
- Raw non-ASCII characters in query (invalid)
- Caret `^` in query (invalid)
- Incomplete percent-encoding `%` + 1 digit in fragment (invalid)
- Invalid hex digit `%G0` in fragment (invalid)
- Lone percent `%` in fragment (invalid)
- Second hash `#` in fragment (invalid)
- Caret `^` in fragment (invalid)
- Raw non-ASCII characters in fragment (invalid)
- Valid percent-encoding in host reg-name (valid)

### Ecosystem Impact (Triangulation):
Under Bowtie verification against 8 active implementations, these cases successfully caught live compliance issues:
1. **Go & PHP Bugs Caught:** Both engines incorrectly accept incomplete percent-encoding (`"%2"`), invalid hex (`"%G0"`), and lone percents (`"%"`) in queries and fragments.
2. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts raw non-ASCII `é` and carets in queries and fragments.
3. **Go Bug Caught:** `go-gojsonschema` incorrectly rejects valid percent-encoding in host reg-names (`"http://ex%61mple.com"`).

@jviotti @jdesrosiers @karenetheridge Ready for review.