### PR TITLE
test(format/uri): assert IPv6 and IPvFuture host formatting constraints

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -224,6 +224,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -224,6 +224,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -224,6 +224,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -227,6 +227,106 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "host IPv6 missing brackets",
+                "data": "http://2001:db8::1",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with invalid hex digits",
+                "data": "http://[2001:db8::gggg]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 empty brackets",
+                "data": "http://[]",
+                "valid": false
+            },
+            {
+                "description": "query cannot contain brackets",
+                "data": "http://a.com/?arr[]=1",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in fragment",
+                "data": "http://a.com/#a[b]",
+                "valid": false
+            },
+            {
+                "description": "brackets are invalid in path",
+                "data": "http://a.com/[]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with two double-colons is invalid",
+                "data": "http://[2001::db8::1]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with seven groups and no double-colon is invalid",
+                "data": "http://[1:2:3:4:5:6:7]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 address with nine groups is invalid",
+                "data": "http://[1:2:3:4:5:6:7:8:9]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 group with five hex digits exceeds h16 maximum of four",
+                "data": "http://[2001:db8::00000]",
+                "valid": false
+            },
+            {
+                "description": "IPv6 with embedded IPv4 containing out-of-range octet is invalid",
+                "data": "http://[::ffff:1.2.3.256]",
+                "valid": false
+            },
+            {
+                "description": "host IPv6 with embedded IPv4",
+                "data": "http://[::ffff:192.168.1.1]",
+                "valid": true
+            },
+            {
+                "description": "host IPvFuture missing version",
+                "data": "http://[v.fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture missing dot",
+                "data": "http://[v1fe80]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture empty content after dot",
+                "data": "http://[v1.]",
+                "valid": false
+            },
+            {
+                "description": "IPvFuture with non-hex version is invalid",
+                "data": "http://[vG.test]",
+                "valid": false
+            },
+            {
+                "description": "host IPvFuture valid",
+                "data": "http://[v1.fe80::a+b]",
+                "valid": true
+            },
+            {
+                "description": "IPvFuture with uppercase V is valid",
+                "data": "http://[V1.test]",
+                "valid": true
+            },
+            {
+                "description": "non-ASCII Cyrillic characters in host",
+                "data": "http://пример.рф",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII Latin character in host",
+                "data": "http://exämple.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-04, draft-06, draft-07, draft/2019-09, draft/2020-12

Adds 20 new cases asserting strict syntax constraints on IPv6 and IPvFuture host formats, including square bracket requirements, and Cyrillic/non-ASCII host rejections.

Added:
- Unbracketed IPv6 host (invalid)
- Invalid hex digit in IPv6 brackets (invalid)
- Empty brackets `[]` host (invalid)
- Brackets in query (invalid)
- Brackets in fragment (invalid)
- Brackets in path (invalid)
- IPv6 with multiple double-colons (invalid)
- IPv6 with 7 groups and no double-colon (invalid)
- IPv6 with 9 groups (invalid)
- IPv6 group with >4 hex digits (invalid)
- IPv6 with out-of-bounds embedded IPv4 octet (invalid)
- Valid IPv6 with embedded IPv4 (valid)
- IPvFuture missing version (invalid)
- IPvFuture missing dot (invalid)
- IPvFuture empty content after dot (invalid)
- IPvFuture with non-hex version (invalid)
- Valid IPvFuture host (valid)
- IPvFuture with uppercase V version (valid)
- Non-ASCII Cyrillic host (invalid)
- Non-ASCII Latin host (invalid)

### Ecosystem Impact (Triangulation):
Under Bowtie verification against 8 active implementations, these cases successfully caught live compliance issues:
1. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts unbracketed IPv6, empty brackets, brackets in path/query/fragment, and malformed IPv6/IPvFuture hosts.
2. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts Cyrillic and non-ASCII Latin characters in host names.
3. **PHP Bug Caught:** `php-opis-json-schema` incorrectly rejects valid IPv6 with embedded IPv4 (`"http://[::ffff:192.168.1.1]"`), valid IPvFuture hosts, and uppercase `V` versions.
4. **PHP Bug Caught:** `php-opis-json-schema` incorrectly accepts brackets in query/fragment.

@jviotti @jdesrosiers @karenetheridge Ready for review.