### PR TITLE
test(format/uri): add port syntax limits and empty host/userinfo boundary cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -224,6 +224,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -224,6 +224,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -224,6 +224,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -227,6 +227,61 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "multiple colons in port is invalid",
+                "data": "http://a.com:8:0",
+                "valid": false
+            },
+            {
+                "description": "colon in port is invalid",
+                "data": "http://a.com::",
+                "valid": false
+            },
+            {
+                "description": "port may be empty when colon is present",
+                "data": "http://a.com:",
+                "valid": true
+            },
+            {
+                "description": "port has no RFC 3986 upper bound",
+                "data": "http://a.com:999999999",
+                "valid": true
+            },
+            {
+                "description": "authority with empty host and explicit port is valid",
+                "data": "http://:80",
+                "valid": true
+            },
+            {
+                "description": "userinfo may be empty",
+                "data": "http://@a.com",
+                "valid": true
+            },
+            {
+                "description": "userinfo with non-empty value and empty host is valid",
+                "data": "http://user@",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may contain sub-delimiters",
+                "data": "http://!$&'()*+,;=.com",
+                "valid": true
+            },
+            {
+                "description": "host reg-name may end with a dot",
+                "data": "http://example.com.",
+                "valid": true
+            },
+            {
+                "description": "tilde is valid in reg-name because it is an unreserved character",
+                "data": "http://exa~mple.com/",
+                "valid": true
+            },
+            {
+                "description": "underscore is valid in reg-name because it is an unreserved character",
+                "data": "http://under_score.com/",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Applies to: draft-v1, draft-04, draft-06, draft-07, draft/2019-09, draft/2020-12

Adds 11 new cases validating port boundaries, empty host/userinfo scanning limits, and host reg-name character compatibility.

Added:
- Invalid colons in port `:8:0` and `::` (invalid)
- Empty port with colon (valid)
- Port with no upper bound (valid)
- Empty host with explicit port (valid)
- Empty userinfo `@` (valid)
- Userinfo with empty host (valid)
- Sub-delimiters in host reg-name (valid)
- Host reg-name ending in a dot (valid)
- Tilde in host reg-name (valid)
- Underscore in host reg-name (valid)

### Ecosystem Impact (Triangulation):
Under Bowtie verification against 8 active implementations, these cases successfully caught live compliance issues:
1. **Go Bug Caught:** `go-gojsonschema` incorrectly accepts invalid colons in port.
2. **PHP Bug Caught:** `php-opis-json-schema` incorrectly rejects empty ports, ports with no upper bound, empty host with port, empty host with userinfo, sub-delimiters, trailing dots, tildes, and underscores in host reg-names.

@jviotti @jdesrosiers @karenetheridge Ready for review.