### PR TITLE
test(format/date-time): add trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -165,6 +165,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -165,6 +165,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -52,6 +52,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -162,6 +162,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -162,6 +162,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -162,6 +162,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -165,6 +165,11 @@
                 "description": "a second fraction of fifteen nines is valid",
                 "data": "1985-04-12T00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) and found the suite has no date-time test for a trailing newline.

RFC 3339 section 5.6 defines `date-time = full-date "T" full-time`, and every production is a fixed sequence of digits and literals ending at the time-offset - the grammar emits no line feed, so nothing may follow the offset. A single trailing `\n` is therefore invalid. The suite tests a trailing space (`Z `) and trailing content (`Z extra`), both of which the reference validator rejects; it does not test the newline, which the reference validator accepts.

## Changes

- Added 1 test case across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `1985-04-12T23:20:50Z\n` - a valid date-time followed by a single line feed - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1**: FAILS (accepts it). Its `date-time` check delegates to rfc3339-validator, which builds `RFC3339_REGEX + "$"` and calls `re.match`; Python's `$` matches immediately before a single trailing `\n`, so the line feed is never seen. `Z ` and `Z extra` get rejected, but `Z\n` slips through.
2. **ajv-formats 3.0.1 (full and fast)**: PASSES (rejects it). JavaScript `$` without the `m` flag matches only at the very end of the string, so the trailing `\n` is not consumed.
3. **sourcemeta/core `is_rfc3339_datetime`**: PASSES (rejects it) - it requires the whole string to parse.
4. Corroboration: jsonschema-rs 0.45.0, boon 0.6.1, santhosh-tekuri/jsonschema v6.0.2, and @hyperjump/json-schema 1.17.6 (four more JSON Schema validators, each with its own RFC 3339 parser) all reject it - so python-jsonschema is the lone outlier.

## RFC References

- RFC 3339 section 5.6 (Internet Date/Time Format): https://www.rfc-editor.org/rfc/rfc3339#section-5.6

Reproduction and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
