### PR TITLE
test(format/date-time): add numeric offset without minutes as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -150,6 +150,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -150,6 +150,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -37,6 +37,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -147,6 +147,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -147,6 +147,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -147,6 +147,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -150,6 +150,11 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) and found the suite has no date-time test for a numeric offset that omits the minutes.

RFC 3339 section 5.6 defines `time-numoffset = ("+" / "-") time-hour ":" time-minute` - the colon and the two-digit `time-minute` are both required. So `+01` (hour only, no `:mm`) is invalid. The suite covers a bad offset minute (`+10:60`) and a bad offset hour (`+24:00`), but not a whole missing minutes component.

## Changes

- Added 1 test case across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `1985-04-12T23:20:50+01` - a numeric offset with no minutes - invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 (full and fast)**: FAILS (accepts it). The offset in ajv's TIME regex is `(z|([+-])(\d\d)(?::?(\d\d))?)` - the entire `(?::?(\d\d))?` minute group is optional, so `+01` matches with the minutes treated as absent. This is the default `addFormats(ajv)` mode.
2. **python-jsonschema 4.25.1**: PASSES (rejects it) - rfc3339-validator requires `[+-]\d\d:\d\d`.
3. **sourcemeta/core `is_rfc3339_datetime`**: PASSES (rejects it).
4. Corroboration: jsonschema-rs 0.45.0, boon 0.6.1, santhosh-tekuri/jsonschema v6.0.2, and @hyperjump/json-schema 1.17.6 all reject it - ajv-formats is the outlier.

This is the same regex-branch class as ajv-formats issue [#117](https://github.com/ajv-validator/ajv-formats/issues/117) (colonless offset `+0130`); the missing-minutes form `+01` is the second, distinct sub-branch of the same optional group.

## RFC References

- RFC 3339 section 5.6 (Internet Date/Time Format, `time-numoffset`): https://www.rfc-editor.org/rfc/rfc3339#section-5.6

Reproduction and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
