### PR TITLE
test(format/date-time): add high-precision second fraction as valid

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -160,6 +160,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -160,6 +160,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -47,6 +47,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -157,6 +157,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -157,6 +157,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -157,6 +157,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -160,6 +160,11 @@
                 "description": "hour 24 is invalid even with a leap second",
                 "data": "2016-12-31T24:59:60+01:00",
                 "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) and found the suite has no date-time test for a second fraction long enough to expose the float-coercion bound in a real validator.

RFC 3339 section 5.6 defines `time-secfrac = "." 1*DIGIT` - the fraction is unbounded, any number of digits is valid. `1985-04-12T00:59:59.999999999999999Z` (second 59, fifteen 9s) is therefore valid. This exercises the boundary a validator hits if it coerces the seconds field to a float: fifteen 9s is the smallest count that rounds `59.999...` up to exactly `60.0`.

## Changes

- Added 1 test case across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `1985-04-12T00:59:59.999999999999999Z` - a valid second fraction of fifteen 9s - valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 full**: FAILS (rejects it). ajv computes `sec = Number("59." + fifteen 9s)`, which is `60.0` exactly (IEEE-754; the gap between representable doubles at 60 is 2^-47), so `sec < 60` is false and it falls into the leap-second branch, which needs UTC hour 23 - at hour 00 it rejects a valid input. This is the default `addFormats(ajv)` mode; ajv-fast (pure regex) accepts it. Fourteen 9s (the control) stays below 60.0 and is accepted.
2. **python-jsonschema 4.25.1**: PASSES (accepts it).
3. **sourcemeta/core `is_rfc3339_datetime`**: PASSES (accepts it).
4. Corroboration: jsonschema-rs 0.45.0, boon 0.6.1, santhosh-tekuri/jsonschema v6.0.2, and @hyperjump/json-schema 1.17.6 all accept it - ajv-formats full is the lone validator wrongly rejecting a valid input.

## RFC References

- RFC 3339 section 5.6 (Internet Date/Time Format, `time-secfrac = "." 1*DIGIT`): https://www.rfc-editor.org/rfc/rfc3339#section-5.6

Reproduction and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
