### PR TITLE
fix: handle unknown specification kinds

### DIFF
--- a/bin/annotate-specification-links
+++ b/bin/annotate-specification-links
@@ -108,7 +108,7 @@ def main():
 
                         (kind, spec) = extract_kind_and_spec(key)
 
-                        url_template = version_urls[kind]
+                        url_template = version_urls.get(kind)
                         if url_template is None:
                             error = annotation(
                                 level="error",


### PR DESCRIPTION
## Summary

`bin/annotate-specification-links` currently looks up URL templates using `version_urls[kind]`. If `kind` is not present in `specification_urls.json`, this raises a `KeyError` before the subsequent `None` check can run, making the intended error-handling path unreachable.

This change replaces the dictionary indexing with `version_urls.get(kind)`, allowing unknown specification kinds to be handled gracefully by emitting the existing annotation instead of terminating the script with a traceback.

## Changes

- Replace `version_urls[kind]` with `version_urls.get(kind)` in `bin/annotate-specification-links`.

## Why

The code already contains logic to handle missing URL templates:

```python
url_template = version_urls.get(kind)
if url_template is None:
    ...
```

