### PR TITLE
fix: handle non-JSON files and invalid JSON

### DIFF
--- a/bin/annotation-tests.ts
+++ b/bin/annotation-tests.ts
@@ -8,9 +8,18 @@ console.log("Validating annotation tests ...");
 
 let isValid = true;
 for await (const entry of Deno.readDir("./annotations/tests")) {
-  if (entry.isFile) {
+  if (entry.isFile && entry.name.endsWith(".json")) {
     const json = await Deno.readTextFile(`./annotations/tests/${entry.name}`);
-    const suite = JSON.parse(json);
+
+    let suite;
+    try {
+      suite = JSON.parse(json);
+    } catch (error) {
+      isValid = false;
+      console.log(`\x1b[31m✖\x1b[0m ${entry.name}`);
+      console.log(`  contains invalid JSON (${error.message})`);
+      continue;
+    }
 
     const output = validateTestSuite(suite, BASIC);
 


### PR DESCRIPTION
## Summary

This PR improves the robustness of the repository's annotation validation scripts by handling two cases that currently result in uncaught exceptions.

- `bin/annotate-specification-links` now uses `version_urls.get(kind)` instead of direct dictionary indexing, allowing the existing error-handling path for unknown specification kinds to execute.
- `bin/annotation-tests.ts` now only processes `.json` files and reports invalid JSON with a readable per-file error instead of aborting with an uncaught exception.

## Changes

### `bin/annotate-specification-links`

- Replace `version_urls[kind]` with `version_urls.get(kind)`.

This ensures that unknown specification kinds are handled by the existing `None` check rather than raising a `KeyError`.

### `bin/annotation-tests.ts`

- Only process files ending with `.json`.
- Wrap `JSON.parse` in a `try`/`catch`.
- Report invalid JSON as a per-file validation error and continue validating the remaining files.

This prevents unrelated files (such as `README.md` or editor temporary files) or malformed JSON from terminating the validation script with an uncaught exception.

## Why

Both changes make the validation scripts more resilient while preserving their behavior for valid inputs.

- Unknown specification kinds now follow the existing error-reporting path instead of raising a `KeyError`.
- Annotation test validation now ignores non-JSON files and reports malformed JSON with a clear error message instead of failing with a stack trace.
