### PR TITLE
test(duration): reject weeks combined with time or a zero-valued component

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -237,6 +237,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "P1D\n",
                 "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -237,6 +237,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "P1D\n",
                 "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -237,6 +237,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "P1D\n",
                 "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) and the `duration` format definition in the validation spec, and found the current duration.json covers `P1Y2W` (week + a non-zero date component) but not two related week-exclusivity cases.

RFC 3339 Appendix A makes `dur-week` a top-level exclusive alternative: `duration = "P" (dur-date / dur-time / dur-week)`. A week cannot be combined with any date or time component.

## Changes

- Added 2 test cases across draft2019-09 and draft2020-12 (the drafts where the duration format exists).
- `P1WT1H` is invalid (week combined with a time component).
- `P0Y1W` is invalid (week after a zero-valued component).

## Ecosystem Impact

1. **python-jsonschema 4.25.1** (via isoduration 20.11.0): FAILS both.
   For `P1WT1H` isoduration parses the part after `T` as a separate `TimeDuration`, so the week-exclusivity check never sees the combination. For `P0Y1W` it checks exclusivity by value (`if is_week(ch) and duration != DateDuration(): raise`), and a `0Y` leaves the object equal to its default so the raise never fires. The existing `P1Y2W` (non-zero) is correctly rejected, so `P0Y1W` exposes a gap that test misses.

2. **jsonschema-rs 0.34.0** and **networknt (strict)**: FAIL `P1WT1H` for the same separate-time-block reason; both reject `P0Y1W`.

3. **ajv-formats 3.0.1** and **sourcemeta/core**: PASS - both reject correctly.

## RFC References

- RFC 3339 Appendix A (duration ABNF): https://www.rfc-editor.org/rfc/rfc3339#appendix-A

Reproduction commands and the wider duration cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/duration.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
