### PR TITLE
test(duration): reject a leading sign

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -217,6 +217,11 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -217,6 +217,11 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -217,6 +217,11 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) and the `duration` format definition in the validation spec, and found the current duration.json has no test for a signed duration.

RFC 3339 Appendix A begins the `duration` production with the literal `"P"`: `duration = "P" (dur-date / dur-time / dur-week)`. There is no sign anywhere in any production - `1*DIGIT` is `%x30-39` only. A leading sign is an ISO 8601-2 extension that Appendix A does not carry.

## Changes

- Added 1 test case across draft2019-09 and draft2020-12 (the drafts where the duration format exists).
- `-P1D` is invalid (a leading sign is not part of the grammar).

## Ecosystem Impact

1. **python-jsonschema 4.25.1** (via isoduration 20.11.0): FAILS.
   isoduration begins with an explicit sign loop (`if first == "-": sign = -1`, and the same for `+`) before the `P`, so the sign is consumed and the rest parses. The result ends in `D`, so the `instance.endswith(tuple("DMYWHMS"))` guard in `is_duration` passes too.

2. **ajv-formats 3.0.1** and **sourcemeta/core**: PASS - both reject (ajv's regex is anchored at `^P`).

This is the same case raised in json-schema-spec [#1603](https://github.com/json-schema-org/json-schema-spec/issues/1603) ("the same issue exists for negative durations, e.g. `-PT1S`").

## RFC References

- RFC 3339 Appendix A (duration ABNF): https://www.rfc-editor.org/rfc/rfc3339#appendix-A

Reproduction commands and the wider duration cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/duration.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
