### PR TITLE
test(duration): reject a number before the time separator with no unit

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -222,6 +222,11 @@
                 "description": "a leading sign is not allowed",
                 "data": "-P1D",
                 "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -222,6 +222,11 @@
                 "description": "a leading sign is not allowed",
                 "data": "-P1D",
                 "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -222,6 +222,11 @@
                 "description": "a leading sign is not allowed",
                 "data": "-P1D",
                 "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) and found the current duration.json has "element without unit" (`P1`, a number with no unit at the end) but no test for a number with no unit that sits before the `T` separator.

Every `1*DIGIT` in the grammar is immediately followed by its unit designator (`dur-day = 1*DIGIT "D"`, etc.). In `P1D2T3H` the digit run `2` is followed by `T`, which is not a unit designator, so the string is invalid. This is a different position from the existing `P1` test.

## Changes

- Added 1 test case across draft2019-09 and draft2020-12 (the drafts where the duration format exists).
- `P1D2T3H` is invalid (the `2` before `T` has no unit designator).

## Ecosystem Impact

1. **python-jsonschema 4.25.1** (via isoduration 20.11.0): FAILS.
   On reaching `T` mid-date-string, isoduration checks whether the accumulated value equals the whole date prefix; it does not (`"2"` vs `"1D2"`), so it drops the dangling `2` and parses `3H` as the time. The result ends in `H`, so the `endswith(tuple("DMYWHMS"))` guard passes. I found this case with a seeded mutation fuzzer, not by hand.

2. **ajv-formats 3.0.1** and **sourcemeta/core**: PASS - both reject.

## RFC References

- RFC 3339 Appendix A (duration ABNF): https://www.rfc-editor.org/rfc/rfc3339#appendix-A

Reproduction commands and the wider duration cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/duration.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
