### PR TITLE
test(duration): reject exponent notation in a component

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -227,6 +227,11 @@
                 "description": "a number before the time separator has no unit",
                 "data": "P1D2T3H",
                 "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -227,6 +227,11 @@
                 "description": "a number before the time separator has no unit",
                 "data": "P1D2T3H",
                 "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -227,6 +227,11 @@
                 "description": "a number before the time separator has no unit",
                 "data": "P1D2T3H",
                 "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) and found the current duration.json tests the no-fraction rule (`PT0.5S`) but not exponent / scientific notation, which the same `1*DIGIT` rule excludes.

Each component amount is `1*DIGIT` where `DIGIT` is `%x30-39`, so `e`/`E` is not allowed. `P1e2D` is invalid.

## Changes

- Added 1 test case across draft2019-09 and draft2020-12 (the drafts where the duration format exists).
- `P1e2D` is invalid (exponent notation is not part of a component).

## Ecosystem Impact

1. **python-jsonschema 4.25.1** (via isoduration 20.11.0): FAILS.
   isoduration parses each component amount with `Decimal(tmp_value)`, and its `is_number` character class includes `e`/`E`, so `Decimal("1e2")` yields 100 and the component is accepted. The result ends in `D`, so the `endswith` guard passes.

2. **ajv-formats 3.0.1** and **sourcemeta/core**: PASS - both reject.

A more serious variant of the same root cause: a huge exponent such as `P1E1000000D` makes `Decimal` raise `decimal.Overflow`, which `is_duration` does not catch (it declares only `raises=isoduration.DurationParsingException`), so python-jsonschema raises an uncaught exception instead of returning a verdict. That one is a robustness issue I am reporting upstream separately; this test covers the plain exponent case.

## RFC References

- RFC 3339 Appendix A (duration ABNF): https://www.rfc-editor.org/rfc/rfc3339#appendix-A

Reproduction commands and the wider duration cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/duration.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
