### PR TITLE
test(duration): reject a trailing newline

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -232,6 +232,11 @@
                 "description": "exponent notation is not allowed in a component",
                 "data": "P1e2D",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -232,6 +232,11 @@
                 "description": "exponent notation is not allowed in a component",
                 "data": "P1e2D",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -232,6 +232,11 @@
                 "description": "exponent notation is not allowed in a component",
                 "data": "P1e2D",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) and found the current duration.json tests a trailing space (`P1D `) but not a trailing newline. These are not the same test: a trailing newline exposes a regex-anchor bug that a trailing space does not. The suite already has a trailing-newline test for `ipv4`, so this brings duration in line.

The duration grammar contains no whitespace, so a duration followed by a newline is invalid.

## Changes

- Added 1 test case across draft2019-09 and draft2020-12 (the drafts where the duration format exists).
- A valid duration followed by a newline (`P1D` + `\n`) is invalid.

## Ecosystem Impact

1. **jsonschemafriend 0.12.5** (Java): FAILS the trailing newline, but correctly rejects a trailing space. Its regex ends with `$`, and Java's `$` matches just before a final `\n`, so only the newline slips through. This is exactly why the trailing-newline case is distinct from the existing trailing-space test.

2. **opis/json-schema 2.6.0** (PHP) and **tdegrunt/jsonschema 1.5.0** (JS): also FAIL (missing end anchor / no anchors at all).

3. **ajv-formats 3.0.1**, **python-jsonschema 4.25.1**, and **sourcemeta/core**: PASS - all reject.

## RFC References

- RFC 3339 Appendix A (duration ABNF): https://www.rfc-editor.org/rfc/rfc3339#appendix-A

Reproduction commands and the wider duration cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/duration.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
