### PR TITLE
test(regex): cover ECMA 262 dialect validity in ecmascript-regex format tests

### DIFF
--- a/tests/draft2020-12/optional/format/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/format/ecmascript-regex.json
@@ -12,5 +12,105 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "Python-specific regular expression syntax is not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "Python named group (?P<name>...) is not ECMA 262",
+        "data": "(?P<name>x)",
+        "valid": false
+      },
+      {
+        "description": "Python named backreference (?P=name) is not ECMA 262",
+        "data": "(?P<n>a)(?P=n)",
+        "valid": false
+      },
+      {
+        "description": "inline comment group (?#...) is not ECMA 262",
+        "data": "(?#comment)a",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "global inline flag groups are not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a single global inline flag (?i)",
+        "data": "(?i)abc",
+        "valid": false
+      },
+      {
+        "description": "multiple global inline flags (?ims)",
+        "data": "(?ims)abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 named groups and backreferences are valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an ECMA 262 named group (?<name>...)",
+        "data": "(?<name>x)",
+        "valid": true
+      },
+      {
+        "description": "an ECMA 262 named backreference \\k<name>",
+        "data": "(?<n>a)\\k<n>",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 lookbehind is valid, including variable width",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a variable-width lookbehind (ES2018)",
+        "data": "(?<=a+)b",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 character classes and escapes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an empty character class is valid ECMA 262",
+        "data": "[]",
+        "valid": true
+      },
+      {
+        "description": "a negated empty character class is valid ECMA 262",
+        "data": "[^]",
+        "valid": true
+      },
+      {
+        "description": "a control escape \\cA is valid ECMA 262",
+        "data": "\\cA",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/tests/v1/format/ecmascript-regex.json
+++ b/tests/v1/format/ecmascript-regex.json
@@ -12,5 +12,105 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "Python-specific regular expression syntax is not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "Python named group (?P<name>...) is not ECMA 262",
+        "data": "(?P<name>x)",
+        "valid": false
+      },
+      {
+        "description": "Python named backreference (?P=name) is not ECMA 262",
+        "data": "(?P<n>a)(?P=n)",
+        "valid": false
+      },
+      {
+        "description": "inline comment group (?#...) is not ECMA 262",
+        "data": "(?#comment)a",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "global inline flag groups are not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a single global inline flag (?i)",
+        "data": "(?i)abc",
+        "valid": false
+      },
+      {
+        "description": "multiple global inline flags (?ims)",
+        "data": "(?ims)abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 named groups and backreferences are valid",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an ECMA 262 named group (?<name>...)",
+        "data": "(?<name>x)",
+        "valid": true
+      },
+      {
+        "description": "an ECMA 262 named backreference \\k<name>",
+        "data": "(?<n>a)\\k<n>",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 lookbehind is valid, including variable width",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a variable-width lookbehind (ES2018)",
+        "data": "(?<=a+)b",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 character classes and escapes",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an empty character class is valid ECMA 262",
+        "data": "[]",
+        "valid": true
+      },
+      {
+        "description": "a negated empty character class is valid ECMA 262",
+        "data": "[^]",
+        "valid": true
+      },
+      {
+        "description": "a control escape \\cA is valid ECMA 262",
+        "data": "\\cA",
+        "valid": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
The optional `ecmascript-regex` format file currently has a single case (`\a` is not an ECMA 262 control escape). `format: regex` points at the [ECMA 262 regular expression dialect](https://json-schema.org/draft/2020-12/json-schema-core#name-regular-expressions), and this file is where dialect-specific validity belongs, so I added the mode-independent cases that the single `\a` test leaves uncovered.

## Changes

Added to `tests/draft2020-12/optional/format/ecmascript-regex.json` and `tests/v1/format/ecmascript-regex.json`:

- Python-specific syntax that is not ECMA 262 (invalid): Python named group `(?P<name>x)`, Python named backreference `(?P<n>a)(?P=n)`, inline comment group `(?#comment)a`.
- Global inline flag groups (invalid): `(?i)abc`, `(?ims)abc`.
- ECMA 262 named groups and backreferences (valid): `(?<name>x)`, `(?<n>a)\k<n>`.
- ECMA 262 lookbehind including variable width (valid): `(?<=a+)b`.
- ECMA 262 character classes and escapes (valid): `[]`, `[^]`, `\cA`.

Every added case has the same verdict under both the strict (`u`-mode) and the default ECMA 262 readings, so none of them depends on the open question of which mode `format: regex` means (unlike the existing `\a` case, which is `u`-mode-only). Verdicts match Node's `RegExp` and ajv-formats.

## Ecosystem impact

- **ajv-formats 3.0.1** (Node `new RegExp`): passes every added case - it is the faithful ECMA 262 reference.
- **python-jsonschema 4.25.1** (validates with Python `re`, not ECMA 262): fails the Python-syntax and inline-flag cases (it accepts `(?P<name>x)`, `(?i)abc`, `(?#c)a`) and fails the ECMA-only valid cases (it rejects `(?<name>x)`, `(?<=a+)b`, `[]`, `\cA`). That is the divergence the tests document: `is_regex` is `re.compile`, so it mirrors Python's engine rather than ECMA 262.
- These live in `optional/` because the dialect is opt-in; a validator runs them only if it claims ECMA 262 regex support.

## Notes

- `(?P<...>)`, `(?P=...)`, `(?#...)`, and global `(?i)` inline flags are not in the ECMA 262 pattern grammar in any edition (global inline flags never existed; only the bounded `(?i:...)` form, ES2025). Named groups/backreferences and lookbehind (ES2018) are ECMA 262 grammar.
- Validity tests only; matching/anchoring behavior is unchanged.

Related: #965
