### PR TITLE
test(uuid): add an underscore in place of a hex digit as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -130,6 +130,11 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -130,6 +130,11 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -130,6 +130,11 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 9562 section 4](https://www.rfc-editor.org/rfc/rfc9562.html#section-4) (the string representation, `HEXDIG = DIGIT / "A".."F"`) and found that the current file has no case for a non-hex character that a lenient integer parser would still accept. The existing "bad characters (not hex)" case uses `g`, which every validator rejects.

An underscore is not a `HEXDIG`, so `2eb8aa08-aa98-11ea-b4aa-73b441d1_380` is not a valid UUID string. It is exactly 36 characters with hyphens in the right places, so a length or hyphen-position check does not catch it - only a character-set check does.

## Changes

- Added 1 test case to draft2019-09 and draft2020-12.
- `2eb8aa08-aa98-11ea-b4aa-73b441d1_380` - an underscore where a hex digit should be, expected invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1**: PASSES (rejects it). Its regex validates each position against a literal `[0-9a-f]`, which does not include `_`.
2. **python-jsonschema 4.25.1**: FAILS (accepts it). `is_uuid` builds `UUID(instance)` and then only checks the hyphen positions. Inside `uuid.UUID`, the 32 hex characters are validated with `int(hex, 16)`, and Python's `int(str, 16)` treats `_` as a PEP 515 digit separator - `int('73b441d1_380', 16)` succeeds - so `UUID()` never rejects it. This is different from the `g` case, which reaches `int()` and raises `ValueError`.

## RFC References

- RFC 9562 section 4 (UUID string representation, `HEXDIG`): https://www.rfc-editor.org/rfc/rfc9562.html#section-4
- JSON Schema validation section 7.3.5 (the `uuid` format): https://json-schema.org/draft/2020-12/json-schema-validation#section-7.3.5

Reproduction commands and the uuid cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
