### PR TITLE
test(uuid): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -135,6 +135,11 @@
                 "description": "an underscore in place of a hex digit is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -135,6 +135,11 @@
                 "description": "an underscore in place of a hex digit is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -135,6 +135,11 @@
                 "description": "an underscore in place of a hex digit is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 9562 section 4](https://www.rfc-editor.org/rfc/rfc9562.html#section-4) and found that the current file has no case for a trailing newline. The grammar fixes the string at 36 characters with no trailing content, but several validators accept a trailing `\n` because their regex ends in `$`, which matches just before a final newline in most engines.

This is the same anchor class already covered for duration (#982) and date-time (#959); the uuid file does not have it yet.

## Changes

- Added 1 test case to draft2019-09 and draft2020-12.
- `2eb8aa08-aa98-11ea-b4aa-73b441d16380\n` - a complete UUID followed by a newline, expected invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1** and **python-jsonschema 4.25.1**: PASS (reject it). ajv's regex uses JavaScript `$`, which does not match before a trailing newline; python-jsonschema rejects it on the `len(hex) != 32` check inside `uuid.UUID`.
2. **api7/jsonschema 0.9.13** (Lua): FAILS (accepts it). Its pattern `^[0-9a-fA-F]{8}-...-[0-9a-fA-F]{12}$` runs under PCRE, where `$` matches before a trailing `\n`.
3. **opis/json-schema 2.6.0** (PHP) and **Newtonsoft.Json.Schema 4.0.2** (.NET): FAIL (accept it), same trailing-newline anchor behavior.

## RFC References

- RFC 9562 section 4 (UUID string representation, fixed 36-character form): https://www.rfc-editor.org/rfc/rfc9562.html#section-4

Reproduction commands and the uuid cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
