### PR TITLE
test(uuid): add a non-RFC-4122 variant nibble as valid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -140,6 +140,11 @@
                 "description": "a trailing newline after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
                 "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -140,6 +140,11 @@
                 "description": "a trailing newline after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
                 "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -140,6 +140,11 @@
                 "description": "a trailing newline after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
                 "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 9562 section 4.1](https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1) and found that the current file pins the version field (the "hypothetical version 6/15" cases) but has nothing pinning the variant field. Every valid case in the file happens to use variant nibble `b`.

The `uuid` format is a string-syntax check. Section 4.1 does not constrain the variant nibble at the string level, so a UUID whose variant is outside RFC 4122's `8/9/a/b` range is still a valid string. This case pins that field so a validator cannot wrongly enforce it.

## Changes

- Added 1 test case to draft2019-09 and draft2020-12.
- `2eb8aa08-aa98-11ea-f4aa-73b441d16380` - variant nibble `f` (not defined by RFC 4122), expected valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1**, **python-jsonschema 4.25.1**, and **sourcemeta/core** `is_uuid_like`: PASS (accept it). None of them constrains the variant nibble.
2. This catches a validator that enforces the variant on its per-version path - `uuid` npm and `validator.js` both do that (see [validator.js #2419](https://github.com/validatorjs/validator.js/issues/2419)) - which no existing test catches, since every valid case in the file uses variant `b`.

## RFC References

- RFC 9562 section 4.1 (variant field, no string-level constraint): https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1
- RFC 9562 section 4 (UUID string representation): https://www.rfc-editor.org/rfc/rfc9562.html#section-4

Reproduction commands and the uuid cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uuid.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
