### PR TITLE
Add annotation tests for v1 changes to $dynamicRef

### DIFF
--- a/annotations/README.md
+++ b/annotations/README.md
@@ -59,6 +59,12 @@ compatible only with 2020-12.
 
 **Example**: `"compatibility": "=2020"`
 
+This test suite can support tests for yet to be released features as well. Use
+`9999` for these tests. When the feature is officially released, the
+compatibility needs to be updated to match the release version.
+
+**Example**: `"compatibility": "9999"`
+
 ### schema
 
 The schema that will serve as the subject for the tests. Whenever possible, this

--- a/annotations/test-case.schema.json
+++ b/annotations/test-case.schema.json
@@ -10,7 +10,7 @@
     "compatibility": {
       "markdownDescription": "Set which dialects the Test Case is compatible with. Examples:\n- `\"7\"` -- draft-07 and above\n- `\"<=2019\"` -- 2019-09 and previous\n- `\"6,<=2019\"` -- Between draft-06 and 2019-09\n- `\"=2020\"` -- 2020-12 only",
       "type": "string",
-      "pattern": "^(<=|=)?([123467]|2019|2020)(,(<=|=)?([123467]|2019|2020))*$"
+      "pattern": "^(<=|=)?([123467]|2019|2020|9999)(,(<=|=)?([123467]|2019|2020|9999))*$"
     },
     "schema": {
       "markdownDescription": "This schema shouldn't include `$schema` or `id`/`$id` unless necessary for the test because Test Cases should be designed to work with as many releases as possible.",

--- a/annotations/tests/core.json
+++ b/annotations/tests/core.json
@@ -28,7 +28,34 @@
     },
     {
       "description": "`$dynamicRef` resolves to `$dynamicAnchor`",
-      "compatibility": "2020",
+      "compatibility": "9999",
+      "schema": {
+        "$dynamicRef": "foo",
+        "$defs": {
+          "foo": {
+            "$dynamicAnchor": "foo",
+            "title": "Foo"
+          }
+        }
+      },
+      "tests": [
+        {
+          "instance": "bar",
+          "assertions": [
+            {
+              "location": "",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/foo": "Foo"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "`$dynamicRef` resolves to `$dynamicAnchor`",
+      "compatibility": "=2020",
       "schema": {
         "$dynamicRef": "#foo",
         "$defs": {
@@ -55,7 +82,81 @@
     },
     {
       "description": "`$dynamicRef` resolves to different `$dynamicAnchor`s depending on dynamic path",
-      "compatibility": "2020",
+      "compatibility": "9999",
+      "schema": {
+        "$id": "https://test.json-schema.org/dynamic-ref-annotation/main",
+        "if": {
+          "properties": { "kindOfList": { "const": "numbers" } },
+          "required": ["kindOfList"]
+        },
+        "then": { "$ref": "numberList" },
+        "else": { "$ref": "stringList" },
+        "$defs": {
+          "genericList": {
+            "$id": "genericList",
+            "properties": {
+              "list": {
+                "items": { "$dynamicRef": "itemType" }
+              }
+            },
+            "$defs": {
+              "defaultItemType": {
+                "$dynamicAnchor": "itemType"
+              }
+            }
+          },
+          "numberList": {
+            "$id": "numberList",
+            "$defs": {
+              "itemType": {
+                "$dynamicAnchor": "itemType",
+                "title": "Number Item"
+              }
+            },
+            "$ref": "genericList"
+          },
+          "stringList": {
+            "$id": "stringList",
+            "$defs": {
+              "itemType": {
+                "$dynamicAnchor": "itemType",
+                "title": "String Item"
+              }
+            },
+            "$ref": "genericList"
+          }
+        }
+      },
+      "tests": [
+        {
+          "instance": { "kindOfList": "numbers", "list": [1] },
+          "assertions": [
+            {
+              "location": "/list/0",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/numberList/$defs/itemType": "Number Item"
+              }
+            }
+          ]
+        },
+        {
+          "instance": { "kindOfList": "strings", "list": ["foo"] },
+          "assertions": [
+            {
+              "location": "/list/0",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/stringList/$defs/itemType": "String Item"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "`$dynamicRef` resolves to different `$dynamicAnchor`s depending on dynamic path",
+      "compatibility": "=2020",
       "schema": {
         "$id": "https://test.json-schema.org/dynamic-ref-annotation/main",
         "if": {
@@ -127,6 +228,5 @@
         }
       ]
     }
-
   ]
-} 
+}


### PR DESCRIPTION
This adds support for adding annotation tests for new v1 features. This allows tests for the v1 changes to `$dynamicRef`.