### PR TITLE
test(ipv4): add valid coverage for the 200-249 and two-digit dec-octet branches

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false


### PR DESCRIPTION

I traced the ipv4 format to the dotted-quad grammar in RFC 3986 Section 3.2.2 (https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), where `dec-octet` has five alternatives:

```
dec-octet = DIGIT                 ; 0-9
          / %x31-39 DIGIT         ; 10-99
          / "1" 2DIGIT            ; 100-199
          / "2" %x30-34 DIGIT     ; 200-249
          / "25" %x30-35          ; 250-255
```

The three valid tests currently in `optional/format/ipv4.json` (`192.168.0.1`, `0.0.0.0`, `255.255.255.255`) only exercise three of these five branches. Their octet values are 0, 1, 168, 192, 255, which land in the `DIGIT`, `"1" 2DIGIT`, and `"25" %x30-35` branches. Nothing valid exercises the `%x31-39 DIGIT` branch (a two-digit octet 10-99) or the `"2" %x30-34 DIGIT` branch (200-249).

That is a real gap. A validator whose regex drops the `2[0-4]\d` alternative (for example `25[0-5]|1\d\d|[1-9]?\d`) would wrongly reject `200.0.0.0` while still passing every existing valid test. I checked this by building a regex missing that alternative: it passes all 38 current tests and rejects `200.0.0.0`. The same holds for a validator that only accepts a single-digit low octet - it passes the current tests and rejects `10.20.30.40`.

## Changes

Two valid tests, added to the draft4/6/7/2019-09/2020-12 copies of the file:

- `200.0.0.0` - an octet in the 200-249 branch (`"2" %x30-34 DIGIT`)
- `10.20.30.40` - every octet in the two-digit 10-99 branch (`%x31-39 DIGIT`)

Both are accepted by ajv-formats 3.0.1 (full and fast) and python-jsonschema 4.25.1, so they pass on a correct implementation. They exist to catch a wrong one that no current test catches.

## RFC References

- RFC 3986 Section 3.2.2 - the `IPv4address` / `dec-octet` ABNF.

Related: #965
