### PR TITLE
test(ipv4): add IPv4-mapped IPv6 address as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv4.json
+++ b/tests/draft2019-09/optional/format/ipv4.json
@@ -193,6 +193,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false

--- a/tests/draft2020-12/optional/format/ipv4.json
+++ b/tests/draft2020-12/optional/format/ipv4.json
@@ -193,6 +193,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false

--- a/tests/draft4/optional/format/ipv4.json
+++ b/tests/draft4/optional/format/ipv4.json
@@ -190,6 +190,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false

--- a/tests/draft6/optional/format/ipv4.json
+++ b/tests/draft6/optional/format/ipv4.json
@@ -190,6 +190,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false

--- a/tests/draft7/optional/format/ipv4.json
+++ b/tests/draft7/optional/format/ipv4.json
@@ -190,6 +190,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false

--- a/tests/v1/format/ipv4.json
+++ b/tests/v1/format/ipv4.json
@@ -193,6 +193,11 @@
                 "valid": false
             },
             {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
+                "valid": false
+            },
+            {
                 "description": "single octet out of range in last position",
                 "data": "192.168.0.256",
                 "valid": false


### PR DESCRIPTION

RFC 3986 Section 3.2.2 (https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) defines `IPv4address` as exactly four `dec-octet` groups separated by `.` - a colon is not in the grammar, so the IPv4-mapped IPv6 literal `::ffff:192.168.0.1` is not an ipv4 value.

The suite already rejects a colon in `192.168.0.1:80` (the port test), but that test does not catch this bug class. A validator that delegates its ipv4 check to a general IP parser accepts the mapped literal while still rejecting `:80`, because the mapped form parses as an address and the port form does not. gojsonschema does exactly this - its checker is ([format_checkers.go, v1.2.0](https://github.com/xeipuuv/gojsonschema/blob/v1.2.0/format_checkers.go)):

```go
ip := net.ParseIP(asString)
return ip != nil && strings.Contains(asString, ".")
```

`::ffff:192.168.0.1` contains dots and `net.ParseIP` accepts it, so the check returns true. The same checker with `":"` backs its ipv6 format, so this one string passes both formats there.

## Changes

One test, added to the draft4/6/7/2019-09/2020-12 copies after the port test:

- `::ffff:192.168.0.1` - invalid

## Ecosystem Impact

- **gojsonschema v1.2.0** (Go): FAILS - returns valid (run live through its test harness; source above).
- **com.github.java-json-tools json-schema-validator 2.2.14** (Java): FAILS - returns valid (run live; it rejects `256.0.0.0` in the same run, so its ipv4 assertion is active).
- **ajv-formats 3.0.1** (full and fast): PASSES - rejects.
- **python-jsonschema 4.25.1** (`ipaddress.IPv4Address`): PASSES - rejects.

## RFC References

- RFC 3986 Section 3.2.2 - `IPv4address` / `dec-octet` ABNF.
- RFC 4291 Section 2.5.5.2 - the IPv4-mapped IPv6 address form this string actually is.

Related: #965
