### PR TITLE
test(hostname): reject a trailing newline

### DIFF
--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -120,6 +120,11 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     },

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -120,6 +120,11 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     },

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -142,6 +142,11 @@
                 "description": "IDN label separator",
                 "data": "example\uff0ecom",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -142,6 +142,11 @@
                 "description": "IDN label separator",
                 "data": "example\uff0ecom",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -117,6 +117,11 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     },

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -120,6 +120,11 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
             }
         ]
     },


### PR DESCRIPTION
I was checking `format: hostname` against [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) and found that a valid host name followed by a single line feed is accepted by python-jsonschema.

RFC 1123 section 2.1 changes exactly one aspect of the RFC 952 syntax - "the restriction on the first character is relaxed to allow either a letter or a digit" - and leaves the character repertoire alone. [RFC 952](https://www.rfc-editor.org/rfc/rfc952) defines that repertoire as "a text string up to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-), and period (.)", so a line feed cannot appear anywhere in a host name.

None of the existing tests in these files cover a trailing control character.

## Changes

One test in the "validation of host names" group, added to draft4, draft6, draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "trailing newline is invalid",
    "data": "example.com\n",
    "valid": false
}
```

## Ecosystem Impact

**python-jsonschema 4.25.1** (with the `[format]` extra) - FAILS. Its `is_host_name` calls `FQDN(instance, min_labels=1).is_valid`, and [fqdn](https://pypi.org/project/fqdn/) matches with `^...$`:

```python
PREFERRED_NAME_SYNTAX_REGEXSTR = (
    r"^((?![-])[-A-Z\d]{1,63}(?<!-)[.])*(?!-)[-A-Z\d]{1,63}(?<!-)[.]?$"
)
```

Python's `$` matches before a single trailing newline, so `example.com\n` passes. `\Z` would not. Only a single trailing LF slips through - CR, CRLF, a doubled LF, a leading LF, space, tab and NUL are all correctly rejected.

**ajv-formats 3.0.1** - PASSES (both `full` and `fast` mode).

Four other implementations accept it through the same anchor: **Corvus.JsonSchema 4.5.8**, **Newtonsoft.Json.Schema 4.0.2**, **opis/json-schema 2.6.0** (PHP), and **api7/jsonschema 0.9.13** (Lua, whose entire hostname check is the PCRE `^[a-zA-Z0-9\-\.]+$`).

This is the same anchor class as the `ipv4` trailing-newline test that landed in #840.

## RFC References

- [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) - relaxes only the first character; the repertoire is unchanged
- [RFC 952](https://www.rfc-editor.org/rfc/rfc952) ASSUMPTIONS 1 - the closed character set for a name
- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) - `<letter>` is "any one of the 52 alphabetic characters A through Z in upper case and a through z in lower case"

Related: #965
