### PR TITLE
test(hostname): reject a non-ASCII letter that case-maps to ASCII

### DIFF
--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     },

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     },

--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -147,6 +147,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -147,6 +147,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -122,6 +122,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     },

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -125,6 +125,11 @@
                 "description": "trailing newline is invalid",
                 "data": "example.com\n",
                 "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     },


### PR DESCRIPTION
While checking `format: hostname` against [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) I found that python-jsonschema accepts a host name whose first character is U+212A KELVIN SIGN rather than ASCII `k`. It renders as `Kelvin.example.com`, so it reads as an ordinary ASCII host name, but it is not one.

RFC 1123 section 2.1 changes only the first-character rule of the RFC 952 syntax and leaves the repertoire alone. [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) closes that repertoire: `<letter>` is "any one of the 52 alphabetic characters A through Z in upper case and a through z in lower case". U+212A is not one of the 52, so the host name is invalid.

The only test in these files containing a non-ASCII character is "IDN label separator" (U+FF0E), which python-jsonschema rejects correctly, so nothing here catches this.

## Changes

One test in the "validation of host names" group, added to draft4, draft6, draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
    "data": "\u212Aelvin.example.com",
    "valid": false
}
```

I wrote the character as the escape `\u212A` rather than pasting it. A raw U+212A is byte-different from ASCII `K` but renders identically, so pasted in there would be no way to tell from the diff what the test is about. The file already writes its other non-ASCII test that way (`example\uff0ecom`).

## Ecosystem Impact

**python-jsonschema 4.25.1** (with the `[format]` extra) - FAILS. `is_host_name` calls `FQDN(instance, min_labels=1).is_valid`, and [fqdn](https://pypi.org/project/fqdn/) lowercases the input before it validates:

```python
self._fqdn = fqdn.lower()
```

Python's `str.lower()` maps U+212A to ASCII `k`, so by the time the regex runs the string is `kelvin.example.com` and matches. The check validates a string the caller never supplied.

This is worth separating from the more familiar non-ASCII-digit leaks. fqdn's regex is Unicode-aware in two other places as well - `\d` matches the 640 Unicode decimal digits, and `re.IGNORECASE` makes `[-A-Z\d]` match U+0131 and U+017F - but compiling that regex with `re.ASCII` fixes those 642 codepoints and still leaves U+212A, because the lowercasing happens first. Sweeping the whole codepoint space through the installed checker, it accepts 643 non-ASCII codepoints in a label.

**ajv-formats 3.0.1** - PASSES (both modes).

Also accepting it: **Corvus.JsonSchema 4.5.8** and **java-json-tools 2.2.14**, plus the Node WHATWG URL parser, Go `x/net/idna`, the Rust `idna` crate and PHP `filter_var(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)`, which map or normalize before checking.

## RFC References

- [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) - relaxes only the first character
- [RFC 952](https://www.rfc-editor.org/rfc/rfc952) ASSUMPTIONS 1 - "drawn from the alphabet (A-Z), digits (0-9), minus sign (-), and period (.)"
- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) - `<letter>` is the 52 ASCII alphabetic characters

Related: #965

