### PR TITLE
test(hostname): accept consecutive hyphens inside a label

### DIFF
--- a/tests/draft2019-09/optional/format/hostname.json
+++ b/tests/draft2019-09/optional/format/hostname.json
@@ -130,6 +130,11 @@
                 "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
                 "data": "\u212Aelvin.example.com",
                 "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/tests/draft2020-12/optional/format/hostname.json
+++ b/tests/draft2020-12/optional/format/hostname.json
@@ -130,6 +130,11 @@
                 "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
                 "data": "\u212Aelvin.example.com",
                 "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/tests/draft7/optional/format/hostname.json
+++ b/tests/draft7/optional/format/hostname.json
@@ -127,6 +127,11 @@
                 "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
                 "data": "\u212Aelvin.example.com",
                 "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/tests/v1/format/hostname.json
+++ b/tests/v1/format/hostname.json
@@ -130,6 +130,11 @@
                 "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
                 "data": "\u212Aelvin.example.com",
                 "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
The hostname files test a leading hyphen, a trailing hyphen and a single interior hyphen, but never two hyphens in a row. [RFC 952](https://www.rfc-editor.org/rfc/rfc952) gives the label grammar that RFC 1123 section 2.1 amends:

```
<name>  ::= <let>[*[<let-or-digit-or-hyphen>]<let-or-digit>]
```

The `*[<let-or-digit-or-hyphen>]` repetition puts no cap on how many hyphens run together, as long as the label does not begin or end with one. That branch has no test.

## Changes

One test in the "validation of host names" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "consecutive hyphens inside a label",
    "data": "a--b.com",
    "valid": true
}
```

draft4 and draft6 already have an equivalent test (`ab--cd.example`, added in #874); these four files never got one.

## Ecosystem Impact

This one does not break either reference validator - ajv-formats 3.0.1 and python-jsonschema 4.25.1 both accept it, as does sourcemeta/core. It is worth adding for what it does catch:

- **Corvus.JsonSchema 4.5.8** - FAILS (rejects a valid host name)
- **clojure-json-schema** - FAILS

Both accept `host-name`, so the existing single-hyphen test does not catch either of them. The repetition is what they get wrong.

I used `a--b.com` rather than draft4's `ab--cd.example` on purpose. A label with `--` in the third and fourth positions specifically is a "reserved LDH label" under [RFC 5890 section 2.3.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.1), and some implementations reject that form on IDNA grounds - @hyperjump/json-schema 1.17.7 accepts `a--b.com` but rejects `ab--cd.example` for exactly that reason. Whether a reserved LDH label should be rejected here is a separate question, so this test stays clear of it and pins only the grammar's repetition branch.

## RFC References

- [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) - amends the RFC 952 syntax
- [RFC 952](https://www.rfc-editor.org/rfc/rfc952) - the `<name>` production above
- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) - `<let-dig-hyp>`

Related: #965
