### PR TITLE
test(format/date): add date inside the Gregorian reform gap as valid

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -387,6 +387,11 @@
                 "description": "invalid: duplicated second hyphen",
                 "data": "2020-01--01",
                 "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -387,6 +387,11 @@
                 "description": "invalid: duplicated second hyphen",
                 "data": "2020-01--01",
                 "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -384,6 +384,11 @@
                 "description": "invalid: duplicated second hyphen",
                 "data": "2020-01--01",
                 "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -387,6 +387,11 @@
                 "description": "invalid: duplicated second hyphen",
                 "data": "2020-01--01",
                 "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I enumerated every full-date RFC 3339 admits - all 3,652,425 of them from `0000-01-01` to `9999-12-31` - through each validator, looking for valid dates that get rejected. Across the whole matrix exactly ten come back wrong, and they are consecutive: `1582-10-05` through `1582-10-14`.

Those are the ten days dropped when the Julian calendar was replaced by the Gregorian one in October 1582. [json_schemer](https://github.com/davishmcclurg/json_schemer) rejects all ten because it implements `format: date` on top of Ruby's `Date`, and Ruby's `Date` defaults to `Date::ITALY` - a reform-aware calendar in which those days never existed:

```ruby
require 'json_schemer'
schema = JSONSchemer.schema({'type' => 'string', 'format' => 'date'}, format: true)
schema.valid?('1582-10-14')   # => false
schema.valid?('1582-10-15')   # => true
```

RFC 3339 does not have a reform. [Section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) defines `full-date = date-fullyear "-" date-month "-" date-mday` with `date-mday = 2DIGIT`, and [section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) gives the maximum unconditionally - October is 31, with no exception for 1582. [Section 1](https://www.rfc-editor.org/rfc/rfc3339#section-1) puts the whole range in scope: "All dates and times are assumed to be in the 'current era', somewhere between 0000AD and 9999AD." The words "Julian", "reform" and "proleptic" do not appear in the document. `1582-10-10` satisfies every production, so it is a valid `full-date`.

The suite has already taken this reading. `0001-01-01` and `0400-02-29` are both asserted valid today, and neither exists in the historical Gregorian calendar either - they are only meaningful under a proleptic reading. This test applies the same reading at the one boundary where a real implementation diverges.

## Changes

One case per draft (draft7, draft2019-09, draft2020-12, v1):

```json
{
    "description": "valid: date inside the Julian to Gregorian reform gap",
    "data": "1582-10-10",
    "valid": true
}
```

## Ecosystem Impact

- **json_schemer 2.2.1** (Ruby 2.6.10) - **FAILS**. `lib/json_schemer/format.rb:8` implements the format by appending a time and handing the result to Ruby's date parser:
  ```ruby
  DATE = proc do |instance, _format|
    !instance.is_a?(String) || valid_date_time?("#{instance}T04:05:06.123456789+07:00")
  end
  ```
  and `valid_date_time?` (line 96) calls `DateTime.rfc3339(data)` with `rescue ArgumentError` at line 101. Ruby raises `ArgumentError` for the ten reform-gap days, so they are reported invalid. **This is not version skew** - the same code is on `main` today (latest release 2.5.0), byte for byte.
- I enumerated all 3,652,425 valid dates through that exact call. It rejects **exactly ten** - the gap and nothing else - so one representative covers the whole mechanism.
- The same bug reaches `format: date-time` in that library (`1582-10-10T00:00:00Z` is rejected too), since `DATE_TIME` uses the same helper.
- **ajv-formats 3.0.1** (full and fast) - PASSES.
- **python-jsonschema 4.25.1** - PASSES.
- **sourcemeta/core `is_rfc3339_fulldate`** - PASSES.
- Every other asserting implementation I ran PASSES: the 15 in the Bowtie census (Corvus.JsonSchema 4.5.8, Newtonsoft.Json.Schema 4.0.2, gojsonschema v1.2.0, valijson, jsonschemafriend 0.12.5, openapiprocessor 2026.1, cfworker 4.1.1, tdegrunt jsonschema 1.5.0, schemasafe 1.3.0, api7/jsonschema 0.9.13, JSON::Schema::Modern 0.641, justinrainbow 6.7.2, opis 2.6.0, fastjsonschema 2.21.2, vscode-json-languageservice 5.7.2) plus ata-validator 1.2.1, @hyperjump/json-schema, networknt 1.5.6/1.5.9/3.0.1/ 3.0.6, vertx-json-schema 4.5.28, everit-json-schema 1.14.6, santhosh-tekuri v6, qri-io and jsonschema-rs.

The underlying split is a language one, not a library one. Enumerating the same 3,652,425 dates through the platform parsers: `java.time.LocalDate` rejects 0, but `java.text.SimpleDateFormat` with `setLenient(false)` rejects the identical ten, because `GregorianCalendar` has the same 1582-10-15 cutover. Go's `time.Parse` rejects 0. So any validator built on Ruby `Date` or Java `Calendar` inherits this, and one built on `java.time`, Go or a hand-written check does not.

## RFC References

- [RFC 3339 section 1](https://www.rfc-editor.org/rfc/rfc3339#section-1) - the 0000AD-9999AD range
- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `full-date`
- [RFC 3339 section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) - the `date-mday` maximum table

Related: #965