### PR TITLE
test(format/date): add out-of-range year as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -392,6 +392,11 @@
                 "description": "valid: date inside the Julian to Gregorian reform gap",
                 "data": "1582-10-10",
                 "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -392,6 +392,11 @@
                 "description": "valid: date inside the Julian to Gregorian reform gap",
                 "data": "1582-10-10",
                 "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -389,6 +389,11 @@
                 "description": "valid: date inside the Julian to Gregorian reform gap",
                 "data": "1582-10-10",
                 "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -392,6 +392,11 @@
                 "description": "valid: date inside the Julian to Gregorian reform gap",
                 "data": "1582-10-10",
                 "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
The suite already pins a five-digit year (`"12020-01-01"`, invalid), which catches a validator that does not enforce `date-fullyear = 4DIGIT`. It does not catch what happens when the year is not just too long but numerically too large for the integer type the validator parses it into.

[valijson](https://github.com/tristanpenman/valijson) accepts every over-long year up to `2147483647-01-01`, and then **aborts the process** at `2147483648-01-01`:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoi
```

`include/valijson/validation_visitor.hpp:415` matches the year with `([0-9]+)` rather than four digits, then line 418 does `std::stoi(matches[1].str())`. `std::stoi` throws `std::out_of_range` when the value exceeds `INT_MAX`, nothing catches it, and the process terminates. The trigger is the *value*, not the length: `"0000000000-01-01"` is ten digits and is accepted, `"2147483647-01-01"` is accepted, and `"2147483648-01-01"` aborts.

RFC 3339 [section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) gives `date-fullyear = 4DIGIT`, so any year of a different width is invalid regardless of its value. A `format` check has to return a verdict; terminating the process is a distinct failure from returning the wrong one, and the existing five-digit test provably does not produce it.

## Changes

One case per draft (draft7, draft2019-09, draft2020-12, v1):

```json
{
    "description": "invalid: year field numerically larger than a 32-bit signed integer",
    "data": "2147483648-01-01",
    "valid": false
}
```

## Ecosystem Impact

- **valijson** (Bowtie `cpp-valijson`, draft-07) - **FAILS**, `std::out_of_range` from `std::stoi` terminates the process. Boundary confirmed by bisection:

  | input | valijson |
  |---|---|
  | `2147483647-01-01` | accepted (wrongly - `4DIGIT` violated) |
  | `2147483648-01-01` | **abort** |
  | `0000000000-01-01` | accepted (wrongly) |
  | `9999999999-01-01` | **abort** |

  **This is not version skew** - `([0-9]+)` and the unguarded `std::stoi` are both on valijson `master` today. The same pattern is repeated for `format: date-time` at line 466, and `"9999999999-01-01T00:00:00Z"` aborts identically. `format: time` is unaffected because its regex bounds every field.
- **ajv-formats 3.0.1** (full and fast) - PASSES.
- **python-jsonschema 4.25.1** - PASSES.
- **sourcemeta/core `is_rfc3339_fulldate`** - PASSES (its `value.size() != 10` guard runs first, so no digit is ever converted).
- The remaining 14 asserting implementations in the Bowtie census all PASS, as do ata-validator 1.2.1, @exodus/schemasafe, @cfworker/json-schema, @hyperjump/json-schema, networknt 1.5.6/1.5.9/3.0.1/3.0.6, vertx-json-schema 4.5.28, everit-json-schema 1.14.6, santhosh-tekuri v6, qri-io, jsonschema-rs and json_schemer.

I swept the same integer boundaries (`INT32_MAX`, `UINT32_MAX`, `INT64_MAX`, `UINT64_MAX`, and their successors) through the year, month and day fields of every column. valijson is the only JSON Schema validator that overflows - the month and day fields are safe everywhere because their regexes bound them to two digits.

## RFC References

- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `date-fullyear = 4DIGIT`

Related: #965