### PR TITLE
test(format/date): add NUL character after a valid full-date as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -412,6 +412,11 @@
                 "description": "invalid: en dash separators instead of hyphen-minus",
                 "data": "2020\u201301\u201301",
                 "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -412,6 +412,11 @@
                 "description": "invalid: en dash separators instead of hyphen-minus",
                 "data": "2020\u201301\u201301",
                 "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -409,6 +409,11 @@
                 "description": "invalid: en dash separators instead of hyphen-minus",
                 "data": "2020\u201301\u201301",
                 "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -412,6 +412,11 @@
                 "description": "invalid: en dash separators instead of hyphen-minus",
                 "data": "2020\u201301\u201301",
                 "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
I was running the `date` corpus through the PHP validators and [justinrainbow/json-schema](https://github.com/jsonrainbow/json-schema) stopped returning a verdict at all on one input. `"2020-01-01\u0000"` - a valid full-date with a trailing NUL - makes it throw an uncaught `ValueError` instead of reporting the instance invalid:

```
PHP Fatal error: Uncaught ValueError: DateTime::createFromFormat():
Argument #2 ($datetime) must not contain any null bytes
  in src/JsonSchema/Constraints/FormatConstraint.php:157
```

`FormatConstraint.php:40` routes `format: date` into `validateDateTime($element, 'Y-m-d')`, which calls `\DateTime::createFromFormat($format, (string) $datetime)` at line 157. Under PHP 8 that function raises `ValueError` on a NUL byte rather than returning `false`, and nothing in the constraint catches it. A `format` check has to return a verdict; throwing is a different failure mode from returning the wrong answer, and no existing test in `date.json` exercises it.

RFC 3339 [section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) gives `full-date = date-fullyear "-" date-month "-" date-mday` with `date-fullyear = 4DIGIT`, `date-month = 2DIGIT` and `date-mday = 2DIGIT`. That is exactly ten characters and [RFC 5234 section 3.4](https://www.rfc-editor.org/rfc/rfc5234#section-3.4) fixes `DIGIT = %x30-39`, so an eleventh character of any kind is invalid - there is no production that admits a trailing NUL.

## Changes

One case per draft (draft7, draft2019-09, draft2020-12, v1):

```json
{
    "description": "invalid: NUL character after an otherwise valid full-date",
    "data": "2020-01-01\u0000",
    "valid": false
}
```

## Ecosystem Impact

- **justinrainbow/json-schema 6.10.0** (PHP 8.1.34) - **FAILS**, uncaught `ValueError` from `FormatConstraint.php:157`. Reproduced standalone:
  ```php
  $v = new JsonSchema\Validator();
  $data = "2020-01-01\x00";
  $v->validate($data, (object)['type' => 'string', 'format' => 'date']);
  // PHP Fatal error: Uncaught ValueError
  ```
- **justinrainbow/json-schema 6.7.2.0** - **FAILS** the same way. Driven through its Bowtie harness, the container returned results for 1770 of 1777 inputs; the 7 missing are exactly the NUL-bearing ones, so this is not specific to the newest release.
- The same code path backs `format: time` (`FormatConstraint.php:50`, `'H:i:s'`) and `format: utc-millisec` (line 70, `'U'`), which throw identically. `format: date-time` uses a separate regex path and is unaffected.
- **ajv-formats 3.0.1** (full and fast) - PASSES, its `DATE` regex rejects the input.
- **python-jsonschema 4.25.1** - PASSES, `_RE_DATE.fullmatch` rejects it.
- **sourcemeta/core `is_rfc3339_fulldate`** - PASSES, the `value.size() != 10` guard rejects it (the function takes a `std::string_view`, so the NUL does not truncate).
- 12 further asserting implementations from the Bowtie census (Corvus.JsonSchema 4.5.8, Newtonsoft.Json.Schema 4.0.2, gojsonschema v1.2.0, jsonschemafriend 0.12.5, openapiprocessor 2026.1, cfworker 4.1.1, tdegrunt jsonschema 1.5.0, schemasafe 1.3.0, api7/jsonschema 0.9.13, JSON::Schema::Modern 0.641, opis 2.6.0, fastjsonschema 2.21.2, vscode-json-languageservice 5.7.2) all PASS.

## RFC References

- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `full-date`
- [RFC 5234 section 3.4](https://www.rfc-editor.org/rfc/rfc5234#section-3.4) - `DIGIT = %x30-39`

Related: #965