### PR TITLE
test(format/date): add second-digit, byte-length, and en dash separator cases

### DIFF
--- a/tests/draft2019-09/optional/format/date.json
+++ b/tests/draft2019-09/optional/format/date.json
@@ -397,6 +397,21 @@
                 "description": "invalid: year field numerically larger than a 32-bit signed integer",
                 "data": "2147483648-01-01",
                 "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date.json
+++ b/tests/draft2020-12/optional/format/date.json
@@ -397,6 +397,21 @@
                 "description": "invalid: year field numerically larger than a 32-bit signed integer",
                 "data": "2147483648-01-01",
                 "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date.json
+++ b/tests/draft7/optional/format/date.json
@@ -394,6 +394,21 @@
                 "description": "invalid: year field numerically larger than a 32-bit signed integer",
                 "data": "2147483648-01-01",
                 "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date.json
+++ b/tests/v1/format/date.json
@@ -397,6 +397,21 @@
                 "description": "invalid: year field numerically larger than a 32-bit signed integer",
                 "data": "2147483648-01-01",
                 "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
While checking how much of RFC 3339 [section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) the `date` file already pins, I found three rules that no current test can fail an implementation on. Nothing in the ecosystem gets these wrong today - these are coverage, not bug reports - but each one is reachable by a plausible implementation mistake that every existing test would let through. I checked each against the whole file rather than adding variants of what is already there.

`full-date = date-fullyear "-" date-month "-" date-mday`, with `date-fullyear = 4DIGIT`, `date-month = 2DIGIT ; 01-12` and `date-mday = 2DIGIT`. [RFC 5234 section 3.4](https://www.rfc-editor.org/rfc/rfc5234#section-3.4) fixes `DIGIT = %x30-39`.

## Changes

Three cases per draft (draft7, draft2019-09, draft2020-12, v1).

1. `"2020-01-0:"` - a character just above `'9'` as the second digit of the day

   `date-mday` is `2DIGIT`, and a common shape for reading it is to check the first digit and then compute `(first - '0') * 10 + (second - '0')`. `':'` is `0x3A`, one past `'9'`, so `':' - '0' == 10` and an implementation that checks only the first digit derives day `10` - inside the legal range - and accepts.

   The file's existing digit tests cannot catch that. `"2020-01-DD"` also fails the *first* digit check, so it is rejected before the second digit is ever consulted. This case keeps the first digit valid so the second is the only thing standing between the input and an accept.

2. `"২0-01-01"` - a non-ASCII digit leaving ten UTF-8 bytes but eight characters

   The file already has non-ASCII digit tests (`"২020-01-01"`, `"2020-0৪-01"`, `"1963-06-1৪"`), but all of them are ten *characters* and therefore twelve *bytes*. An implementation that scans bytes and starts with a length check rejects every one of them on length alone and never reaches its digit test. `"২0-01-01"` is eight characters but exactly ten bytes, so a byte-oriented implementation gets past the length check and has to reject on `DIGIT = %x30-39` instead.

3. `"2020–01–01"` - en dash separators instead of hyphen-minus

   The two separators in `full-date` are the literal `"-"`, U+002D. Every separator test in the file today uses an ASCII character (`":"`, `"."`, `" "`, `"/"`, a duplicated `"-"`), so an implementation matching a Unicode dash class, or normalising the instance before validating, passes all of them. U+2013 is the separator most likely to arrive from word-processed or copy-pasted input.

## Ecosystem Impact

All three are handled correctly by every asserting implementation I ran, which is why they are coverage rather than breaker tests: **ajv-formats 3.0.1** (full and fast), **python-jsonschema 4.25.1**, **sourcemeta/core `is_rfc3339_fulldate`**, plus the 15 asserting implementations in the Bowtie census (Corvus.JsonSchema 4.5.8, Newtonsoft.Json.Schema 4.0.2, gojsonschema v1.2.0, valijson, jsonschemafriend 0.12.5, openapiprocessor 2026.1, cfworker 4.1.1, tdegrunt jsonschema 1.5.0, schemasafe 1.3.0, api7/jsonschema 0.9.13, JSON::Schema::Modern 0.641, justinrainbow 6.7.2, opis 2.6.0, fastjsonschema 2.21.2, vscode-json-languageservice 5.7.2) and the directly wired ata-validator 1.2.1, @exodus/schemasafe, @hyperjump/json-schema, networknt 1.5.6/1.5.9/ 3.0.1/3.0.6, vertx-json-schema 4.5.28, everit-json-schema 1.14.6, santhosh-tekuri v6, qri-io, jsonschema-rs and json_schemer.

For cases 1 and 2 I checked the "would this catch anything" question directly rather than by argument. I built single-branch mutants of `sourcemeta/core`'s `is_rfc3339_fulldate` and measured which ones the existing tests kill. A mutant that drops the second-digit check on `date-mday`, and a mutant whose digit test wrongly accepts any byte `>= 0x80`, both survive Core's entire existing 66-test file. Case 1 kills the first and case 2 kills the second.

## RFC References

- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `full-date`
- [RFC 3339 section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) - the `date-mday` maximum table
- [RFC 5234 section 3.4](https://www.rfc-editor.org/rfc/rfc5234#section-3.4) - `DIGIT = %x30-39`

Related: #965