### PR TITLE
test(relative-json-pointer): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -125,6 +125,11 @@
                 "description": "empty reference tokens in the json-pointer part",
                 "data": "0//",
                 "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -125,6 +125,11 @@
                 "description": "empty reference tokens in the json-pointer part",
                 "data": "0//",
                 "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -122,6 +122,11 @@
                 "description": "empty reference tokens in the json-pointer part",
                 "data": "0//",
                 "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -125,6 +125,11 @@
                 "description": "empty reference tokens in the json-pointer part",
                 "data": "0//",
                 "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [draft-handrews-relative-json-pointer-01 section 3](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3) and found that the `relative-json-pointer` files do not test a newline in any position, so three implementations that accept a trailing one pass the whole file today.

The grammar is `relative-json-pointer = non-negative-integer <json-pointer>` and `=/ non-negative-integer "#"`. After the integer the only continuations are a json-pointer, which is either zero-length or starts with `/`, or a single `#`. A newline is neither, so `"1\n"` is invalid. The mirror case is what makes this specific rather than a general no-newlines rule: `"0/foo\n"` is **valid**, because [RFC 6901 section 3](https://www.rfc-editor.org/rfc/rfc6901#section-3) has `unescaped = %x00-2E / %x30-7D / %x7F-10FFFF` and %x0A sits inside the first range, so a newline is a legal character inside a reference token. Every implementation I ran gets the mirror right, so I have not added a test for it.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `1\n` - a valid non-negative integer followed by a trailing newline, invalid because a newline can neither start a json-pointer nor be the `#` alternative.

I checked the rest of the newline family before picking one representative. `0#\n` and `120\n` fail on the same three implementations for the same reason, so they collapse into this one.

## Ecosystem Impact

1. **ajv-formats 3.0.1, python-jsonschema 4.25.1, sourcemeta/core, @cfworker/json-schema 4.1.1, @exodus/schemasafe 1.3.0, gojsonschema v1.2.0, fastjsonschema 2.21.2, JSON::Schema::Modern 0.641**: PASS (reject it). The JavaScript regexes anchor with `$` under ECMAScript semantics, where `$` without the `m` flag matches only at the very end of input, and the hand-written scanners check that the character after the integer is `/` or `#`.
2. **Corvus.JsonSchema 4.5.8**: FAILS (accepts it). Its format check is regex-anchored with `$` under .NET semantics, where `$` matches before a final newline unless `RegexOptions.Singleline`-style end anchoring is used, so the trailing `\n` slips past the end anchor.
3. **jsonschemafriend 0.12.5**: FAILS (accepts it). Same anchor class through `java.util.regex`, whose `$` matches before a line terminator by default; it accepts `"0\r\n"` as well, which is the Java-specific line-terminator set rather than just `\n`.
4. **opis/json-schema 2.6.0**: FAILS (accepts it). `JsonPointer::isRelativePointer` matches `'~^(?:(?<level>0|[1-9][0-9]*)(?<shift>(?:\+|-)(?:0|[1-9][0-9]*))?)?(?<pointer>(?:/[^/#]*)*)(?<fragment>#)?$~'`, and PCRE `$` also matches before a trailing newline, so the pattern completes one character early.

This is the same trailing-newline class as the merged duration test in #982.

## RFC References

- draft-handrews-relative-json-pointer-01 section 3 (Syntax): https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3
- RFC 6901 section 3 (JSON Pointer syntax, `unescaped` includes %x0A): https://www.rfc-editor.org/rfc/rfc6901#section-3

Reproduction commands and the relative-json-pointer cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/relative-json-pointer.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
