### PR TITLE
test(relative-json-pointer): add json-pointer part coverage (escapes, octothorpe placement, empty tokens)

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -105,6 +105,26 @@
                 "description": "multi-digit prefix with a zero followed by another digit",
                 "data": "100",
                 "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -105,6 +105,26 @@
                 "description": "multi-digit prefix with a zero followed by another digit",
                 "data": "100",
                 "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -102,6 +102,26 @@
                 "description": "multi-digit prefix with a zero followed by another digit",
                 "data": "100",
                 "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -105,6 +105,26 @@
                 "description": "multi-digit prefix with a zero followed by another digit",
                 "data": "100",
                 "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [draft-handrews-relative-json-pointer-01 section 3](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3) and found that the `relative-json-pointer` files only ever exercise the integer prefix. Every case in them is about the leading number - negative, positive, leading zero, multi-digit, non-ASCII digit - and the json-pointer half is only ever exercised by two well-formed pointers, `0/foo/bar` and `2/0/baz/1/zip`. Nothing in any draft tests the `~0`/`~1` escapes, and nothing tests where the `#` may appear.

That is the gap [#202](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/202) has been open on since 2017. The grammar makes the tail an [RFC 6901 section 3](https://www.rfc-editor.org/rfc/rfc6901#section-3) json-pointer, with `escaped = "~" ( "0" / "1" )` and `reference-token = *( unescaped / escaped )`, and the `"#"` alternative is the whole remainder so nothing may follow it. I picked these four by writing a wrong implementation for each and keeping only the cases that catch one while passing all 14 tests currently in the file.

## Changes

- Added 4 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `0/~2` - a `~` followed by a character other than `0` or `1`, invalid because `~` is excluded from `unescaped` and `escaped` admits only `~0` and `~1`.
- `0/foo/bar~` - the same rule at end-of-string, a `~` with no second character, invalid.
- `1#/foo/bar` - a json-pointer after the `#`, invalid because the `"#"` alternative terminates the production.
- `0//` - two empty reference tokens, valid because `reference-token = *( unescaped / escaped )` admits the empty token.

I dropped the cases that earn nothing. `0/a~1b` and `0/m~0n` are the obvious valid-escape analogues from `json-pointer.json`, but a validator that ignores `~` entirely still accepts them, so they catch no defect the file misses - only the invalid direction does. I also dropped `0/` (strictly weaker than `0//`), `0`, `2#`, `0/~0~1` and `0/~01` as combinations of parts the file already covers.

## Ecosystem Impact

1. **ajv-formats 3.0.1, python-jsonschema 4.25.1, sourcemeta/core, @cfworker/json-schema 4.1.1, @exodus/schemasafe 1.3.0, gojsonschema v1.2.0, fastjsonschema 2.21.2, JSON::Schema::Modern 0.641, Corvus.JsonSchema 4.5.8, jsonschemafriend 0.12.5**: PASS (all four verdicts correct). These do not break on the new cases, so this is coverage rather than a bug report.
2. **@swagger-api/apidom-json-pointer-relative 1.11.3**: FAILS `0/~2` and `0/foo/bar~` (accepts both). Its pointer branch in `src/parse.cjs` is `'(?<jsonPointer>\\/.*)'`, so once it sees a `/` it accepts everything to the end of the string and never inspects the escapes. It passes all 14 tests currently in the file, so nothing today distinguishes it from a correct implementation. It is a standalone pointer library rather than a JSON Schema validator, so I am not claiming it as a validator breaker - but it is the concrete case for the two escape tests.
3. **Nothing I ran fails `1#/foo/bar` or `0//`**: I checked 34 Bowtie images as well, and all nine that assert this format get both right. Those two rest on the wrong-implementation argument alone, and I would not argue against dropping them if you would rather keep this to the two escape cases.

## RFC References

- draft-handrews-relative-json-pointer-01 section 3 (Syntax, and the `"#"` alternative): https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3
- RFC 6901 section 3 (`reference-token`, `unescaped`, `escaped`): https://www.rfc-editor.org/rfc/rfc6901#section-3

`1#/foo/bar` and the dangling-`~` shape both come from Henry Andrews' own malformed-pointer list, written to catch "likely regular expression errors, such as improper grouping of terms or incorrectly handling 0": https://gist.github.com/handrews/41b3b7cd6c011563f6a39b766b09c4c7

Reproduction commands and the relative-json-pointer cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/relative-json-pointer.md

This touches the same file as #1030, so whichever lands second will need a trivial rebase.

Related: [#965](https://github.com/json-schema-org/community/issues/965)
