### PR TITLE
Test relative JSON Pointer index manipulation

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -57,6 +57,31 @@
                 "valid": true
             },
             {
+                "description": "a valid RJP with forward index manipulation",
+                "data": "0+1",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with forward index manipulation and a JSON Pointer",
+                "data": "0+1/foo",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with backward index manipulation and a JSON Pointer",
+                "data": "1-2/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with zero index manipulation",
+                "data": "0-0",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with index manipulation taking the index name",
+                "data": "0-1#",
+                "valid": true
+            },
+            {
                 "description": "an invalid RJP that is a valid JSON Pointer",
                 "data": "/foo/bar",
                 "valid": false
@@ -69,6 +94,26 @@
             {
                 "description": "explicit positive prefix",
                 "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "index manipulation without an integer",
+                "data": "0+",
+                "valid": false
+            },
+            {
+                "description": "index manipulation integer with a leading zero",
+                "data": "0-01",
+                "valid": false
+            },
+            {
+                "description": "index manipulation with two signs",
+                "data": "0++1",
+                "valid": false
+            },
+            {
+                "description": "index manipulation followed by an invalid JSON Pointer",
+                "data": "0+1not-a-pointer",
                 "valid": false
             },
             {

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -57,6 +57,31 @@
                 "valid": true
             },
             {
+                "description": "a valid RJP with forward index manipulation",
+                "data": "0+1",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with forward index manipulation and a JSON Pointer",
+                "data": "0+1/foo",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with backward index manipulation and a JSON Pointer",
+                "data": "1-2/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with zero index manipulation",
+                "data": "0-0",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with index manipulation taking the index name",
+                "data": "0-1#",
+                "valid": true
+            },
+            {
                 "description": "an invalid RJP that is a valid JSON Pointer",
                 "data": "/foo/bar",
                 "valid": false
@@ -69,6 +94,26 @@
             {
                 "description": "explicit positive prefix",
                 "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "index manipulation without an integer",
+                "data": "0+",
+                "valid": false
+            },
+            {
+                "description": "index manipulation integer with a leading zero",
+                "data": "0-01",
+                "valid": false
+            },
+            {
+                "description": "index manipulation with two signs",
+                "data": "0++1",
+                "valid": false
+            },
+            {
+                "description": "index manipulation followed by an invalid JSON Pointer",
+                "data": "0+1not-a-pointer",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -54,6 +54,31 @@
                 "valid": true
             },
             {
+                "description": "a valid RJP with forward index manipulation",
+                "data": "0+1",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with forward index manipulation and a JSON Pointer",
+                "data": "0+1/foo",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with backward index manipulation and a JSON Pointer",
+                "data": "1-2/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with zero index manipulation",
+                "data": "0-0",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with index manipulation taking the index name",
+                "data": "0-1#",
+                "valid": true
+            },
+            {
                 "description": "an invalid RJP that is a valid JSON Pointer",
                 "data": "/foo/bar",
                 "valid": false
@@ -66,6 +91,26 @@
             {
                 "description": "explicit positive prefix",
                 "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "index manipulation without an integer",
+                "data": "0+",
+                "valid": false
+            },
+            {
+                "description": "index manipulation integer with a leading zero",
+                "data": "0-01",
+                "valid": false
+            },
+            {
+                "description": "index manipulation with two signs",
+                "data": "0++1",
+                "valid": false
+            },
+            {
+                "description": "index manipulation followed by an invalid JSON Pointer",
+                "data": "0+1not-a-pointer",
                 "valid": false
             },
             {

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -57,6 +57,31 @@
                 "valid": true
             },
             {
+                "description": "a valid RJP with forward index manipulation",
+                "data": "0+1",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with forward index manipulation and a JSON Pointer",
+                "data": "0+1/foo",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with backward index manipulation and a JSON Pointer",
+                "data": "1-2/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with zero index manipulation",
+                "data": "0-0",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP with index manipulation taking the index name",
+                "data": "0-1#",
+                "valid": true
+            },
+            {
                 "description": "an invalid RJP that is a valid JSON Pointer",
                 "data": "/foo/bar",
                 "valid": false
@@ -69,6 +94,26 @@
             {
                 "description": "explicit positive prefix",
                 "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "index manipulation without an integer",
+                "data": "0+",
+                "valid": false
+            },
+            {
+                "description": "index manipulation integer with a leading zero",
+                "data": "0-01",
+                "valid": false
+            },
+            {
+                "description": "index manipulation with two signs",
+                "data": "0++1",
+                "valid": false
+            },
+            {
+                "description": "index manipulation followed by an invalid JSON Pointer",
+                "data": "0+1not-a-pointer",
                 "valid": false
             },
             {


### PR DESCRIPTION
## Summary

- add valid Relative JSON Pointer format cases for forward, backward, and zero index manipulation;
- add malformed index-manipulation controls; and
- cover both Draft 2020-12 and the future v1 draft while leaving older drafts unchanged.

## Why

Draft 2020-12 added the optional `+N` / `-N` index-manipulation production, but the shared format suite did not exercise it. These cases provide implementation-neutral coverage and are a prerequisite for python-jsonschema/jsonschema#1534.

Specification: https://json-schema.org/draft/2020-12/relative-json-pointer

## Validation

- `python -m json.tool` for both changed files
- `python bin/jsonschema_suite check` — 11 checks passed, 4 skipped
- `git diff --check`
