### PR TITLE
test(idn-email): remove the lone surrogate local part case

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -62,11 +62,6 @@
                 "valid": true
             },
             {
-                "description": "a local part with a lone UTF-16 surrogate is invalid",
-                "data": "\ud800@example.com",
-                "valid": false
-            },
-            {
                 "description": "a domain label that is not in Unicode NFC is valid",
                 "data": "user@cafe\u0301.com",
                 "valid": true

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -62,11 +62,6 @@
                 "valid": true
             },
             {
-                "description": "a local part with a lone UTF-16 surrogate is invalid",
-                "data": "\ud800@example.com",
-                "valid": false
-            },
-            {
                 "description": "a domain label that is not in Unicode NFC is valid",
                 "data": "user@cafe\u0301.com",
                 "valid": true

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -59,11 +59,6 @@
                 "valid": true
             },
             {
-                "description": "a local part with a lone UTF-16 surrogate is invalid",
-                "data": "\ud800@example.com",
-                "valid": false
-            },
-            {
                 "description": "a domain label that is not in Unicode NFC is valid",
                 "data": "user@cafe\u0301.com",
                 "valid": true

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -67,11 +67,6 @@
                 "valid": true
             },
             {
-                "description": "a local part with a lone UTF-16 surrogate is invalid",
-                "data": "\ud800@example.com",
-                "valid": false
-            },
-            {
                 "description": "a domain label that is not in Unicode NFC is valid",
                 "data": "user@cafe\u0301.com",
                 "valid": true


### PR DESCRIPTION
Removing the lone surrogate case I added in #946, following the reports from @gregsdennis, @xinz and @karenetheridge.

I measured it before answering, because I wanted to know whether a separate file would have helped. It would not. The file itself is fine - `\ud800` is six ASCII characters on disk, so it decodes from UTF-8 without trouble and the escape is allowed by RFC 8259. What has no UTF-8 representation is the decoded string value, which is why some parsers read it happily and only fail on output. That matches Greg's stack trace, where the failure is in `Serialize` rather than the read.

The part that decided it for me is that two implementations do not fail at all - they silently change the value. Ruby's `json` parses it to `?example.com`, replacing the surrogate and swallowing the `@` with it, so a Ruby runner is no longer testing a lone surrogate, it is testing a string with no `@`. In Node the string survives `JSON.parse` and `JSON.stringify`, but any UTF-8 write turns it into U+FFFD, so `Buffer.from(s, "utf8")` does not round trip. A separate file only helps implementations that cannot load it, not the ones that load it and get a different string.

Worth flagging that `sourcemeta/core` is affected too. At `main` (99b6a5e) `parse_json` rejects `"\ud800@example.com"` outright, while paired surrogates like `"𝄞"` parse fine.

I also ran the wider roster: of 33 implementations that start up, 12 cannot parse it, 20 of the remaining 21 accept it, and the only one that rejects it rejects everything else too. RFC 8259 section 8.2 more or less predicts this - it says behaviour on unpaired surrogates "is unpredictable" and implementations "might return different values for the length of a string value or even suffer fatal runtime exceptions".

## Changes

- Removed 1 test case from draft7, draft2019-09, draft2020-12, and v1.
- This was the only lone surrogate anywhere in `tests/`, so nothing else is affected.

The underlying rule is still real - RFC 6532 section 3.1 points at RFC 3629 section 4, whose UTF8-3 production caps the byte after `ED` at `9F` precisely to exclude D800-DFFF. It just is not reliably testable through a JSON file, and it is the only RFC 3629 exclusion that has a JSON representation at all, since overlong forms and anything above U+10FFFF cannot be written either.

## RFC References

- RFC 8259 section 8.2 (unpaired surrogates, unpredictable behaviour): https://www.rfc-editor.org/rfc/rfc8259#section-8.2
- RFC 3629 section 4 (UTF-8 syntax, surrogates excluded): https://www.rfc-editor.org/rfc/rfc3629#section-4

Related: [#965](https://github.com/json-schema-org/community/issues/965)
