### PR TITLE
test(idn-email): add address-literal coverage

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -100,6 +100,30 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
                 "data": "\ud835\udd4f@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv4-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 address-literal = \"[\" IPv4-address-literal \"]\"; RFC 6531 does not change it",
+                "data": "δοκιμή@[192.0.2.1]",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv6-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 IPv6-address-literal = \"IPv6:\" IPv6-addr",
+                "data": "δοκιμή@[IPv6:2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "an octet greater than 255 in an address-literal is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum is a decimal integer in the range 0 through 255",
+                "data": "user@[192.0.2.300]",
+                "valid": false
+            },
+            {
+                "description": "leading zeros in an address-literal octet are valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum = 1*3DIGIT representing 0 through 255, which permits leading zeros unlike the dec-octet rule behind the ipv4 format",
+                "data": "user@[01.0.0.1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -100,6 +100,30 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
                 "data": "\ud835\udd4f@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv4-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 address-literal = \"[\" IPv4-address-literal \"]\"; RFC 6531 does not change it",
+                "data": "δοκιμή@[192.0.2.1]",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv6-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 IPv6-address-literal = \"IPv6:\" IPv6-addr",
+                "data": "δοκιμή@[IPv6:2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "an octet greater than 255 in an address-literal is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum is a decimal integer in the range 0 through 255",
+                "data": "user@[192.0.2.300]",
+                "valid": false
+            },
+            {
+                "description": "leading zeros in an address-literal octet are valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum = 1*3DIGIT representing 0 through 255, which permits leading zeros unlike the dec-octet rule behind the ipv4 format",
+                "data": "user@[01.0.0.1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -97,6 +97,30 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
                 "data": "\ud835\udd4f@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv4-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 address-literal = \"[\" IPv4-address-literal \"]\"; RFC 6531 does not change it",
+                "data": "δοκιμή@[192.0.2.1]",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv6-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 IPv6-address-literal = \"IPv6:\" IPv6-addr",
+                "data": "δοκιμή@[IPv6:2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "an octet greater than 255 in an address-literal is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum is a decimal integer in the range 0 through 255",
+                "data": "user@[192.0.2.300]",
+                "valid": false
+            },
+            {
+                "description": "leading zeros in an address-literal octet are valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum = 1*3DIGIT representing 0 through 255, which permits leading zeros unlike the dec-octet rule behind the ipv4 format",
+                "data": "user@[01.0.0.1]",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -105,6 +105,30 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
                 "data": "\ud835\udd4f@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv4-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 address-literal = \"[\" IPv4-address-literal \"]\"; RFC 6531 does not change it",
+                "data": "δοκιμή@[192.0.2.1]",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an IPv6-address-literal is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 IPv6-address-literal = \"IPv6:\" IPv6-addr",
+                "data": "δοκιμή@[IPv6:2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "an octet greater than 255 in an address-literal is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum is a decimal integer in the range 0 through 255",
+                "data": "user@[192.0.2.300]",
+                "valid": false
+            },
+            {
+                "description": "leading zeros in an address-literal octet are valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3 Snum = 1*3DIGIT representing 0 through 255, which permits leading zeros unlike the dec-octet rule behind the ipv4 format",
+                "data": "user@[01.0.0.1]",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5321 section 4.1.3](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3) and found that `idn-email.json` has no address-literal tests at all, while `email.json` has three. RFC 6531 does not change the address-literal branch, so everything `email` tests there applies to `idn-email` too.

The interesting one is the leading zero. `Snum = 1*3DIGIT` with the comment "representing a decimal integer value in the range 0 through 255", so the rule constrains the value and not the digit count - `01` is a legal `Snum`. That differs from the dec-octet rule behind `format: ipv4`, which forbids leading zeros, so an implementation that reuses its ipv4 checker for the bracket form gets this wrong.

## Changes

- Added 4 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `δοκιμή@[192.0.2.1]` - a non-ASCII local part with an IPv4-address-literal - valid.
- `δοκιμή@[IPv6:2001:db8::1]` - a non-ASCII local part with an IPv6-address-literal - valid.
- `user@[192.0.2.300]` - an octet over 255 inside the brackets - invalid.
- `user@[01.0.0.1]` - leading zeros in an octet - valid.

## Ecosystem Impact

1. **sourcemeta/core (main, 99b6a5e)**: PASSES all four. `is_snum` in `src/core/email/helpers.h` checks the parsed value against 255 rather than the digit count, and the comment there calls out the difference from the RFC 3986 dec-octet behind `is_ipv4`.
2. **go-gojsonschema v1.2.0**: FAILS (rejects `user@[01.0.0.1]`, and also `[192.168.1.1]` and the IPv6 form) - it does not implement the address-literal branch.
3. **java-jsonschemafriend 0.12.5**: FAILS (rejects `user@[01.0.0.1]` and the IPv6 form).
4. **java-networknt-json-schema-validator 3.0.1**: FAILS (rejects `user@[01.0.0.1]`).
5. **python email_validator 2.3.0**: FAILS (rejects `user@[01.0.0.1]` even with `allow_domain_literal=True`) - it hands the bracket contents to Python's `ipaddress.IPv4Address`, which raises `AddressValueError: Leading zeros are not permitted`.
6. **validator.js 13.15**: FAILS (rejects `user@[01.0.0.1]` even with `allow_ip_domain: true`) - same shape, a strict IPv4 pattern applied to the literal.

## RFC References

- RFC 5321 section 4.1.3 (Address Literals, `Snum` and the IPv6 form): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3
- RFC 5321 section 4.1.2 (Mailbox = Local-part "@" ( Domain / address-literal )): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 6531 section 3.3 (what the internationalized extension does and does not change): https://www.rfc-editor.org/rfc/rfc6531#section-3.3

Reproduction commands and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
