### PR TITLE
test(idn-email): add a supplementary-plane local part

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -94,6 +94,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
                 "data": "user\uff20example.com",
                 "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -94,6 +94,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
                 "data": "user\uff20example.com",
                 "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -91,6 +91,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
                 "data": "user\uff20example.com",
                 "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -99,6 +99,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
                 "data": "user\uff20example.com",
                 "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 6532 section 3.1](https://www.rfc-editor.org/rfc/rfc6532#section-3.1) and found the suite exercises two of the three UTF8-non-ascii byte-length classes in the local part but not the third.

`UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4`. The existing tests cover UTF8-2 (Greek, in `δοκιμή@example.com`) and UTF8-3 (Hangul, in the `실례` case), but nothing covers UTF8-4 - the supplementary planes, U+10000 and above. That is the class where implementations that work on UTF-16 code units rather than code points tend to slip, because an astral character is a surrogate pair rather than a single unit.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `𝕏@example.com` (U+1D54F, written as the escape pair `𝕏`) - a supplementary-plane local part - valid.

## Ecosystem Impact

1. **sourcemeta/core (main, 99b6a5e)**: PASSES (accepts it). `utf8_codepoint_length` implements the RFC 3629 four-byte branch directly, so the astral character is one atext codepoint.
2. **validator.js 13.15**: FAILS (rejects it) - its `allow_utf8_local_part` pattern is built from BMP ranges only, so a surrogate pair never matches.
3. **python-jsonschema 4.25.1**: PASSES, but only incidentally - its `idn-email` checker is `"@" in instance`, so it accepts every string that contains an `@`.

## RFC References

- RFC 6532 section 3.1 (`UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4`): https://www.rfc-editor.org/rfc/rfc6532#section-3.1
- RFC 3629 section 4 (the UTF8-4 production): https://www.rfc-editor.org/rfc/rfc3629#section-4
- RFC 6531 section 3.3 (`atext =/ UTF8-non-ascii`): https://www.rfc-editor.org/rfc/rfc6531#section-3.3

Reproduction commands and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
