### PR TITLE
test(idn-email): reject a fullwidth commercial at

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -88,6 +88,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
                 "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
                 "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -88,6 +88,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
                 "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
                 "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -85,6 +85,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
                 "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
                 "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -93,6 +93,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
                 "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
                 "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) and found nothing in the suite pins the `@` delimiter itself for an internationalized address.

`Mailbox = Local-part "@" ( Domain / address-literal )` splits on U+0040. U+FF20 FULLWIDTH COMMERCIAL AT looks like an `@` and is a plausible thing to arrive from a form or a paste, but it is an ordinary character, so a string carrying one instead has no delimiter and cannot be a Mailbox. This case only really exists for the internationalized formats, which is why `email.json` has no equivalent.

It is worth being explicit about one thing, since U+FF20 does map to U+0040 in the UTS #46 table: that mapping applies to the domain the split produces, so it cannot manufacture the delimiter that the split needs in the first place.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `user＠example.com` (U+FF20, written as the escape `＠`) - no U+0040 anywhere - invalid.

## Ecosystem Impact

1. **sourcemeta/core (main, 99b6a5e)**: PASSES (rejects it). `is_mailbox` scans for a literal `'@'` and returns false when the local part ends without one.
2. **python-jsonschema 4.25.1**: PASSES (rejects it). Its checker is `"@" in instance`, and there is no ASCII `@` here, so the trivial check happens to give the right answer.
3. **ajv-formats 3.0.1**: FAILS (accepts it) - it has no `idn-email` format at all, so the keyword compiles to a no-op.

## RFC References

- RFC 5321 section 4.1.2 (`Mailbox = Local-part "@" ( Domain / address-literal )`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 6531 section 3.3 (the extension leaves the delimiter unchanged): https://www.rfc-editor.org/rfc/rfc6531#section-3.3

Reproduction commands and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
