### PR TITLE
test(idn-email): add a local part at the octet limit

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -82,6 +82,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
                 "data": "\uffff@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -82,6 +82,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
                 "data": "\uffff@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -79,6 +79,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
                 "data": "\uffff@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -87,6 +87,12 @@
                 "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
                 "data": "\uffff@example.com",
                 "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
This follows the ruling @jdesrosiers gave in [#948](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/948) on the RFC 5321 section 4.5.3.1 limits:

> That sounds like it's valid for implementations to support parts larger than those limits. I think we should be testing that implementations work up to those limits. Beyond those limits, support is optional, so we shouldn't have tests for those.

The suite currently has no test at the limit, so there is nothing pinning that an implementation must accept a 64-octet local part. This adds the "up to" case only - no over-limit test, per the ruling.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- A local part of exactly 64 octets followed by `@example.com` - valid.

## Ecosystem Impact

1. **sourcemeta/core (main, 99b6a5e)**: PASSES (accepts it). `is_mailbox` caps at `position > 64`, so 64 is inside the limit and 65 is not.
2. **python-jsonschema 4.25.1**: PASSES (accepts it), incidentally - its `idn-email` checker is `"@" in instance`.
3. **ajv-formats 3.0.1**: PASSES (accepts it), incidentally - it has no `idn-email` format.

No implementation I ran rejects it, so this is a coverage test rather than a breaker. It is here because the limit is a real requirement with nothing currently holding implementations to it.

## RFC References

- RFC 5321 section 4.5.3.1.1 (Local-part, 64 octets): https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1.1
- RFC 5321 section 4.5.3.1 ("Every implementation MUST be able to receive objects of at least these sizes"): https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1

Reproduction commands and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
