### PR TITLE
test(idn-email): add control and noncharacter local parts

### DIFF
--- a/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/draft2019-09/optional/format/idn-email.json
@@ -75,6 +75,18 @@
                 "description": "a local part that is not in Unicode NFC is valid",
                 "data": "cafe\u0301@example.com",
                 "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/draft2020-12/optional/format/idn-email.json
@@ -75,6 +75,18 @@
                 "description": "a local part that is not in Unicode NFC is valid",
                 "data": "cafe\u0301@example.com",
                 "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/idn-email.json
+++ b/tests/draft7/optional/format/idn-email.json
@@ -72,6 +72,18 @@
                 "description": "a local part that is not in Unicode NFC is valid",
                 "data": "cafe\u0301@example.com",
                 "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/idn-email.json
+++ b/tests/v1/format/idn-email.json
@@ -80,6 +80,18 @@
                 "description": "a local part that is not in Unicode NFC is valid",
                 "data": "cafe\u0301@example.com",
                 "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
This follows the ruling @jdesrosiers gave in [#948](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/948) on control and noncharacter code points in the local part:

> Both replies assert that the ABNF is correct. The text in question was intended to be a clarification, not to add any constraints. Therefore, we can ignore the errata and only consider the ABNF, which is well defined.

So the grammar governs. `atext =/ UTF8-non-ascii` and `UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4` put no code-point-class filter on the local part, which makes a C1 control and a noncharacter both valid there - surprising, but that is what the productions say. Nothing in the suite pins it today.

(@RishiByte offered to write these in the issue thread - I had them ready from the idn-email work so I am putting them up, happy to close this if you would rather they went that way.)

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- U+0085 NEXT LINE in the local part, written as the escape `` - valid.
- U+FFFF in the local part, written as the escape `￿` - valid.

Both are written as escapes rather than raw characters, so the files stay plain ASCII on disk.

## Ecosystem Impact

1. **sourcemeta/core (main, 99b6a5e)**: PASSES both (accepts them). Its local-part scan only asks `utf8_codepoint_length` for a well-formed 2-, 3- or 4-byte sequence and applies no property filter, which is the grammar-faithful reading.
2. **python email_validator 2.3.0**: FAILS both (rejects them) - it applies a "safe characters" filter that the RFC 6531 grammar does not have.
3. **validator.js 13.15**: FAILS both (rejects them) - same shape, its local-part pattern excludes both classes.
4. **isemail 3.2.0**: FAILS on the C1 control (rejects it).

## RFC References

- RFC 6531 section 3.3 (`atext =/ UTF8-non-ascii`): https://www.rfc-editor.org/rfc/rfc6531#section-3.3
- RFC 6532 section 3.1 (`UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4`): https://www.rfc-editor.org/rfc/rfc6532#section-3.1
- RFC 3629 section 4 (the UTF8-2 and UTF8-3 productions that admit U+0085 and U+FFFF): https://www.rfc-editor.org/rfc/rfc3629#section-4

Reproduction commands and the idn-email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
