### PR TITLE
Add minLength specification links

### DIFF
--- a/tests/draft2019-09/minLength.json
+++ b/tests/draft2019-09/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "minLength": 2
@@ -35,6 +40,11 @@
     },
     {
         "description": "minLength validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "minLength": 2.0

--- a/tests/draft2020-12/minLength.json
+++ b/tests/draft2020-12/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "minLength": 2
@@ -35,6 +40,11 @@
     },
     {
         "description": "minLength validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "minLength": 2.0

--- a/tests/draft3/minLength.json
+++ b/tests/draft3/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "core": "5.17"
+            }
+        ],
         "schema": {"minLength": 2},
         "tests": [
             {

--- a/tests/draft4/minLength.json
+++ b/tests/draft4/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "validation": "5.2.2"
+            }
+        ],
         "schema": {"minLength": 2},
         "tests": [
             {

--- a/tests/draft6/minLength.json
+++ b/tests/draft6/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "validation": "6.7"
+            }
+        ],
         "schema": {"minLength": 2},
         "tests": [
             {
@@ -32,6 +37,11 @@
     },
     {
         "description": "minLength validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.7"
+            }
+        ],
         "schema": {"minLength": 2.0},
         "tests": [
             {

--- a/tests/draft7/minLength.json
+++ b/tests/draft7/minLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "minLength validation",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {"minLength": 2},
         "tests": [
             {
@@ -32,6 +37,11 @@
     },
     {
         "description": "minLength validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.3.2"
+            }
+        ],
         "schema": {"minLength": 2.0},
         "tests": [
             {


### PR DESCRIPTION
Adds `minLength` specification links to every supported dialect. The section numbers differ for drafts 3, 4, and 6, and are `6.3.2` in later drafts.

Tests: `python -X utf8 bin/jsonschema_suite check`

Part of #699