### PR TITLE
test(duration): add digit-run and separator coverage

### DIFF
--- a/tests/draft2019-09/optional/format/duration.json
+++ b/tests/draft2019-09/optional/format/duration.json
@@ -247,6 +247,26 @@
                 "description": "weeks cannot be combined with a zero-valued component",
                 "data": "P0Y1W",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/duration.json
+++ b/tests/draft2020-12/optional/format/duration.json
@@ -247,6 +247,26 @@
                 "description": "weeks cannot be combined with a zero-valued component",
                 "data": "P0Y1W",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/duration.json
+++ b/tests/v1/format/duration.json
@@ -247,6 +247,26 @@
                 "description": "weeks cannot be combined with a zero-valued component",
                 "data": "P0Y1W",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION

The `duration` grammar in [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A) builds every component out of `1*DIGIT`:

```
dur-day = 1*DIGIT "D"
```

`1*DIGIT` is one-or-more `%x30-39` with no upper bound and no rule about leading zeros, and there is no fraction production anywhere in the appendix. The current file has 36 string cases, and none of them pins any of that: the longest valid string it contains is 20 characters, no valid case has a leading zero, and the only fraction case uses a dot. I checked each of the four cases below against a wrong implementation that passes all 36 existing cases, so each one catches something the file does not already catch.

## Changes

Four cases, added to the three files where `format: duration` exists.

**`P01D` is valid.** `1*DIGIT` says nothing about leading zeros. The file has no leading-zero case at all, so an implementation that writes each component as `0|[1-9][0-9]*` - the usual "no leading zeros" idiom, and the shape RFC 3986 uses for `dec-octet` - passes every existing case and rejects this one.

**A 78-digit component is valid.** `1*DIGIT` is unbounded. This is the case with real breakage behind it: **@exodus/schemasafe 1.3.0** guards `input.length > 1 && input.length < 80` before it looks at the string at all (`src/formats.js:152-157`), and **@cfworker/json-schema 4.1.1** ships a character-identical copy (`dist/esm/format.js:32-36`). Total length here is exactly 80, so both reject a valid duration. The same case also catches an implementation that parses a component into a 32-bit integer and range-checks it, and one that caps the digit run at two characters.

**`PT0,5S` is invalid.** ISO 8601 section 5.3.1.3 allows the comma as the decimal separator as well as the dot, but Appendix A has no fraction production either way. The file's only fraction case is `PT0.5S`, so a fraction guard written as "reject if the string contains a dot" passes it and accepts this one.

**`P-1D` is invalid.** `1*DIGIT` is `%x30-39`, so a sign is not part of a component. This is a different position from the leading sign in #979 and a different code path: an implementation anchored at `P` rejects `-P1D` on the first character but can still accept `P-1D` if it reads each component with the language's own number parser. I checked that #979's case does not catch that implementation, so the two do not overlap.

I left out three cases I had prepared, because a wrong implementation that fails them already fails an existing case: `P100D` and `P2147483648D` are both covered by the 78-digit case, and `P0Y0M0DT0H0M0S` did not catch anything the file misses.

## Ecosystem Impact

Scored against 9 format-asserting implementations plus `sourcemeta/core` as the reference.

| case | ajv-formats 3.0.1 | python-jsonschema 4.25.1 | @exodus/schemasafe 1.3.0 | @cfworker/json-schema 4.1.1 | sourcemeta/core |
|---|---|---|---|---|---|
| `P01D` valid | PASSES | PASSES | PASSES | PASSES | PASSES |
| 78-digit valid | PASSES | PASSES | **FAILS** | **FAILS** | PASSES |
| `PT0,5S` invalid | PASSES | **FAILS** | **FAILS** | **FAILS** | PASSES |
| `P-1D` invalid | PASSES | **FAILS** | PASSES | PASSES | PASSES |

python-jsonschema fails the last two through `isoduration`: `is_duration` calls `isoduration.parse_duration`, whose `is_number` treats `[+\-0-9.,eE]` as part of a component (`parser/util.py`) and then evaluates it with `Decimal` (`parser/parsing.py`). ajv-formats gets all four right - its duration regex uses `\d`, which is ASCII-only in JavaScript without the `u` flag.

## RFC References

- [RFC 3339 Appendix A](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A) - the `duration` ABNF, and the note that the appendix is "informational only"
- [RFC 5234 section 3.6](https://www.rfc-editor.org/rfc/rfc5234.html#section-3.6) - `1*DIGIT` is one-or-more with no upper bound
- [RFC 5234 section 6.1](https://www.rfc-editor.org/rfc/rfc5234.html#section-6.1) - `DIGIT = %x30-39`

Related: #965
