### PR TITLE
test(uri-template): add varname structure cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -140,6 +140,21 @@
                 "description": "a variable list with more than one varspec is valid",
                 "data": "{x,y}",
                 "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -140,6 +140,21 @@
                 "description": "a variable list with more than one varspec is valid",
                 "data": "{x,y}",
                 "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -97,6 +97,21 @@
                 "description": "a variable list with more than one varspec is valid",
                 "data": "{x,y}",
                 "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -137,6 +137,21 @@
                 "description": "a variable list with more than one varspec is valid",
                 "data": "{x,y}",
                 "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -140,6 +140,21 @@
                 "description": "a variable list with more than one varspec is valid",
                 "data": "{x,y}",
                 "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
RFC 6570 [section 2.3](https://www.rfc-editor.org/rfc/rfc6570#section-2.3) defines

```
varname = varchar *( ["."] varchar )
varchar = ALPHA / DIGIT / "_" / pct-encoded
```

so a dot is legal between two varchars but not doubled, and a varname may begin with a
pct-encoded triplet. The fixture has no varname test at all beyond `term`.

- `{a.b}` valid - `ajv-formats` rejects it. Its varname class is `(?:[a-z0-9_]|%[0-9a-f]{2})+`,
  which has no dot; the dot only appears in its leading operator class.
- `{a..b}` invalid - `python-jsonschema` accepts it. `uri_template`'s `charset.py` sets
  `VAR_CHAR = VAR_START + '.'` with no adjacency check, so any number of dots passes.
- `{%41}` valid - `python-jsonschema` rejects it. `variable.py` checks a `VAR_START` set of
  ALPHA/DIGIT/`_` before it ever reaches the pct-encoded branch, so a leading `%` is refused.
  `{a%41}` is accepted by the same library, which isolates it to the leading position.

Go [`yosida95/uritemplate`](https://github.com/yosida95/uritemplate) v3.0.2 and
[`sourcemeta/core`](https://github.com/sourcemeta/core) agree with the RFC on all three.