### PR TITLE
test(uri-template): add prefix max-length boundary cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -155,6 +155,16 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -155,6 +155,16 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -152,6 +152,16 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -152,6 +152,16 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -155,6 +155,16 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
RFC 6570 [section 2.4.1](https://www.rfc-editor.org/rfc/rfc6570#section-2.4.1):

```
prefix     = ":" max-length
max-length = %x31-39 0*3DIGIT   ; positive integer < 10000
```

Four digits are allowed and the first digit cannot be zero. The fixture only ever uses `{term:1}`.

- `{v:1000}` valid - `python-jsonschema` rejects every four-digit max-length. `variable.py`
  guards with `len(max_length) < 4` where it needs `< 5`. The Rust crate
  `uri-template-system` 0.1.5 has the same off-by-one independently.
- `{v:01}` invalid - `python-jsonschema` accepts it, because it converts with `int()` and never
  range-checks the first digit. Java `Handy-URI-Templates` 2.1.8 accepts it too.

`ajv-formats` gets both right - its `(?::[1-9][0-9]{0,3})` is a faithful transcription.