### PR TITLE
test(uri-template): add literal character set cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -165,6 +165,16 @@
                 "description": "a leading zero in the prefix max-length is invalid",
                 "data": "{v:01}",
                 "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -165,6 +165,16 @@
                 "description": "a leading zero in the prefix max-length is invalid",
                 "data": "{v:01}",
                 "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -162,6 +162,16 @@
                 "description": "a leading zero in the prefix max-length is invalid",
                 "data": "{v:01}",
                 "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -162,6 +162,16 @@
                 "description": "a leading zero in the prefix max-length is invalid",
                 "data": "{v:01}",
                 "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -165,6 +165,16 @@
                 "description": "a leading zero in the prefix max-length is invalid",
                 "data": "{v:01}",
                 "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
RFC 6570 [section 2.1](https://www.rfc-editor.org/rfc/rfc6570#section-2.1) enumerates the
literal set and its comment names the exclusions: *"any Unicode character except: CTL, SP,
DQUOTE, "'", "%" (aside from pct-encoded), "<", ">", "\", "^", "`", "{", "|", "}"*. The fixture
tests no literal character at all.

- `a b` invalid - `python-jsonschema` accepts it. `uri_template` performs no literal character
  check whatsoever; `uritemplate.py` only looks for a stray brace. It also accepts `a"b`,
  `a<b`, `a\b`, `a^b`, a backtick and `a|b`.
- `a<DEL>b` (U+007F) invalid - both gating validators accept it. DEL is a CTL per RFC 5234
  appendix B.1 and sits in the gap between `%x7E` and the start of `ucschar` at `%xA0`.
  `ajv-formats` misses it because its negated class is `[^\x00-\x20"'<>%\\^`{|}]`, which
  excludes controls only up to `%x20`.

Go, Core and the Rust crate all reject both.