### PR TITLE
test(uri-template): add variable list cases

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -175,6 +175,21 @@
                 "description": "a delete character in a literal is invalid",
                 "data": "a\u007fb",
                 "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -175,6 +175,21 @@
                 "description": "a delete character in a literal is invalid",
                 "data": "a\u007fb",
                 "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -172,6 +172,21 @@
                 "description": "a delete character in a literal is invalid",
                 "data": "a\u007fb",
                 "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -172,6 +172,21 @@
                 "description": "a delete character in a literal is invalid",
                 "data": "a\u007fb",
                 "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -175,6 +175,21 @@
                 "description": "a delete character in a literal is invalid",
                 "data": "a\u007fb",
                 "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
RFC 6570 [section 2.3](https://www.rfc-editor.org/rfc/rfc6570#section-2.3):

```
variable-list = varspec *( "," varspec )
varspec       = varname [ modifier-level4 ]
```

A varspec is required after every comma, and a varspec is a varname plus at most one modifier -
there is no default-value syntax and no second operator.

- `{a,}` invalid - `python-jsonschema` accepts it. `expansions.py` strips a single trailing
  character in `, . / ; &` before splitting on the comma, as part of its `partial()` round-trip
  support, so `a,` becomes `a`. The same strip makes it accept `{a;}`, `{a&}` and `{x,y,}`.
  It correctly rejects `{a,,b}`, which shows the trailing case is a distinct path.
- `{var=def}` invalid - `python-jsonschema` accepts it. `variable.py` splits the varspec on `=`
  and treats the right side as a default value. That syntax comes from the pre-RFC
  draft-gregorio-uritemplate drafts and did not survive into RFC 6570.
- `{,+var}` invalid - `python-jsonschema` accepts it. `uritemplate.py` has a branch
  `elif (',' == part[1]): if ((1 < len(part)) and ('+' == part[2])): ReservedCommaExpansion(...)`,
  an extension the RFC does not define.

The third case is worth spelling out, because it does **not** depend on how the reserved
operators `= , ! @ |` are read. Under the permissive reading, where op-reserve counts as a
usable operator, `,` fills the single operator slot and what follows must be a variable-list -
but `+` is not a varchar, so there is no parse. Under the strict reading, where op-reserve
cannot be used at all, there is no parse either. Both readings reject it, so it needs no ruling.
Every other implementation I checked - `ajv-formats`, Go `yosida95/uritemplate`, `sourcemeta/core`,
Rust `uri-template-system`, Java `Handy-URI-Templates` - rejects it.