### PR TITLE
test(uri-template): add literal apostrophe case

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -190,6 +190,11 @@
                 "description": "an operator in place of the first varspec is invalid",
                 "data": "{,+var}",
                 "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -190,6 +190,11 @@
                 "description": "an operator in place of the first varspec is invalid",
                 "data": "{,+var}",
                 "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -187,6 +187,11 @@
                 "description": "an operator in place of the first varspec is invalid",
                 "data": "{,+var}",
                 "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -187,6 +187,11 @@
                 "description": "an operator in place of the first varspec is invalid",
                 "data": "{,+var}",
                 "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -190,6 +190,11 @@
                 "description": "an operator in place of the first varspec is invalid",
                 "data": "{,+var}",
                 "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
This one turns on an erratum rather than the published RFC text, flagging that up front.

RFC 6570 section 2.1 as published excludes `%x27` from the literal set. Errata ID
[6937](https://www.rfc-editor.org/errata/eid6937) corrects the ranges `%x26 / %x28-3B` to
`%x26-3B`, which puts the apostrophe back in. It is marked **Verified**.

The RFC's own section 3.2.1 example is `'{var}'`, which is only a valid template with the
erratum applied - that inconsistency is what the erratum fixes.

- `a'b` valid - `ajv-formats` rejects it; its literal class negates `'`.

Go `yosida95/uritemplate` changed to accept the apostrophe for exactly this reason
([issue #14](https://github.com/yosida95/uritemplate/issues/14), fixed in v3.0.2), and
`sourcemeta/core` accepts it deliberately with a comment pointing at the spec's own examples.
`python-jsonschema` accepts it only incidentally, since it does no literal checking at all, so
it is not evidence either way.