### PR TITLE
test(uri-template): add operator and modifier coverage

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -95,6 +95,51 @@
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -95,6 +95,51 @@
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -52,6 +52,51 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -92,6 +92,51 @@
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -95,6 +95,51 @@
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The fixture has four real string tests and none of them contains an operator, an explode
modifier, or a variable list with more than one member. RFC 6570
[section 2.2](https://www.rfc-editor.org/rfc/rfc6570#section-2.2) defines seven usable
operators and every implementation I looked at gives each its own code path -
`sourcemeta/core` has a separate token type per operator, `uri_template` a separate branch -
so a validator can support `+` and forget `&` and still pass the suite today.

Adds `{+var}`, `{#var}`, `{.var}`, `{/var}`, `{;var}`, `{?var}`, `{&var}`, plus `{var*}` for the
explode alternative of `modifier-level4` and `{x,y}` for the `*( "," varspec )` repetition.

All nine pass on both gating validators (`ajv-formats` and `python-jsonschema`), so this is
coverage rather than a breaker. `{x,y}` is not entirely free of breakers though -
`php-justinrainbow/json-schema` rejects it.