### PR TITLE
test(uri-template): add expression and literal boundary coverage

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -55,6 +55,46 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -55,6 +55,46 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -52,6 +52,46 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -55,6 +55,46 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Boundary cases with no existing test on either side of them:

- `{}` invalid - `variable-list` requires at least one varspec. Java `Handy-URI-Templates`
  2.1.8 throws `StringIndexOutOfBoundsException` on this input rather than its declared
  `MalformedUriTemplateException`.
- `{a,,b}` invalid - an empty member in the middle of the list, which is a different code path
  from a trailing comma in every implementation I read.
- `{v:0}` invalid - `max-length` is a positive integer; this pins the value bound.
- `{v:10000}` invalid - `max-length` is `%x31-39 0*3DIGIT`; this pins the digit-count bound,
  which nothing else does once a four-digit case exists.
- `""` valid - `URI-Template = *( literals / expression )` permits zero repetitions.
- `foo}bar` invalid - `}` is excluded from literals. The fixture tests a missing `}` but never
  a stray one.
- `a%41b` valid - a pct-encoded triplet in a literal, which the fixture never exercises.
- `a<U+1F600>b` valid - `ucschar` reaches above the BMP.
  `php-opis/json-schema` rejects this one.