### PR TITLE
test(uri): reject a leading zero in an embedded IPv4 address

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -224,6 +224,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -224,6 +224,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -224,6 +224,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -227,6 +227,11 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A) and found that nothing covers the `dec-octet` rule in the one position where it is actually load-bearing - the IPv4 address embedded in an IPv6 literal.

`dec-octet` has no leading-zero alternative; the only two-digit form is `%x31-39 DIGIT`, whose first digit is 1-9. In a bare host that rule is unobservable, because a dotted-quad that fails `IPv4address` simply falls through to `reg-name`, where digits and dots are ordinary unreserved characters - this file already records that with `http://087.10.0.1/` being valid. Inside an IP-literal `reg-name` cannot apply, since `[` and `]` are not `reg-name` characters, so `ls32 = ( h16 ":" h16 ) / IPv4address` is the only slot where a leading zero is genuinely invalid. The existing embedded-IPv4 cases cover a valid address and an out-of-range octet, but not this one.

## Changes

- Added 1 test case across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `http://[::ffff:01.2.3.4]` - a leading zero in the IPv4 address embedded in an IPv6 literal, invalid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1** (via rfc3987 1.3.8): FAILS (accepts it). Its `dec_octet` pattern is `(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)` - the `[01]?` prefix makes a leading zero legal.
2. **ajv-formats 3.0.1** (full mode): FAILS (accepts it). The same shape appears in its URI regex: `(?:25[0-5]|2[0-4]\d|[01]?\d\d?)`.
3. **@cfworker/json-schema 4.1.1** and **@exodus/schemasafe 1.3.0**: FAIL (accept it). Both carry the same `[01]?` in their own copies of that regex.
4. **sourcemeta/core** `is_uri`: PASSES (rejects it). It is a hand-written parser that enforces the five `dec-octet` alternatives directly rather than by regex.

The out-of-range control `http://[::ffff:1.2.3.256]` is rejected correctly by both python-jsonschema and ajv-formats, so what these miss is specifically the leading zero and not the range check.

## RFC References

- RFC 3986 Appendix A (collected ABNF - `dec-octet`, `ls32`, `IPv4address`): https://www.rfc-editor.org/rfc/rfc3986#appendix-A
- RFC 3986 section 3.2.2 (host, IP-literal): https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2

Reproduction commands and the uri cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
