### PR TITLE
test(uri): reject square brackets in a path segment

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -232,6 +232,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -232,6 +232,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -229,6 +229,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -229,6 +229,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -229,6 +229,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -232,6 +232,11 @@
                 "description": "leading zero in an embedded IPv4 address is invalid",
                 "data": "http://[::ffff:01.2.3.4]",
                 "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A) and found that the file tests square brackets in a path only when the URI also has a `//` authority, which turns out to be the case implementations get right.

`[` and `]` are `gen-delims` and appear in no `pchar` alternative, so they cannot occur in a path segment. With a single slash after the scheme the `"//" authority` alternative of `hier-part` cannot apply, so `http:/[::1]` can only be `path-absolute`, whose first segment is `segment-nz = 1*pchar` - and that excludes brackets. [Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) says the same thing in prose: the host is "the only place where square bracket characters are allowed in the URI syntax". The existing bracket cases all carry a `//` authority, so the bracket really is in a path, query or fragment and implementations reject them correctly - none of them exercises the single-slash form.

## Changes

- Added 1 test case across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `http:/[::1]` - an IPv6 literal in a single-slash path, invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1** (full mode): FAILS (accepts it). Its authority alternative opens `(?:\/?\/` with the first slash optional, so a single `/` enters the authority branch and `[::1]` matches the IP-literal alternative there. Deleting that one `?`, so the second slash is mandatory, flips this input to rejected and leaves every other verdict in the file unchanged.
2. **@cfworker/json-schema 4.1.1** and **@exodus/schemasafe 1.3.0**: FAIL (accept it). Both carry the same optional-first-slash construct in their own URI patterns.
3. **python-jsonschema 4.25.1** (via rfc3987 1.3.8): PASSES (rejects it).
4. **sourcemeta/core** `is_uri` and **@hyperjump/json-schema 1.17.7**: PASS (reject it). Hyperjump builds its pattern from the ABNF productions rather than as one hand-written regex.

What shows this is the authority branch being reached rather than a loose character class: the same implementations correctly reject `a:/[]`, `a:/[zz]`, `a:/[1.2.3.4]` and `a:/x/[::1]`. Only a well-formed IP-literal, and only in the first segment, gets through.

## RFC References

- RFC 3986 Appendix A (collected ABNF - `hier-part`, `path-absolute`, `segment-nz`, `pchar`, `gen-delims`): https://www.rfc-editor.org/rfc/rfc3986#appendix-A
- RFC 3986 section 3.2.2 (host - brackets are allowed only in an IP-literal): https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
- RFC 3986 section 3.3 (path): https://www.rfc-editor.org/rfc/rfc3986#section-3.3

Reproduction commands and the uri cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
