### PR TITLE
test(regex): back port the ECMA 262 dialect cases to draft-07 and 2019-09

### DIFF
--- a/tests/draft2019-09/optional/format/ecmascript-regex.json
+++ b/tests/draft2019-09/optional/format/ecmascript-regex.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/tests/draft7/optional/format/ecmascript-regex.json
+++ b/tests/draft7/optional/format/ecmascript-regex.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Follow-up to [#998](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/998), where you asked whether the ECMA 262 cases should be back ported to the other dialects. They should - the `regex` format has always been defined as ECMA 262, so the same cases apply to every dialect that tests the format at all.

The [draft-07 validation spec section 7.3.8](https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01#rfc.section.7.3.8) and [2019-09 section 7.3.8](https://json-schema.org/draft/2019-09/draft-handrews-json-schema-validation-02#rfc.section.7.3.8) both say a `regex` instance "should be a valid regular expression, according to the ECMA 262 regular expression dialect" - the same wording 2020-12 uses. Both of those dialects already have a `regex.json`, but neither had an `ecmascript-regex.json`, so the dialect-validity cases only existed for 2020-12 and v1. draft-04 and draft-06 have no `regex` format file at all, so I left those alone.

## Changes

- Added `tests/draft7/optional/format/ecmascript-regex.json` and `tests/draft2019-09/optional/format/ecmascript-regex.json`.
- 12 test cases each, the same set merged for 2020-12 in #998: Python-only syntax (`(?P<name>...)`, `(?P=name)`, `(?#...)`) and global inline flag groups (`(?i)`, `(?ims)`) are invalid; ECMA 262 named groups and backreferences, variable-width lookbehind, empty and negated-empty character classes, and the `\cA` control escape are valid; `\a` is not an ECMA 262 control escape.
- Each file follows its own dialect's conventions - draft-07 omits `$schema` and uses the one-line schema form, 2019-09 pins its `$schema`.

## Ecosystem Impact

Same as #998 - the cases are dialect-independent because the ECMA 262 requirement is worded identically across draft-07, 2019-09 and 2020-12.

1. **python-jsonschema 4.25.1**: FAILS the invalid cases (accepts them). It compiles the pattern with Python's `re`, so Python-only constructs and inline flag groups compile happily and are reported valid.
2. **ajv-formats 3.0.1**: PASSES (rejects them). It compiles with the JavaScript `RegExp` constructor, which is ECMA 262 by definition.

## RFC References

- JSON Schema Validation draft-07 section 7.3.8 (regex - ECMA 262): https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01#rfc.section.7.3.8
- JSON Schema Validation 2019-09 section 7.3.8 (regex - ECMA 262): https://json-schema.org/draft/2019-09/draft-handrews-json-schema-validation-02#rfc.section.7.3.8
- ECMA 262, Patterns: https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns

Related: [#965](https://github.com/json-schema-org/community/issues/965)
