### PR TITLE
test(iri): add a leading zero in an embedded IPv4 as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -80,6 +80,11 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -80,6 +80,11 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -77,6 +77,11 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -80,6 +80,11 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: iri` against [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found that an IPv6 host whose embedded IPv4 address has a leading zero is accepted by python-jsonschema under both of its format extras.

RFC 3987 takes `ihost` from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), where the last 32 bits of an IPv6 literal may be written as an IPv4 address:

```abnf
ls32          = ( h16 ":" h16 ) / IPv4address
IPv4address   = dec-octet "." dec-octet "." dec-octet "." dec-octet
dec-octet     = DIGIT                 ; 0-9
              / %x31-39 DIGIT         ; 10-99
              / "1" 2DIGIT            ; 100-199
              / "2" %x30-34 DIGIT     ; 200-249
              / "25" %x30-35          ; 250-255
```

None of those five alternatives matches `01` - a two-digit octet must start `%x31-39`. So `::ffff:192.168.0.01` is not a valid IPv6 address.

What makes this position different from a bare host is that there is no fallback. `host = IP-literal / IPv4address / reg-name`, so a bare `http://192.168.0.01/` is perfectly valid - it simply matches `reg-name`, since `unreserved` includes DIGIT and `.`. Inside the brackets `reg-name` is not an alternative, so the octet has to be a real `dec-octet` and a leading zero has nowhere to go.

The existing files have no IPv6 host with an embedded IPv4 at all.

## Changes

One test in the "validation of IRIs" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
    "data": "http://[::ffff:192.168.0.01]",
    "valid": false
}
```

## Ecosystem Impact

**python-jsonschema 4.25.1 with the `[format]` extra** - FAILS (accepts it). `rfc3987 1.3.8` builds `dec_octet` as a single alternation and the `DIGIT` branch is not anchored within the octet, so a leading zero is absorbed. Confirmed end to end through `Draft202012Validator`, 0 errors.

**python-jsonschema 4.25.1 with the `[format-nongpl]` extra** - FAILS (accepts it) for `uri` and `uri-reference`. That path uses `rfc3986_validator 0.1.1`, whose octet subpattern is written `[01]?[0-9][0-9]?` - an explicitly optional leading `0` or `1`, which admits `01`, `00`, `000` and `09`.

I swept this exhaustively rather than sampling: every octet string of one to three digits in each of the four positions, 4440 probes. Both libraries diverge from the grammar on exactly **440**, and every one of the 440 is a leading-zero octet - no other octet value diverges in either. So the mechanism is precisely "a leading zero in a `dec-octet` inside an `ls32`" and nothing wider.

**sourcemeta/core `is_iri`** - PASSES (rejects it). **Rust `iri-string` 0.7.12** - PASSES.

**ajv-formats 3.0.1** - not applicable. Its format table has no `iri` key.

Note that `format: ipv6` is not affected - python-jsonschema validates that one with `ipaddress`, which rejects `::ffff:192.168.0.01` correctly. The leak is specific to the RFC 3986 grammar libraries behind `iri`, `iri-reference`, `uri` and `uri-reference`.

## Relationship to the open uri PRs

[#957](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/957) adds `http://[::ffff:1.2.3.256]` (an octet over 255) and `http://[::ffff:192.168.1.1]` (valid). Neither covers a leading zero, and the out-of-range case does not catch this - both libraries correctly reject `256` while accepting `01`. The published `ipv6.json` files have `::ffff:192.168.0.1` only.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - `ihost = IP-literal / IPv4address / ireg-name`
- [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - `ls32`, `IPv4address` and the five `dec-octet` alternatives

Related: [#965](https://github.com/json-schema-org/community/issues/965)
