### PR TITLE
test(iri): add a compressed IPv6 host as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -85,6 +85,11 @@
                 "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
                 "data": "http://[::ffff:192.168.0.01]",
                 "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -85,6 +85,11 @@
                 "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
                 "data": "http://[::ffff:192.168.0.01]",
                 "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -82,6 +82,11 @@
                 "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
                 "data": "http://[::ffff:192.168.0.01]",
                 "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -85,6 +85,11 @@
                 "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
                 "data": "http://[::ffff:192.168.0.01]",
                 "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: iri` against [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found that a host written as a compressed IPv6 literal is rejected by python-jsonschema when it is installed with the `format-nongpl` extra.

RFC 3987 defines `ihost = IP-literal / IPv4address / ireg-name` and takes `IP-literal` straight from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), whose `IPv6address` rule has nine alternatives. Seven of them begin with an optional group - `[ *4( h16 ":" ) h16 ] "::" ls32` and its neighbours - so the number of `h16` groups before the `::` may be anything from zero up to the stated maximum. `2001:db8::1` uses two of them.

The one IPv6 test in these files is `http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]`, which is the fully written out eight-group form. That is the single alternative with no `::` in it, so nothing in the file exercises the compressed alternatives at all.

## Changes

One test in the "validation of IRIs" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "a valid IRI with a compressed IPv6 host",
    "data": "http://[2001:db8::1]",
    "valid": true
}
```

## Ecosystem Impact

**python-jsonschema 4.25.1 with the `[format-nongpl]` extra** - FAILS (rejects it). That extra pulls in [rfc3987-syntax 1.1.0](https://pypi.org/project/rfc3987-syntax/) instead of `rfc3987`, and `_format.py` routes `is_iri` to `rfc3987_syntax.is_valid_syntax("iri", instance)`. That library is a Lark grammar, and its `syntax_rfc3987.lark` transcribes `IPv6address` with the optional prefix groups dropped and the repetition counts frozen:

```lark
ipv6address: h16 ":" h16 ":" h16 ":" h16 ":" h16 ":" h16 ":" ls32
           | "::" h16 ":" h16 ":" h16 ":" h16 ":" h16 ":" ls32
           | h16 "::" h16 ":" h16 ":" h16 ":" h16 ":" ls32
           ...
```

Where RFC 3986 writes `[ *4( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32`, the grammar writes a fixed `h16 "::" h16 ":" ...`. So an address only parses when the number of groups on each side of the `::` happens to match one fixed alternative exactly. Enumerating the shape space exhaustively - every `::` position crossed with every group count, 225 distinct shapes - it rejects **51 of the 67 valid ones**, including `::1`, `::`, `fe80::1`, `2001:db8::1` and `::ffff:192.168.0.1`. The eight-group form already in the file is one of the shapes it gets right, which is why the current test does not catch this.

**python-jsonschema 4.25.1 with the `[format]` extra** - PASSES (accepts it). That path uses `rfc3987 1.3.8`, whose regex is generated from the ABNF and keeps the optional groups.

**ajv-formats 3.0.1** - not applicable. Its format table has no `iri` key, so ajv treats the format as unknown.

**sourcemeta/core `is_iri`** - PASSES. **Rust `iri-string` 0.7.12** - PASSES. **rfc3987-syntax2 1.3.2** - PASSES; the maintained fork of the same library has already restored the full rule.

python-jsonschema runs its own test suite against both extras - `noxfile.py` parametrises `format` and `format-nongpl`, and `.github/workflows/ci.yml` runs `tests-3.14(format-nongpl)` - so this test exercises a path their CI already covers.

## Why this test and not `http://[::1]`

A checker that special-cases a leading `::` but still requires a full-length prefix otherwise passes all nine existing string tests and passes `http://[::1]`, while failing `http://[2001:db8::1]`. The reverse is not true. So the two-group form catches strictly more than the loopback form, and one test is enough.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - `ihost = IP-literal / IPv4address / ireg-name`
- [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - the nine `IPv6address` alternatives and the optional prefix groups

Related: [#965](https://github.com/json-schema-org/community/issues/965)
