### PR TITLE
test(iri): add supplementary-plane ucschar and iprivate as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -122,7 +122,7 @@
                 "valid": true
             },
             {
-                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
                 "data": "http://ƒøø.ßår/?q=󰀀",
                 "valid": true
             }

--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -115,6 +115,16 @@
                 "description": "a valid IRI with no authority and an absolute path",
                 "data": "file:/etc/hosts",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -122,7 +122,7 @@
                 "valid": true
             },
             {
-                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
                 "data": "http://ƒøø.ßår/?q=󰀀",
                 "valid": true
             }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -115,6 +115,16 @@
                 "description": "a valid IRI with no authority and an absolute path",
                 "data": "file:/etc/hosts",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -119,7 +119,7 @@
                 "valid": true
             },
             {
-                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
                 "data": "http://ƒøø.ßår/?q=󰀀",
                 "valid": true
             }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -112,6 +112,16 @@
                 "description": "a valid IRI with no authority and an absolute path",
                 "data": "file:/etc/hosts",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -122,7 +122,7 @@
                 "valid": true
             },
             {
-                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
                 "data": "http://ƒøø.ßår/?q=󰀀",
                 "valid": true
             }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -115,6 +115,16 @@
                 "description": "a valid IRI with no authority and an absolute path",
                 "data": "file:/etc/hosts",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use character in the query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: iri` against [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found that no test in these files uses a character above the Basic Multilingual Plane, even though most of the `ucschar` rule lives up there.

`ucschar` has seventeen ranges and fourteen of them are supplementary:

```abnf
ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
               / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
               / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
               / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
               / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
               / %xD0000-DFFFD / %xE1000-EFFFD

iprivate       = %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
```

Every non-ASCII character in the current file is in the BMP - `ƒøø`, `ßår`, `∂éœ`, `πîüx`. So the whole supplementary part of `ucschar`, and both supplementary `iprivate` ranges, are untested.

## Changes

Two tests in the "validation of IRIs" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "a valid IRI with a supplementary-plane character in the path",
    "data": "http://ƒøø.ßår/𐌀",
    "valid": true
},
{
    "description": "a valid IRI with a supplementary-plane private-use character in the query",
    "data": "http://ƒøø.ßår/?q=󰀀",
    "valid": true
}
```

The first uses U+10300 OLD ITALIC LETTER A, in `ucschar`'s `%x10000-1FFFD`. The second uses U+F0000, in `iprivate`'s `%xF0000-FFFFD`, and it is in the query because `iprivate` appears only in the `iquery` production.

## Ecosystem Impact

**python-jsonschema 4.25.1 with the `[format-nongpl]` extra** - FAILS (rejects both). That extra routes `is_iri` to [rfc3987-syntax 1.1.0](https://pypi.org/project/rfc3987-syntax/), whose Lark grammar stops both rules at the end of the BMP:

```lark
ucschar: /[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]/
iprivate: /[\uE000-\uF8FF]/
```

All fourteen supplementary `ucschar` ranges and both supplementary `iprivate` ranges are missing, so every character above U+FFFF is rejected wherever it appears - path, query, fragment, host, userinfo.

**python-jsonschema 4.25.1 with the `[format]` extra** - PASSES (accepts both). `rfc3987 1.3.8` builds its character classes from the full ABNF.

**ajv-formats 3.0.1** - not applicable. Its format table has no `iri` key.

**sourcemeta/core `is_iri`** - PASSES. **Rust `iri-string` 0.7.12** - PASSES. **rfc3987-syntax2 1.3.2** - PASSES; the maintained fork has the complete ranges.

python-jsonschema parametrises both extras in `noxfile.py` and runs `tests-3.14(format-nongpl)` in CI, so this covers a path they already test.

## Why two tests

`ucschar` and `iprivate` are separate productions on separate lines, and a transcription can complete one and miss the other. A checker with the supplementary `ucschar` ranges restored but `iprivate` still capped at U+F8FF passes all nine existing string tests and the first new test, and fails only the second. If that seems too fine a distinction I am happy to drop the `iprivate` one and keep the `ucschar` case alone.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - the `ucschar` and `iprivate` ranges, and `iprivate` appearing only in `iquery`

Related: [#965](https://github.com/json-schema-org/community/issues/965)
