### PR TITLE
test(iri): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -90,6 +90,11 @@
                 "description": "a valid IRI with a compressed IPv6 host",
                 "data": "http://[2001:db8::1]",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -90,6 +90,11 @@
                 "description": "a valid IRI with a compressed IPv6 host",
                 "data": "http://[2001:db8::1]",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -87,6 +87,11 @@
                 "description": "a valid IRI with a compressed IPv6 host",
                 "data": "http://[2001:db8::1]",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -90,6 +90,11 @@
                 "description": "a valid IRI with a compressed IPv6 host",
                 "data": "http://[2001:db8::1]",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: iri` against [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found that a valid IRI followed by a single line feed is accepted by python-jsonschema.

A line feed appears in no production of the section 2.2 grammar. `ucschar` starts at `%xA0`, `iunreserved` is ALPHA, DIGIT, `-`, `.`, `_`, `~` and `ucschar`, and neither `sub-delims` nor `pct-encoded` reaches it, so U+000A cannot appear anywhere in an IRI.

None of the existing tests in these files cover a trailing control character.

## Changes

One test in the "validation of IRIs" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "a trailing newline after a valid IRI is invalid",
    "data": "http://ƒøø.ßår/\n",
    "valid": false
}
```

## Ecosystem Impact

**python-jsonschema 4.25.1 with the `[format]` extra** - FAILS (accepts it). Its `is_iri` calls `rfc3987.parse(instance, rule="IRI")`. `parse` delegates to `match` at `rfc3987.py` line 460, and `match` at line 424 is:

```python
return get_compiled_pattern('^%%(%s)s$' % rule).match(string)
```

The anchor is `$`, not `\Z`, and with default flags Python's `$` matches at the end of the string **or immediately before a single trailing newline**, so `http://ƒøø.ßår/\n` parses. `\Z` would not. The leak is narrow - a doubled LF, an LF in the middle, a CR, a CRLF, and a trailing space, tab, vertical tab or form feed are all correctly rejected. Only one terminal LF slips through.

Because the same `^...$` construction backs all four of that library's rules, the same input is accepted for `iri-reference`, `uri` and `uri-reference` as well.

**python-jsonschema 4.25.1 with the `[format-nongpl]` extra** - PASSES (rejects it). That path uses `rfc3987-syntax`, a Lark grammar whose parser requires a full-input match.

**ajv-formats 3.0.1** - not applicable. Its format table has no `iri` key.

**sourcemeta/core `is_iri`** - PASSES. **Rust `iri-string` 0.7.12** - PASSES.

This is the same anchor class as the `ipv4` trailing-newline test in #840, the `duration` one in #982 and the `hostname` one in #1023.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - the IRI grammar; no production admits U+000A

Related: [#965](https://github.com/json-schema-org/community/issues/965)
