### PR TITLE
test(iri): add an uppercase IPvFuture version letter as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -95,6 +95,11 @@
                 "description": "a trailing newline after a valid IRI is invalid",
                 "data": "http://ƒøø.ßår/\n",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -95,6 +95,11 @@
                 "description": "a trailing newline after a valid IRI is invalid",
                 "data": "http://ƒøø.ßår/\n",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -92,6 +92,11 @@
                 "description": "a trailing newline after a valid IRI is invalid",
                 "data": "http://ƒøø.ßår/\n",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -95,6 +95,11 @@
                 "description": "a trailing newline after a valid IRI is invalid",
                 "data": "http://ƒøø.ßår/\n",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: iri` against [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found that an IPvFuture host whose version letter is written in uppercase is rejected by every Python implementation of this format, although it is valid.

RFC 3987 takes `IP-literal` from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2):

```abnf
IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
```

[RFC 5234 section 2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) says of ABNF that "terminal values are case-insensitive" and gives the worked example that `%d97` and `%d65` both satisfy the literal `"a"`. So the `"v"` in `IPvFuture` matches `V` as well. RFC 3986 section 3.2.2 says the same thing in prose for this exact rule - it describes "an IP literal that starts with `v` (case-insensitive)" - and adds that "the host subcomponent is case-insensitive".

The existing files have no IPvFuture test at all, in either case.

## Changes

One test in the "validation of IRIs" group, added to draft7, draft2019-09, draft2020-12 and v1:

```json
{
    "description": "an IPvFuture host with an uppercase version letter is valid",
    "data": "http://[V1.fe]",
    "valid": true
}
```

## Ecosystem Impact

**python-jsonschema 4.25.1 with the `[format]` extra** - FAILS (rejects it). `rfc3987 1.3.8` builds its IPvFuture pattern with a hardcoded lowercase letter and no case-insensitive flag:

```python
r"v{hexdig}+\.(?:{unreserved}|{sub_delims}|:)+"
```

`http://[v1.fe]` is accepted, so the version letter's case is the only difference.

**python-jsonschema 4.25.1 with the `[format-nongpl]` extra** - FAILS (rejects it). Different library, same mistake: `rfc3987-syntax`'s Lark grammar writes `ipvfuture: "v" hexdig+ "." (unreserved | sub_delims | ":")+`, and Lark string literals are case-sensitive by default.

**rfc3987-syntax2 1.3.2** - FAILS. The maintained fork carries the rule across unchanged.

So all three Python libraries that back this format reject it, which is why it is worth pinning.

**sourcemeta/core `is_iri`** - PASSES. Its parser tests the letter explicitly as `'v' || 'V'`. **Rust `iri-string` 0.7.12** - PASSES.

**ajv-formats 3.0.1** - not applicable. Its format table has no `iri` key.

## Note on overlap with the open uri PRs

[#957](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/957) adds `http://[V1.test]` to the `uri` files. This test is for the `iri` files, which have no IPvFuture case of either kind. The two are not the same code path in the implementations that get this wrong - `rfc3987` compiles a separate pattern per rule and exposes `IRI` and `URI` as different entry points, and sourcemeta/core has separate `is_iri` and `is_uri` functions - so a fix driven by the `uri` test would not necessarily be exercised here. If the maintainers would rather see one of the two, I am happy to defer to #957 and close this.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - `ihost = IP-literal / IPv4address / ireg-name`
- [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - the `IPvFuture` rule, and the host subcomponent being case-insensitive
- [RFC 5234 section 2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) - ABNF terminal values are case-insensitive

Related: [#965](https://github.com/json-schema-org/community/issues/965)
