### PR TITLE
test(iri): add host and path branches with no existing coverage

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -100,6 +100,21 @@
                 "description": "an IPvFuture host with an uppercase version letter is valid",
                 "data": "http://[V1.fe]",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -100,6 +100,21 @@
                 "description": "an IPvFuture host with an uppercase version letter is valid",
                 "data": "http://[V1.fe]",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -97,6 +97,21 @@
                 "description": "an IPvFuture host with an uppercase version letter is valid",
                 "data": "http://[V1.fe]",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -100,6 +100,21 @@
                 "description": "an IPvFuture host with an uppercase version letter is valid",
                 "data": "http://[V1.fe]",
                 "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I walked the [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) grammar against the current `optional/format/iri.json` (9 real string tests) and found three structural branches the suite does not exercise anywhere, each of which can catch a wrong implementation the existing tests let through. All three are accepted by python-jsonschema 4.25.1 (both format extras), so they do not break the dominant validator - they close real gaps.

Every existing test builds its host with `ireg-name` and its authority with `//`. That leaves two host alternatives and two `ihier-part` alternatives completely untested:

```abnf
ihost      = IP-literal / IPv4address / ireg-name
ihier-part = "//" iauthority ipath-abempty
           / ipath-absolute / ipath-rootless / ipath-empty
```

I checked distinctness the same way as the ipv4 coverage PR: for each candidate I built a checker missing exactly that branch and confirmed it still passes all 9 existing string tests, so the new case is what catches it, not an existing one.

- A checker with `ihost` missing the `IPv4address` alternative (`IP-literal` and `ireg-name` only) passes all 9 existing tests and rejects `http://192.168.0.1/p`.
- A checker with `ihier-part` requiring a `//` authority (dropping `ipath-rootless`, `ipath-absolute`, `ipath-empty`) passes all 9 existing tests and rejects `urn:example:resource` and `file:/etc/hosts`.

I also tried `http://[::1]` (the IPv6 loopback) and an explicit `:port`, but a checker that special-cases a leading `::` while still requiring a full-length prefix elsewhere passes `[::1]` and only fails on a compressed form with a non-empty prefix, and a checker missing the optional port fails an existing test outright - so both were dropped as redundant against the three below.

## Changes

Three valid tests, added to the draft7/2019-09/2020-12/v1 copies of the file:

- `http://192.168.0.1/p` - `ihost = IPv4address`, the branch nothing in the suite exercises.
- `urn:example:resource` - `ihier-part = ipath-rootless`, a scheme with no authority.
- `file:/etc/hosts` - `ihier-part = ipath-absolute`, a scheme with an absolute path and no authority.

All three are accepted by python-jsonschema 4.25.1 under both the `[format]` and `[format-nongpl]` extras, so they pass on a correct implementation.

## RFC References

- [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) - `ihost` and `ihier-part`

Related: [#965](https://github.com/json-schema-org/community/issues/965)
