### PR TITLE
test(uri-template): add draft-06 expression and literal boundary coverage

### DIFF
--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -54,6 +54,46 @@
                 "valid": true
             },
             {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true


### PR DESCRIPTION
Follow-up to #1060 - that PR added this coverage to `draft2019-09`, `draft2020-12`, `draft7`
and `v1` but missed `draft6`, which also carries a `uri-template` format fixture.

Same eight cases #1060 added, applied to `tests/draft6/optional/format/uri-template.json`:
`{}`, `{a,,b}`, `{v:0}`, `{v:10000}` invalid; `""`, `a%41b`, `foo}bar` (invalid), and the
supplementary-plane literal, all matching the already-reviewed content on the other drafts.