### PR TITLE
test(uri-reference): reject a colon in the first segment of a relative reference

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -146,6 +146,18 @@
                 "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -146,6 +146,18 @@
                 "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -143,6 +143,18 @@
                 "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -143,6 +143,18 @@
                 "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -146,6 +146,18 @@
                 "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I was checking `format: uri-reference` against the [RFC 3986 §4.2](https://www.rfc-editor.org/rfc/rfc3986#section-4.2) grammar and found that the rule which stops a relative reference from being read as a URI is not tested anywhere in the file.

`relative-part` uses `path-noscheme`, and `path-noscheme = segment-nz-nc *( "/" segment )` where [§3.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) defines `segment-nz-nc` as `1*( unreserved / pct-encoded / sub-delims / "@" )` with the comment "non-zero-length segment without any colon". §4.2 spells out the consequence: "A path segment that contains a colon character (e.g., "this:that") cannot be used as the first segment of a relative-path reference, as it would be mistaken for a scheme name. Such a segment must be preceded by a dot-segment (e.g., "./this:that") to make a relative-path reference."

`1:b` cannot be read as a URI either, because `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` and a scheme may not start with a digit. So neither branch of `URI-reference = URI / relative-ref` matches and the string is invalid.

## Changes

- `1:b` invalid - a colon in the first segment where the prefix cannot be a scheme
- `./this:that` valid - the RFC's own repair, and the case that stops the test from being read as "colons are banned"

I did not use `this:that` itself: `this` is a well-formed scheme, so that string is a valid URI and does not discriminate.

## Ecosystem Impact

- **ajv-formats 3.0.1** (`full` and `fast`) accepts `1:b`. The relative branch of its `uri-reference` pattern is `(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/...)*`, which is `path-rootless` - the colon is inside the first-segment class. FAILS.
- **@cfworker/json-schema 4.1.1**, **@exodus/schemasafe 1.3.0**, **z-schema 12.4.1**, **json-schema-library 11.6.2**, **ata-validator 1.2.2** all accept it. FAIL.
- Across a 38-image Bowtie census, 5 of the 12 asserting implementations accept it: `js-json-schema`, `js-schemasafe`, `perl-json-schema-modern`, `php-justinrainbow-json-schema`, `python-fastjsonschema`.
- **python-jsonschema 4.25.1** (rfc3987 1.3.8), **djv 2.1.4**, **jsonschema 1.5.0**, **sourcemeta/core**, **jsonschema-rs**, **fluent-uri**, **iri-string** and **rust-boon** all reject it. PASS.
- Only `clojure-json-schema` fails the valid half, and it rejects every string in the file including the ones already published.

ajv-formats in `full` mode passes all 11 existing string tests in this file, so nothing here catches this today.

## RFC References

- [RFC 3986 §4.2](https://www.rfc-editor.org/rfc/rfc3986#section-4.2) - `relative-part`
- [RFC 3986 §3.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) - `segment-nz-nc`
- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) - `scheme`

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
