### PR TITLE
test(uri-reference): reject a leading zero in an embedded IPv4 address

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -140,6 +140,12 @@
                 "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
                 "data": "//a@b@example.com/",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -140,6 +140,12 @@
                 "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
                 "data": "//a@b@example.com/",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -137,6 +137,12 @@
                 "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
                 "data": "//a@b@example.com/",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -137,6 +137,12 @@
                 "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
                 "data": "//a@b@example.com/",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -140,6 +140,12 @@
                 "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
                 "data": "//a@b@example.com/",
                 "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
This is the one case I found that both gating validators get wrong.

Inside an IP-literal there is no `reg-name` fallback, so a dotted quad has to be an `IPv4address`, and [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) gives `dec-octet = DIGIT / %x31-39 DIGIT / "1" 2DIGIT / "2" %x30-34 DIGIT / "25" %x30-35` - five alternatives, none of which admits a leading zero. `192.168.0.01` is therefore not an `IPv4address`, `::ffff:192.168.0.01` is not an `IPv6address`, and the whole reference is invalid.

The file already has `http://087.10.0.1/` as valid, which is the other half of the same section: outside brackets a dotted quad that fails `IPv4address` falls through to `reg-name` and stays valid. This test pins the case where that fallback does not exist. The control is worth stating explicitly - `//192.168.0.01/` on its own **is** valid, so only the bracketed form discriminates.

## Changes

- `//[::ffff:192.168.0.01]/p` invalid

## Ecosystem Impact

- **python-jsonschema 4.25.1** accepts it. `rfc3987.py:171` defines `('dec_octet', r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)")`, and the third alternative `[01]?[0-9][0-9]?` matches `01`. FAILS.
- **ajv-formats 3.0.1** accepts it in both modes; its pattern uses `(?:25[0-5]|2[0-4]\d|[01]?\d\d?)`, the same shape. FAILS.
- 8 of the 12 asserting implementations in the Bowtie census accept it: `go-gojsonschema`, `java-networknt-json-schema-validator`, `js-json-schema`, `js-jsonschema`, `js-schemasafe`, `perl-json-schema-modern`, `php-justinrainbow-json-schema`, `python-fastjsonschema`.
- **@cfworker/json-schema**, **@exodus/schemasafe**, **djv**, **z-schema**, **json-schema-library**, **ata-validator** also accept it.
- **sourcemeta/core**, **jsonschema-rs**, **fluent-uri**, **iri-string** and **rust-boon** reject it. PASS.

Both regexes get the *range* right - `//[::ffff:1.2.3.256]` is correctly rejected - and only the leading zero leaks, so an out-of-range test does not catch this.

## RFC References

- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - `IP-literal`, `IPv6address`, `dec-octet`, and the reg-name fallback

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
