### PR TITLE
test(uri-reference): reject a non-numeric port and a repeated at-sign

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -128,6 +128,18 @@
                 "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
                 "data": "/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -128,6 +128,18 @@
                 "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
                 "data": "/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -125,6 +125,18 @@
                 "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
                 "data": "/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -125,6 +125,18 @@
                 "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
                 "data": "/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -128,6 +128,18 @@
                 "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
                 "data": "/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
[RFC 3986 §3.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2) gives `authority = [ userinfo "@" ] host [ ":" port ]`, and [§3.2.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.3) gives `port = *DIGIT`. `reg-name` admits no colon, so text after the colon can only be a port; and neither `userinfo` nor `host` admits a literal at-sign, so an authority can contain at most one.

Both cases matter for `uri-reference` specifically because a validator built around an optional `//` can backtrack out of the authority and re-read the remainder as a path.

## Changes

- `//example.com:abc/p` invalid - a non-numeric port
- `//a@b@example.com/` invalid - a second at-sign

## Ecosystem Impact

- **ajv-formats 3.0.1** accepts both in `full` mode. Its authority alternative starts `\/?\/`, so a single slash opens the authority branch with an empty host and the rest lands in the path. To be upfront about it: in ajv-formats this is the same one-character defect that also makes it accept `/[::1]` (the other PR I am opening), and patching `\/?\/` to `\/\/` repairs all three at once. I kept them as separate tests because **different implementations fail different subsets** - `go-gojsonschema` and `go-jsonschema` handle the port correctly and still accept `//a@b@example.com/`, while `perl-json-schema-modern` is the reverse. FAILS.
- **@cfworker/json-schema 4.1.1**, **@exodus/schemasafe 1.3.0**, **z-schema 12.4.1**, **json-schema-library 11.6.2**, **ata-validator 1.2.2** accept both. FAIL.
- Bowtie census: 6 asserting implementations accept `//example.com:abc/p` and 7 accept `//a@b@example.com/`. The split across the four authority/path-character cases:

| implementation | `//example.com:abc/p` | `//a@b@example.com/` | `/[::1]` | `/a"b` |
|---|---|---|---|---|
| go-gojsonschema, go-jsonschema | ok | accepts | accepts | accepts |
| java-networknt | accepts | accepts | ok | ok |
| perl-json-schema-modern | accepts | ok | ok | ok |
| js-schemasafe | accepts | accepts | accepts | ok |
| js-json-schema, php-justinrainbow, python-fastjsonschema | accepts | accepts | accepts | accepts |
- **python-jsonschema**, **sourcemeta/core**, **jsonschema-rs**, **fluent-uri**, **iri-string**, **rust-boon** and **djv** reject both. PASS.

## RFC References

- [RFC 3986 §3.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2) - `authority`
- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.3) - `port = *DIGIT`

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
