### PR TITLE
test(uri-reference): reject characters no path production admits

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -116,6 +116,18 @@
                 "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
                 "data": "/%zz",
                 "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -116,6 +116,18 @@
                 "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
                 "data": "/%zz",
                 "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -113,6 +113,18 @@
                 "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
                 "data": "/%zz",
                 "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -113,6 +113,18 @@
                 "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
                 "data": "/%zz",
                 "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -116,6 +116,18 @@
                 "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
                 "data": "/%zz",
                 "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
The file tests the backslash twice but no other excluded character, and two of them are handled differently by real implementations.

`pchar = unreserved / pct-encoded / sub-delims / ":" / "@"` ([Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A)). The double quote is in none of those sets. Square brackets are `gen-delims`, reserved by [§3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) for an IP-literal inside an authority, and `path-absolute` is built from `pchar`, so they cannot appear in a path either.

## Changes

- `/a"b` invalid - a double quote in a path
- `/[::1]` invalid - square brackets outside an authority

## Ecosystem Impact

- **ajv-formats 3.0.1** accepts both in `full` mode. Eight character classes in its `uri-reference` pattern contain a literal `"` after the apostrophe; the `uri` pattern in the same file uses the same classes without it, which is why `format: uri` rejects `http://a"b/` while `format: uri-reference` accepts it. The bracket case has a different cause: the authority alternative begins `\/?\/`, so a single leading slash introduces an authority and `/[::1]` parses as authority `[::1]`. I isolated the two by patching them separately - deleting the stray quotes repairs `/a"b` and not `/[::1]`, and tightening `\/?\/` does the reverse. FAILS both.
- **@cfworker/json-schema 4.1.1** reproduces both, byte for byte - it ships the same pattern.
- **@exodus/schemasafe 1.3.0** rejects the double quote but accepts `/[::1]`.
- Bowtie census: 5 asserting implementations accept `/a"b` and 6 accept `/[::1]`.
- **python-jsonschema**, **sourcemeta/core**, **jsonschema-rs**, **fluent-uri**, **iri-string**, **rust-boon**, **djv** and **jsonschema 1.5.0** reject both. PASS.

`/[a]` is correctly rejected by ajv-formats, so the bracket case only leaks when the interior is a well-formed IPv6 address - which is why a generic "brackets in a path" test with arbitrary contents would not catch it.

## RFC References

- [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A) - `pchar`, `path-absolute`
- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - `IP-literal`

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
