### PR TITLE
test(uri-reference): reject a trailing newline and accept an uppercase IPvFuture version

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -158,6 +158,18 @@
                 "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
                 "data": "./this:that",
                 "valid": true
+            },
+            {
+                "description": "a trailing line feed",
+                "comment": "RFC 3986, Appendix A: no production admits %x0A.",
+                "data": "/p\n",
+                "valid": false
+            },
+            {
+                "description": "an uppercase version character in an IPvFuture literal",
+                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -158,6 +158,18 @@
                 "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
                 "data": "./this:that",
                 "valid": true
+            },
+            {
+                "description": "a trailing line feed",
+                "comment": "RFC 3986, Appendix A: no production admits %x0A.",
+                "data": "/p\n",
+                "valid": false
+            },
+            {
+                "description": "an uppercase version character in an IPvFuture literal",
+                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -155,6 +155,18 @@
                 "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
                 "data": "./this:that",
                 "valid": true
+            },
+            {
+                "description": "a trailing line feed",
+                "comment": "RFC 3986, Appendix A: no production admits %x0A.",
+                "data": "/p\n",
+                "valid": false
+            },
+            {
+                "description": "an uppercase version character in an IPvFuture literal",
+                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -155,6 +155,18 @@
                 "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
                 "data": "./this:that",
                 "valid": true
+            },
+            {
+                "description": "a trailing line feed",
+                "comment": "RFC 3986, Appendix A: no production admits %x0A.",
+                "data": "/p\n",
+                "valid": false
+            },
+            {
+                "description": "an uppercase version character in an IPvFuture literal",
+                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -158,6 +158,18 @@
                 "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
                 "data": "./this:that",
                 "valid": true
+            },
+            {
+                "description": "a trailing line feed",
+                "comment": "RFC 3986, Appendix A: no production admits %x0A.",
+                "data": "/p\n",
+                "valid": false
+            },
+            {
+                "description": "an uppercase version character in an IPvFuture literal",
+                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Two cases that both come from the same library, which is what python-jsonschema uses for this format.

No production in [Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A) admits `%x0A`, so a trailing line feed is invalid. And [§3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) gives `IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )`, where [RFC 5234 §2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) makes ABNF string literals case-insensitive - so an uppercase `V` is valid. §3.2.2 also says the host is case-insensitive.

## Changes

- `/p\n` invalid - a trailing line feed (one representative of a class: `"\n"`, `"?q\n"`, `"#f\n"` and `"a:b\n"` all leak the same way)
- `//[V1.fe]/p` valid - an uppercase version character

## Ecosystem Impact

- **python-jsonschema 4.25.1** gets both wrong. It calls `rfc3987.parse(instance, rule="URI_reference")`, and `rfc3987.py:424` builds `'^%(URI_reference)s$'` - in Python a `$` also matches immediately before a single trailing newline, so `/p\n` is accepted - and so is every other reference with exactly one trailing LF, including the bare `"\n"`. Two line feeds, a `\r`, a `\t`, a `\v` and a `\f` are all correctly rejected, so the leak is precisely the one-trailing-LF case. Separately, `rfc3987.py:172` hardcodes a lowercase `v` in `('IPvFuture', r"v{hexdig}+\.(?:{unreserved}|{sub_delims}|:)+")`, so `//[V1.fe]/p` is rejected. FAILS both.
- **ajv-formats 3.0.1** gets both right in `full` mode. PASSES.
- Bowtie census: `php-opis-json-schema` also accepts the trailing newline; `clojure-json-schema`, `go-jsonschema`, `java-networknt-json-schema-validator` and `php-opis-json-schema` reject the valid IPvFuture.
- **sourcemeta/core**, **jsonschema-rs**, **fluent-uri**, **iri-string** and **rust-boon** get both right. PASS.

Note for review: these are the same two rfc3987 defects already visible on `uri`, `iri` and `iri-reference`. They are here because `uri-reference.json` has no test for either.

One thing worth flagging, because it changes how much an upstream fix would buy: python-jsonschema has **two** backends for this format. `_format.py` does `try: import rfc3987 / except ImportError: from rfc3986_validator import validate_rfc3986`, and the package declares `rfc3987` on the `format` extra against `rfc3986-validator` on `format-nongpl`. I ran the second one over the same corpus - it is a separate implementation by a different author, and it reproduces both defects independently: `re.compile(r"^{uri_re}$", re.VERBOSE)` for the anchor and `v[0-9A-Fa-f]+\.` for the lowercase `v`. So fixing rfc3987 alone would still leave the non-GPL install path failing these two tests.

## RFC References

- [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A)
- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - `IPvFuture`, host case-insensitivity
- [RFC 5234 §2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) - ABNF literals are case-insensitive

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
