### PR TITLE
test(uri-reference): cover the empty reference, query-only and empty authority

### DIFF
--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -92,6 +92,30 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -92,6 +92,30 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -89,6 +89,30 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -89,6 +89,30 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -92,6 +92,30 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
The file covers three of the four `relative-part` alternatives from [§4.2](https://www.rfc-editor.org/rfc/rfc3986#section-4.2) and skips the fourth entirely.

`relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty`. There is a test for a network-path reference, one for an absolute-path reference and one for a relative-path reference, but nothing for `path-empty`, which is zero characters. There is also a fragment-only test but no query-only test, and no test where the authority is empty.

## Changes

- `""` valid - `path-empty`, the missing fourth alternative
- `?query=1` valid - a query with an empty path
- `//` valid - a network-path reference whose `reg-name` is empty
- `/%zz` invalid - `pct-encoded = "%" HEXDIG HEXDIG` ([§2.1](https://www.rfc-editor.org/rfc/rfc3986#section-2.1))

## Ecosystem Impact

- `//` is rejected by **php-justinrainbow-json-schema** in the Bowtie census.
- `/%zz` is accepted by **ajv-formats 3.0.1** in `fast` mode, by **z-schema 12.4.1** and **ata-validator 1.2.2**, and by 3 asserting Bowtie implementations (`perl-json-schema-modern`, `php-justinrainbow-json-schema`, `python-fastjsonschema`).
- `""` and `?query=1` break nothing in the current matrix. They are here because a validator that requires at least one character, or that special-cases `#` without special-casing `?`, would pass every other test in this file. `clojure-json-schema` rejects both, but it rejects every string including the published ones.

## RFC References

- [RFC 3986 §4.2](https://www.rfc-editor.org/rfc/rfc3986#section-4.2) - `relative-part`
- [RFC 3986 §3.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) - `path-empty`
- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) - `reg-name` may be empty
- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986#section-2.1) - `pct-encoded`

Reproduction commands and the uri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/uri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
