### PR TITLE
test(ipv6): assert a leading elision before an embedded IPv4 is valid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -255,6 +255,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -255,6 +255,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -252,6 +252,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -252,6 +252,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -252,6 +252,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -255,6 +255,11 @@
                 "description": "'::' followed by six groups is valid",
                 "data": "::1:2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "leading '::' before five groups and an embedded IPv4 is valid",
+                "data": "::1:2:3:4:5:1.2.3.4",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
[RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) gives `IPv6address` nine alternatives. The second one is

```
/                       "::" 5( h16 ":" ) ls32
```

with `ls32 = ( h16 ":" h16 ) / IPv4address`. `::1:2:3:4:5:1.2.3.4` matches it exactly: `::`, then the five `h16 ":"` groups `1:` `2:` `3:` `4:` `5:`, then the `IPv4address` `1.2.3.4`. [RFC 4291 Section 2.2](https://www.rfc-editor.org/rfc/rfc4291#section-2.2) gets there too, through form 3 (`x:x:x:x:x:x:d.d.d.d`) plus form 2, which says the `::` "can also be used to compress leading or trailing zeros in an address" - the uncompressed spelling is `0:1:2:3:4:5:1.2.3.4`.

That alternative has no valid test in the current file. The three mixed-form valid cases it does have - `1::d6:192.168.0.1`, `1:2::192.168.0.1`, `::ffff:192.168.0.1` - all carry six colons or fewer, and this one carries seven, which is where two implementations break.

json_schemer delegates `ipv6` to Ruby's `IPAddr` ([format.rb](https://github.com/davishmcclurg/json_schemer/blob/main/lib/json_schemer/format.rb)):

```ruby
def valid_ip?(data, family)
  IPAddr.new(data, family)
  IP_REGEX.match?(data)
rescue IPAddr::Error
  false
end
```

and `IPAddr#in6_addr` caps the colon count at six in the branch that handles a compressed address with an embedded IPv4 ([ipaddr.rb](https://github.com/ruby/ipaddr/blob/master/lib/ipaddr.rb)):

```ruby
when RE_IPV6ADDRLIKE_COMPRESSED
  if $4
    left.count(':') <= 6 or raise InvalidAddressError, "invalid address: #{left}"
  else
    left.count(':') <= ($1.empty? || $2.empty? ? 8 : 7) or
```

The branch immediately below raises the cap to 8 when the `::` sits at an edge. The embedded-IPv4 branch never got that adjustment, so a leading `::` before five groups and a dotted quad trips a flat six. `IPAddr.new("::1:2:3:4:5:1.2.3.4")` raises while `IPAddr.new("0:1:2:3:4:5:1.2.3.4")` returns the address - the same address, one spelling accepted and one not. I checked `ipaddr` 1.2.9 from master directly rather than only the copy shipped with my Ruby, and the `<= 6` line is unchanged there, so this is not version skew. json_schemer 2.5.0, the current release, has a byte-identical `valid_ip?`.

## Changes

One test, added to the six files where `format: ipv6` exists:

- `::1:2:3:4:5:1.2.3.4` - valid

## Ecosystem Impact

Both implementations below pass all 40 tests in the current file, so nothing in it catches this.

- **json_schemer 2.2.1** (Ruby): FAILS - rejects. Root cause above.
- **@exodus/schemasafe 1.3.0** (JavaScript): FAILS - rejects, for a different reason. Its scanner ends with `const spaces = s1 > 0 ? 6 : 7` and then `return (start || hex > 0) && s0 < spaces` (`src/formats.js`); `spaces` is the colon count of an uncompressed address and the compressed branch reuses it, but an elision adds a colon.
- **ajv-formats 3.0.1** (full and fast): PASSES - accepts.
- **python-jsonschema 4.25.1** (`ipaddress.IPv6Address`): PASSES - accepts, and expands both spellings to `0000:0001:0002:0003:0004:0005:0102:0304`.
- **fastjsonschema 2.21.2**, **jsonschema-rs 0.34.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**, **sourcemeta/core**: PASSES - all accept.

Outside JSON Schema, C `inet_pton`, Go `net.ParseIP` and `net/netip.ParseAddr`, Rust `std::net::Ipv6Addr` and PHP `filter_var` all accept it as well.

## RFC References

- RFC 3986 Section 3.2.2 - the `IPv6address` / `ls32` / `h16` ABNF.
- RFC 4291 Section 2.2 - forms 2 and 3 of the textual representation.
