### PR TITLE
test(ipv6): assert a compressed address at the maximum colon count is valid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -250,6 +250,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -250,6 +250,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -247,6 +247,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -247,6 +247,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -247,6 +247,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -250,6 +250,11 @@
                 "description": "one group before '::' and five groups after is valid",
                 "data": "1::2:3:4:5:6",
                 "valid": true
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "'::' followed by six groups is valid",
+                "data": "::1:2:3:4:5:6",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The third `IPv6address` alternative in [RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) is

```
/ [               h16 ] "::" 4( h16 ":" ) ls32
```

With the optional prefix absent and `ls32 = h16 ":" h16`, that is `::1:2:3:4:5:6`. The alternative has no valid test in the current file.

**@exodus/schemasafe 1.3.0** rejects it, while passing all 40 tests the file has today. Its `ipv6` checker is a hand-written character scan rather than a regex, and it ends with (`src/formats.js`):

```js
const spaces = s1 > 0 ? 6 : 7
if (!short) return s0 === spaces && start && hex > 0
return (start || hex > 0) && s0 < spaces
```

`s0` is the colon count, `s1` the dot count, and `short` is true when a `::` was seen. `spaces` is the colon count of an **uncompressed** address: seven for eight groups, six for six groups plus a dotted quad. The compressed branch on the last line reuses that same number, but an elision adds a colon to the string. The real maxima are 8 and 7, so every compressed address sitting at the top of its colon range is rejected:

| input | colons | schemasafe |
|---|---|---|
| `::1:2:3:4:5:6` | 7 | rejects |
| `1:2:3:4:5:6:7::` | 8 | rejects |
| `1::2:3:4:5:6:7` | 7 | rejects |
| `1:2:3:4:5::1.2.3.4` | 6 | rejects |
| `1:2:3:4:5::` | 6 | accepts |
| `::ffff:192.168.0.1` | 3 | accepts |

The file's nine compressed valid cases - `::1`, `::abef`, `::`, `::42:ff:1`, `d6::`, `1:d6::42`, `1::d6:192.168.0.1`, `1:2::192.168.0.1`, `::ffff:192.168.0.1` - all sit at six colons or fewer, which is why none of them reaches this.

I picked the seven-colon pure-hex form as the representative because it also fills the missing third alternative. `1:2:3:4:5:6:7::` fails the same way but is a shape the file already covers through `d6::`.

## Changes

One test, added to the six files where `format: ipv6` exists:

- `::1:2:3:4:5:6` - valid

## Ecosystem Impact

- **@exodus/schemasafe 1.3.0** (JavaScript): FAILS - rejects. 1.3.0 is the current release; there is no newer one to upgrade to.
- **ajv-formats 3.0.1** (full and fast): PASSES - accepts.
- **python-jsonschema 4.25.1**: PASSES - accepts.
- **json_schemer 2.2.1**, **fastjsonschema 2.21.2**, **jsonschema-rs 0.34.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**, **sourcemeta/core**: PASSES - all accept.

## RFC References

- RFC 3986 Section 3.2.2 - the `IPv6address` ABNF, third alternative.
- RFC 4291 Section 2.2 - form 2, the `::` elision.
