### PR TITLE
test(ipv6): assert one group before the elision is valid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -245,6 +245,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -245,6 +245,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -242,6 +242,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -242,6 +242,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -242,6 +242,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -245,6 +245,11 @@
                 "description": "an out-of-range first octet in the embedded IPv4 is invalid",
                 "data": "::ffff:256.1.1.1",
                 "valid": false
+            },
+            {
+                "description": "one group before '::' and five groups after is valid",
+                "data": "1::2:3:4:5:6",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The fourth `IPv6address` alternative in [RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) is

```
/ [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
```

`*1( h16 ":" ) h16` is one **or two** `h16` - `*1` is zero-or-one repetitions of `h16 ":"`, followed by a mandatory `h16`. So both `1::2:3:4:5:6` and `1:2::3:4:5:6` are instances of this alternative, and it has no valid test in the current file.

**fastjsonschema 2.21.2** rejects the one-group form while accepting the two-group form. Its `ipv6` pattern (`fastjsonschema/draft04.py`, inherited unchanged by the draft06 and draft07 generators) encodes that alternative as

```
(?:[0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4})?::(?:[0-9A-Fa-f]{1,4}:){3}
```

which is exactly-two-or-zero, not one-or-two. Every other alternative in the same pattern is written with the `{,N}` form - `(?:(?:[0-9A-Fa-f]{1,4}:){,2}[0-9A-Fa-f]{1,4})?::`, `{,3}`, `{,4}`, `{,5}`, `{,6}` - so this one fragment is the odd one out.

The consequence, run live:

| input | groups before `::` | fastjsonschema |
|---|---|---|
| `::2:3:4:5:6` | 0 | accepts |
| `1::2:3:4:5:6` | 1 | rejects |
| `1:2::3:4:5:6` | 2 | accepts |
| `1::2:3:4:1.2.3.4` | 1 | rejects |

The zero-group and two-group spellings are what the existing file happens to reach, which is why the gap is invisible today.

## Changes

One test, added to the six files where `format: ipv6` exists:

- `1::2:3:4:5:6` - valid

## Ecosystem Impact

fastjsonschema passes all 40 tests in the current file, so nothing in it catches this.

- **fastjsonschema 2.21.2** (Python): FAILS - rejects. 2.21.2 is the current release.
- **ajv-formats 3.0.1** (full and fast): PASSES - accepts.
- **python-jsonschema 4.25.1**: PASSES - accepts.
- **json_schemer 2.2.1**, **@exodus/schemasafe 1.3.0**, **jsonschema-rs 0.34.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**, **sourcemeta/core**: PASSES - all accept.

## RFC References

- RFC 3986 Section 3.2.2 - the `IPv6address` ABNF, fourth alternative.
- RFC 5234 Section 3.6 - `<a>*<b>element`, which is what makes `*1( h16 ":" )` zero-or-one.
