### PR TITLE
test(ipv6): assert an out-of-range first embedded IPv4 octet is invalid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -240,6 +240,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -240,6 +240,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -237,6 +237,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -237,6 +237,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -237,6 +237,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -240,6 +240,11 @@
                 "description": "trailing newline is invalid",
                 "data": "::1\n",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,11 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "an out-of-range first octet in the embedded IPv4 is invalid",
+                "data": "::ffff:256.1.1.1",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
[RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) defines all four octets of an embedded IPv4 with the same production:

```
IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet

dec-octet   = DIGIT                 ; 0-9
            / %x31-39 DIGIT         ; 10-99
            / "1" 2DIGIT            ; 100-199
            / "2" %x30-34 DIGIT     ; 200-249
            / "25" %x30-35          ; 250-255
```

so 256 is out of range wherever it appears. The file already has an out-of-range case, `1::2:192.168.256.1`, but the 256 is in the **third** octet. Position turns out to matter.

**@exodus/schemasafe 1.3.0** accepts `::ffff:256.1.1.1` while correctly rejecting `1::2:192.168.256.1`, and it passes all 40 tests in the current file. Its `ipv6` checker scans the string itself and then hands the dotted tail to one regex (`src/formats.js`):

```js
if (s1 > 0 && !/(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/.test(input)) return false
```

Every alternative in that pattern sits behind a literal `.`, and the group repeats three times, so the regex only constrains the last three octets. The first one is bounded by nothing except the scanner's four-hex-digit cap:

| input | schemasafe |
|---|---|
| `::ffff:256.1.1.1` | accepts |
| `::ffff:999.1.1.1` | accepts |
| `::ffff:9999.1.1.1` | accepts |
| `::ffff:01.1.1.1` | accepts |
| `::ffff:1.256.1.1` | rejects |
| `::ffff:1.1.1.256` | rejects |
| `::ffff:1.1.1.01` | rejects |

This is the general shape of a regex written as `(?:<sep><item>){n}$` to validate an `n+1`-element list: the first element never gets checked.

## Changes

One test, added to the six files where `format: ipv6` exists:

- `::ffff:256.1.1.1` - invalid

## Ecosystem Impact

- **@exodus/schemasafe 1.3.0** (JavaScript): FAILS - accepts. 1.3.0 is the current release.
- **ajv-formats 3.0.1** (full and fast): PASSES - rejects.
- **python-jsonschema 4.25.1**: PASSES - rejects.
- **json_schemer 2.2.1**, **fastjsonschema 2.21.2**, **jsonschema-rs 0.34.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**, **sourcemeta/core**: PASSES - all reject.

## RFC References

- RFC 3986 Section 3.2.2 - the `IPv4address` and `dec-octet` ABNF.
- RFC 4291 Section 2.2 - form 3, the `x:x:x:x:x:x:d.d.d.d` representation.
