### PR TITLE
test(ipv6): cover non-canonical valid forms and two invalid neighbours

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -215,6 +215,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -215,6 +215,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -212,6 +212,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -212,6 +212,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -212,6 +212,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -215,6 +215,31 @@
                 "description": "a leading zero in the last IPv4 octet is invalid",
                 "data": "::ffff:192.168.0.01",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,31 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "uppercase hex digits are valid",
+                "data": "2001:DB8::1",
+                "valid": true
+            },
+            {
+                "description": "leading zeros in every group are valid",
+                "data": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                "valid": true
+            },
+            {
+                "description": "two groups before '::' and four groups after is valid",
+                "data": "1:2::3:4:5:6",
+                "valid": true
+            },
+            {
+                "description": "eight groups alongside '::' is invalid",
+                "data": "1:2:3:4:5:6:7:8::",
+                "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "::1\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
This one breaks nothing, so I checked each case against wrong implementations rather than against the ecosystem.

The current file has 34 string cases, 11 of them valid, and none of the 11 uses an uppercase hex digit or a leading zero - even though [RFC 4291 Section 2.2](https://www.rfc-editor.org/rfc/rfc4291#section-2.2)'s own examples are uppercase and `h16 = 1*4HEXDIG` admits all four widths. To decide which gaps were worth filling I wrote down 31 ways an implementation can get `format: ipv6` wrong - each one either a behaviour I saw live in a real validator, an [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952) recommendation wrongly enforced on input, or a classic off-by-one - and ran the current 34 cases against every one. **17 are caught by the file; 14 pass it.** Six of the 14 are covered by four separate breaker PRs. These five cases fail the remaining eight, and I dropped everything that did not.

## Changes

Five cases, added to the six files where `format: ipv6` exists.

**`2001:DB8::1` is valid.** [RFC 5234 Section 2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) makes ABNF quoted strings case-insensitive, so `HEXDIG` covers `a-f` and `A-F` alike. Every valid case in the file today is lowercase, so a regex written without the `i` flag passes all of them and fails this one. It also catches an implementation enforcing RFC 5952 Section 4.3's lowercase recommendation on input, which Section 4 explicitly scopes to generation: "all implementations MUST accept and be able to handle any legitimate [RFC4291] format."

**`2001:0db8:0000:0000:0000:0000:0000:0001` is valid.** Same clause, applied to RFC 5952 Section 4.1's leading-zero suppression. No valid case in the file has a leading zero anywhere, so an implementation that writes each group as `0|[1-9a-fA-F][0-9a-fA-F]*` passes the whole file. **djv 2.1.4** fails this one live.

**`1:2::3:4:5:6` is valid.** This is the fifth `IPv6address` alternative, `[ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32`, with two groups in the optional prefix. It has no valid case in the file, so an implementation missing that one branch passes everything.

**`1:2:3:4:5:6:7:8::` is invalid.** RFC 4291 Section 2.2 form 2: "The use of `::` indicates **one or more** groups of 16 bits of zeros." Eight groups are already written, so the elision has nothing to stand for. The file's existing over-length cases are `1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1` (sixteen groups) and `1:2:3:4:5:::8` (a triple colon); neither is eight well-formed groups plus a well-formed `::`, so an off-by-one on that rule survives today. **ata-validator 1.2.2** accepts it.

**`::1\n` is invalid.** A regex anchored with `$` under Python semantics also matches before a single trailing line feed. The file's `::1  ` case does not catch it, because that implementation rejects spaces and accepts only the `\n`. `ipv4.json` already carries the matching case ("trailing newline is invalid"), so this closes the pair. **tdegrunt jsonschema 1.5.0** and **ata-validator 1.2.2** accept it.

I left out three cases I had prepared because a wrong implementation that fails them already fails an existing case: `fe80::1%25eth0` is covered by the file's `fe80::a%eth1`, `2001:db8::00001` by `12345::` and `::abcef`, and `1:2:3:4:5:6:7:٤` by the Bengali-digit case.

## Ecosystem Impact

Scored against 15 format-asserting implementations. Nothing regresses.

- **ajv-formats 3.0.1** (full and fast), **python-jsonschema 4.25.1**, **sourcemeta/core**, **json_schemer 2.2.1**, **fastjsonschema 2.21.2**, **jsonschema-rs 0.34.0**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**: PASSES - all five correct.
- **djv 2.1.4**: FAILS the leading-zeros case. It already fails 12 of the 40 published cases, so this is not new breakage.
- **tdegrunt jsonschema 1.5.0**: FAILS the trailing-newline case. It already fails 3 of the 40.
- **ata-validator 1.2.2**: FAILS the trailing-newline and eight-groups cases. It already fails 23 of the 40.

## RFC References

- RFC 4291 Section 2.2 - forms 1 to 3, and "one or more groups of 16 bits of zeros".
- RFC 3986 Section 3.2.2 - the `IPv6address` ABNF, fifth alternative, and `h16 = 1*4HEXDIG`.
- RFC 5234 Section 2.3 - ABNF strings are case insensitive.
- RFC 5952 Sections 4, 4.1 and 4.3 - the canonical-form recommendations, and the clause scoping them to generation.
