### PR TITLE
test(ipv6): assert bracketed and last-octet-leading-zero forms are invalid

### DIFF
--- a/tests/draft2019-09/optional/format/ipv6.json
+++ b/tests/draft2019-09/optional/format/ipv6.json
@@ -205,6 +205,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/ipv6.json
+++ b/tests/draft2020-12/optional/format/ipv6.json
@@ -205,6 +205,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/ipv6.json
+++ b/tests/draft4/optional/format/ipv6.json
@@ -202,6 +202,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/ipv6.json
+++ b/tests/draft6/optional/format/ipv6.json
@@ -202,6 +202,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/ipv6.json
+++ b/tests/draft7/optional/format/ipv6.json
@@ -202,6 +202,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/ipv6.json
+++ b/tests/v1/format/ipv6.json
@@ -205,6 +205,16 @@
                 "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
                 "data": "1:2::192.16৪.0.1",
                 "valid": false
+            },
+            {
+                "description": "a bracketed address is invalid",
+                "data": "[::1]",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the last IPv4 octet is invalid",
+                "data": "::ffff:192.168.0.01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Two invalid forms that **json-everything / JsonSchema.Net 7.3.4** accepts, both verified live.

**`[::1]` is invalid.** [RFC 4291 Section 2.2](https://www.rfc-editor.org/rfc/rfc4291#section-2.2) defines no bracketed form. The brackets come from [RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), where they are URI host delimiters around the address, not part of it:

```
IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
```

so the `IPv6address` production is what sits inside the brackets, never with them. This is a realistic input because people paste IPv6 addresses out of URLs.

**`::ffff:192.168.0.01` is invalid.** `dec-octet` admits no leading zero in a multi-digit octet, in any position. JsonSchema.Net accepts a leading zero in the **fourth** octet only and correctly rejects it in the first three - I ran the whole embedded-IPv4 space through it and all 68 accepted leading-zero cases sit at position four.

Both go through `System.Net.IPAddress.TryParse`, which strips the brackets and is lenient about the last octet.

## Changes

Two tests, added to the six files where `format: ipv6` exists:

- `[::1]` - invalid
- `::ffff:192.168.0.01` - invalid

## Why the existing file does not already catch these

JsonSchema.Net does fail two cases in the file today - `fe80::/64` and `fe80::a%eth1` - so it is not a clean-passing implementation. But those two are a prefix length and a zone identifier, which are different code paths: I scored 16,928 inputs through it and its disagreements fall into exactly four classes, zone identifier (121), prefix length (97), bracketed (59) and last-octet leading zero (68). Fixing what the file already flags leaves the last two classes untouched, and the suite would then call the implementation correct.

The same holds against wrong implementations rather than real ones. Of 31 plausible ways to get `format: ipv6` wrong, 14 pass the current 34 string cases; a bracket-stripping parser and a parser lenient about a leading zero in any embedded octet are two of the 14, and these are the two cases that fail them.

## Ecosystem Impact

- **json-everything / JsonSchema.Net 7.3.4** (.NET): FAILS both - accepts. Run live on `mcr.microsoft.com/dotnet/sdk:9.0` with `RequireFormatValidation = true`.
- **ajv-formats 3.0.1** (full and fast), **python-jsonschema 4.25.1**, **sourcemeta/core**, **json_schemer 2.2.1**, **fastjsonschema 2.21.2**, **jsonschema-rs 0.34.0**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **santhosh-tekuri/jsonschema v6.0.2**, **xeipuuv/gojsonschema 1.2.0**, **networknt/json-schema-validator 1.5.6**, **opis/json-schema**, **justinrainbow/json-schema**, **boon 0.6.1**: PASSES - all reject both.
- **ata-validator 1.2.2**: FAILS both, but it already fails 23 of the 40 published cases.

Outside JSON Schema, Ruby `IPAddr` accepts `[::1]`, and C `inet_pton`, `ipaddr.js` and the `ip` npm package accept the last-octet leading zero.

## RFC References

- RFC 4291 Section 2.2 - the three textual forms, none of them bracketed.
- RFC 3986 Section 3.2.2 - `IP-literal` (where the brackets belong) and `dec-octet`.
