### PR TITLE
Add maxLength specification links

### DIFF
--- a/tests/draft2020-12/maxLength.json
+++ b/tests/draft2020-12/maxLength.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "maxLength validation",
+        "specification": [
+            {
+                "validation": "6.3.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxLength": 2
@@ -35,6 +40,11 @@
     },
     {
         "description": "maxLength validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.3.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxLength": 2.0


### PR DESCRIPTION
Part of #699.

Adds the draft 2020-12 Validation section 6.3.1 reference to both test cases in `maxLength.json`, matching the annotation format already used by neighboring validation keyword files.

## Testing

- `python3 -X utf8 bin/jsonschema_suite check` (434 test files, 2,287 cases, 11,098 tests)
- `python3 -m json.tool tests/draft2020-12/maxLength.json`
- `bin/annotate-specification-links` resolves both annotations to the draft 2020-12 Validation section 6.3.1 URL
