### PR TITLE
test(idn-hostname): add UTS 46 mapping-step cases

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -368,6 +368,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -368,6 +368,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -360,6 +360,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -330,6 +330,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -368,6 +368,24 @@
                 "valid": false
             },
             {
+                "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+                "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+                "data": "cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a label of 63 fullwidth characters is valid after mapping",
+                "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+                "data": "\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41\uff41",
+                "valid": true
+            },
+            {
+                "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+                "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+                "data": "\uff58\uff4e--nxasmq6b",
+                "valid": true
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",


### PR DESCRIPTION
Following on from #927 and #928, I went through the rest of the UTS #46 mapping step and found that none of its branches is exercised by the existing tests.

The [format registry](https://github.com/json-schema-org/json-schema-spec/blob/main/specs/registries/format.json) defines `idn-hostname` as "An internationalized host name as defined by IDNA2008 using the UTS #46 mapping". [UTS #46 section 4](https://www.unicode.org/reports/tr46/#Processing) makes that a four-step process - map, normalise to NFC, split into labels, then validate each label. I enumerated every one of the 1,114,112 codepoints in `IdnaMappingTable.txt` and the step changes the verdict on 4,872 of them, in exactly three branches: 4,586 `mapped`, 270 `ignored`, and 16 that only change because of the NFC normalisation. #927 covers `mapped` and #928 covers `ignored`. Nothing covers normalisation, and nothing covers the order the steps run in.

## Changes

Three tests, added to draft7, draft2019-09, draft2020-12 and v1:

- `café.com` - a decomposed U-label. Step 2 normalises to NFC before validating, so this is the normalisation branch on its own, with no table lookup involved.
- 63 x `ａ` - a label that is 189 octets before mapping and 63 after. The length limit has to be applied to the mapped form, which is a different thing from having the mapping table at all.
- `ｘｎ--nxasmq6b` - the fullwidth letters map to `xn`, so the ACE prefix only exists after step 1. The `xn--` test has to run after mapping rather than on the input.

The last two are order-of-operations rather than table lookups: an implementation can ship the whole mapping table and still get them wrong by checking length or the ACE prefix first.

## Ecosystem Impact

All three are rejected by **python-jsonschema 4.25.1**, whose `is_idn_host_name` is `idna.encode(instance)` with no mapping step. **ajv-formats 3.0.1** has no `idn-hostname` at all, so it does not assert either.

They are accepted by `sourcemeta/core`'s `is_idn_hostname_uts46`, by **tr46 6.0.0** with `checkHyphens`, `checkBidi` and `checkJoiners` enabled, and by **PHP 8.1 intl**.

I checked each one against a wrong implementation to make sure it earns its place. A validator that applies the mapping table but skips NFC passes the other two and fails the first. One that measures length before mapping passes the first and third and fails the second. One that looks for `xn--` on the input passes the first two and fails the third.

## RFC References

- [UTS #46 section 4](https://www.unicode.org/reports/tr46/#Processing), the four processing steps and their order
- [UTS #46 section 4.1](https://www.unicode.org/reports/tr46/#Validity_Criteria), the validity criteria applied to each label
- [RFC 5890 section 2.3.2.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1), A-labels and U-labels
- [RFC 1035 section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4), the 63-octet label limit

Related: #965
