### PR TITLE
test(idn-hostname): cover A-label case, the digit-block rule scope, and the Bidi first character

### DIFF
--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/tests/draft2019-09/optional/format/idn-hostname.json
@@ -350,6 +350,24 @@
                 "valid": true
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/tests/draft2020-12/optional/format/idn-hostname.json
@@ -350,6 +350,24 @@
                 "valid": true
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -342,6 +342,24 @@
                 "valid": true
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/draft7/optional/format/idn-hostname.json
+++ b/tests/draft7/optional/format/idn-hostname.json
@@ -330,6 +330,24 @@
                 "valid": false
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -338,6 +338,24 @@
                 "valid": false
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",

--- a/tests/v1/format/idn-hostname.json
+++ b/tests/v1/format/idn-hostname.json
@@ -350,6 +350,24 @@
                 "valid": true
             },
             {
+                "description": "an A-label with an uppercase Punycode body is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.3 lowercases the A-label before the round-trip test, and RFC 3492 section 5 gives A-Z and a-z the same digit-values",
+                "data": "xn--NXASMQ6B",
+                "valid": true
+            },
+            {
+                "description": "the two Arabic-Indic digit blocks may appear in different labels",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8 scopes the rule to \"this label\", so one block per label is valid",
+                "data": "\u0628\u0660.\u0628\u06f0",
+                "valid": true
+            },
+            {
+                "description": "a label of only Arabic-Indic digits is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 condition 1 allows only L, R or AL as the first character, and an Arabic-Indic digit is AN",
+                "data": "\u0660\u0661",
+                "valid": false
+            },
+            {
                 "description": "zero width non-joiner must pass at every occurrence",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
                 "data": "\u0915\u094d\u200c\u0937x\u200cy",


### PR DESCRIPTION
While going through the UTS #46 mapping step for #927 and #928, I mapped the existing `idn-hostname` tests against the full rule set and found three rules with no test behind them. None of these breaks the gating validator - they are the second-tier "good test" kind rather than breakers.

## Changes

Three tests, added to draft7, draft2019-09, draft2020-12 and v1:

**`xn--NXASMQ6B` is valid.** The suite has one uppercase A-label test, `XN--aa---o47jg78q`, and it only exercises the ACE prefix. Nothing exercises the case of the Punycode body. [RFC 5891 section 5.3](https://www.rfc-editor.org/rfc/rfc5891#section-5.3) says the lookup application converts the A-label to a U-label "first ensuring that the A-label is entirely in lowercase (converting it to lowercase if necessary)", and only then applies the round-trip test. [RFC 5891 section 3.1](https://www.rfc-editor.org/rfc/rfc5891#section-3.1) says "A pair of A-labels MUST be compared as case-insensitive ASCII", and [RFC 3492 section 5](https://www.rfc-editor.org/rfc/rfc3492#section-5) gives `41..5A (A-Z)` and `61..7A (a-z)` the same digit-values. So both spellings decode to the same U-label and both are valid.

Worth noting that Unicode's own conformance file cannot cover this - uppercase ASCII inside Punycode is recorded as an untested gap in `IdnaTestV2`, so this is not a case the corpus would catch for us.

**`ب٠.ب۰` is valid.** [RFC 5892 appendix A.8](https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8) scopes the Arabic-Indic digit rule to "this label", so the two digit blocks may appear in the same name as long as they are in different labels. The existing test only covers the two blocks inside one label, which is the invalid direction.

**`٠١` is invalid.** [RFC 5893 section 2](https://www.rfc-editor.org/rfc/rfc5893#section-2) condition 1 allows only L, R or AL as a label's first character, and an Arabic-Indic digit is AN. The suite has no test for a label made entirely of them.

## Ecosystem Impact

These pass on the gating validators, so they are coverage rather than breakers. Each one does catch a specific wrong implementation, which is why I kept these three and dropped four other candidates that turned out to catch nothing:

- the uppercase A-label case is failed by an implementation that compares the round-trip byte-wise instead of lowercasing first, which is what `sourcemeta/core`'s strict path does today
- the digit-block case is failed by an implementation that applies A.8 and A.9 per name instead of per label
- the pure Arabic-Indic case is failed by an implementation that accepts AN as an RTL label's first character

I dropped a 253-octet boundary test because an off-by-one implementation capping at 254 accepts it anyway, so it catches nothing the existing 254-character test does not, and I dropped two Bidi condition tests because the only implementation shape they catch already fails 52 of the current tests.

## RFC References

- [RFC 5891 section 5.3](https://www.rfc-editor.org/rfc/rfc5891#section-5.3) and [section 3.1](https://www.rfc-editor.org/rfc/rfc5891#section-3.1)
- [RFC 3492 section 5](https://www.rfc-editor.org/rfc/rfc3492#section-5)
- [RFC 5892 appendix A.8 and A.9](https://www.rfc-editor.org/rfc/rfc5892#appendix-A.8)
- [RFC 5893 section 2](https://www.rfc-editor.org/rfc/rfc5893#section-2)

Related: #965
