### PR TITLE
test(email): add domain label structure cases

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -235,6 +235,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -270,6 +270,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -232,6 +232,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -232,6 +232,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -232,6 +232,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -270,6 +270,36 @@
                 "description": "an empty string is not valid",
                 "data": "",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain label starting with a hyphen is not valid",
+                "data": "test@-iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain label ending with a hyphen is not valid",
+                "data": "test@iana-.com",
+                "valid": false
+            },
+            {
+                "description": "a domain starting with a dot is not valid",
+                "data": "test@.iana.org",
+                "valid": false
+            },
+            {
+                "description": "a domain ending with a dot is not valid",
+                "data": "test@iana.org.",
+                "valid": false
+            },
+            {
+                "description": "two subsequent dots inside the domain are not valid",
+                "data": "test@iana..com",
+                "valid": false
+            },
+            {
+                "description": "a single-label domain is valid",
+                "data": "test@io",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
I read the `Domain` production in [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) against the current file and found that none of the label boundary rules are tested. The file has `joe.bloggs@invalid=domain.com` for a character outside the label alphabet, and nothing on where a label may start or end.

```
Domain         = sub-domain *("." sub-domain)
sub-domain     = Let-dig [Ldh-str]
Let-dig        = ALPHA / DIGIT
Ldh-str        = *( ALPHA / DIGIT / "-" ) Let-dig
```

Three rules fall out of those four lines. A label cannot begin with a hyphen, because `sub-domain` begins with `Let-dig`. A label cannot end with one either - `Ldh-str` reads like a free run of letters, digits and hyphens, but it is `*( ALPHA / DIGIT / "-" ) Let-dig`, so the last character it matches is always a `Let-dig`. And a single label is already a complete `Domain`, because `*("." sub-domain)` permits zero repetitions.

`Domain` also has no trailing dot. That was filed against this exact production as [erratum 6561](https://www.rfc-editor.org/errata/eid6561) and rejected in 2022; the verifier notes record that the change was raised in the DRUMS working group when RFC 2821 was written, rejected there, revisited in YAM and left alone.

## Changes

- Added 6 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `test@-iana.org` - label starting with a hyphen, invalid.
- `test@iana-.com` - label ending with a hyphen, invalid.
- `test@.iana.org` - `Domain` starting with a dot, invalid.
- `test@iana.org.` - trailing dot, invalid.
- `test@iana..com` - empty label between two dots, invalid.
- `test@io` - single-label domain, valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 (`full`)**: FAILS on `test@io` (rejects it). Its email regex ends `@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?`, and the `(?:...\.)+` group requires at least one dotted label, so a single-label domain cannot match. `fast` mode gets this right - its domain group is `(?:\....)*`.
2. **python-fastjsonschema 2.21.2**: FAILS on five of the six (accepts both hyphen cases, the trailing dot and the empty label; rejects `test@io`).
3. **api7/jsonschema 0.9.13 (Lua)**: FAILS on four (accepts both hyphen cases and the empty label; rejects `test@io`).
4. **ts-vscode-json-languageservice 5.7.2** and **go-gojsonschema v1.2.0**: FAIL on both hyphen cases (accept them).
5. **rust-boon 0.6.1** and **go-jsonschema v6.0.2**: FAIL on the trailing dot (accept it). rust-boon is otherwise the most faithful implementation I measured for this format.
6. **php-opis-json-schema 2.6.0**, **php-justinrainbow-json-schema 6.7.2**, **java-jsonschemafriend 0.12.5**, **dotnet-corvus 4.5.8**, **js-jsonschema 1.5.0**, **clojure-json-schema**: FAIL on `test@io` (reject it).
7. **sourcemeta/core `is_email`** (main, 8af4fe01): PASSES all six.

`test@iana-.com` is the one @jdesrosiers asked about on [#893](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/893) - the rule is the trailing `Let-dig` in `Ldh-str`, and four implementations get it wrong today.

## RFC References

- RFC 5321 section 4.1.2 (`Domain`, `sub-domain`, `Let-dig`, `Ldh-str`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5321 erratum 6561 (rejected - trailing dot in `Domain`): https://www.rfc-editor.org/errata/eid6561

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
