### PR TITLE
test(email): add quoted string local part cases

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -180,6 +180,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -215,6 +215,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -177,6 +177,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -177,6 +177,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -177,6 +177,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -215,6 +215,41 @@
                 "description": "a delete character in the local part is not valid",
                 "data": "\u007f@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a quoted string with no special characters in the local part is valid",
+                "data": "\"test\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted pair in the local part is valid",
+                "data": "\"\\a\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped double quote in the local part is valid",
+                "data": "\"\\\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an escaped backslash in the local part is valid",
+                "data": "\"\\\\\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "an unescaped double quote in an unquoted local part is not valid",
+                "data": "test\"@iana.org",
+                "valid": false
+            },
+            {
+                "description": "text after the closing double quote in the local part is not valid",
+                "data": "\"test\"test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an unclosed double quote in the local part is not valid",
+                "data": "\"test@iana.org",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`Local-part = Dot-string / Quoted-string` in [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2). The file has three quoted-string tests - a space, a double dot and an `@` - and all three are about what may sit *inside* the quotes. Nothing tests the quoting mechanism itself, and nothing tests a quoted pair at all.

```
Quoted-string  = DQUOTE *QcontentSMTP DQUOTE
QcontentSMTP   = qtextSMTP / quoted-pairSMTP
quoted-pairSMTP  = %d92 %d32-126
qtextSMTP      = %d32-33 / %d35-91 / %d93-126
```

`qtextSMTP` excludes %d34 and %d92, so neither a bare double quote nor a bare backslash can be content. A backslash therefore always begins a `quoted-pairSMTP`, and the first unescaped double quote always closes the string - which makes the four quoting cases below decidable rather than ambiguous. It also means a `Quoted-string` has to be the whole `Local-part`: `Local-part` is one alternative or the other, never a concatenation, so nothing may sit outside the quotes.

## Changes

- Added 7 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `"test"@iana.org` - a quoted string needs no special character to justify it, valid.
- `"\a"@iana.org` - `quoted-pairSMTP`, valid.
- `"\""@iana.org` - escaped double quote, so the string is still open, valid.
- `"\\"@iana.org` - escaped backslash, so the third quote closes, valid.
- `test"@iana.org` - %d34 is not `atext`, invalid.
- `"test"test@iana.org` - text after the closing quote, invalid.
- `"test@iana.org` - no closing quote, invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 (both `full` and `fast`)**: FAILS on all four valid cases (rejects them). Neither regex has a quoted-string alternative - `full` starts `^[a-z0-9!#$%&'*+/=?^_\`{|}~-]+` and `fast` starts `^[a-z0-9.!#$%&'*+/=?^_\`{|}~-]+`, and `"` is in neither class.
2. **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0 (tdegrunt)**: FAIL on all four valid cases (reject them).
3. **js-json-schema 4.1.1**, **api7/jsonschema 0.9.13 (Lua)**, **clojure-json-schema**: FAIL on the valid cases in the Bowtie census (reject them).
4. **ata-validator 1.2.1**: FAILS on all three invalid cases (accepts them).
5. **python-jsonschema 4.25.1**: FAILS on all three invalid cases (accepts them) - its `is_email` is `return "@" in instance`.
6. **sourcemeta/core `is_email`** (main, 8af4fe01): PASSES all seven.

The quoted-pair cases are the part with no existing coverage at all - `"\a"@iana.org` is rejected by nine of the implementations I ran.

## RFC References

- RFC 5321 section 4.1.2 (`Local-part`, `Quoted-string`, `QcontentSMTP`, `qtextSMTP`, `quoted-pairSMTP`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5322 section 3.2.3 (`atext`, which section 4.1.2 imports for undefined terminals): https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
