### PR TITLE
test(email): add address literal structure cases

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -265,6 +265,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -300,6 +300,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -262,6 +262,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -262,6 +262,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -262,6 +262,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -300,6 +300,41 @@
                 "description": "a single-label domain is valid",
                 "data": "test@io",
                 "valid": true
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,41 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "an unclosed address literal is not valid",
+                "data": "test@[1.2.3.4",
+                "valid": false
+            },
+            {
+                "description": "empty brackets after the @ are not valid",
+                "data": "a@[]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with three octets is not valid",
+                "data": "a@[1.2.3]",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-address-literal with five octets is not valid",
+                "data": "a@[1.2.3.4.5]",
+                "valid": false
+            },
+            {
+                "description": "bracketed content that is not an address is not valid",
+                "data": "test@[RFC-5322-domain-literal]",
+                "valid": false
+            },
+            {
+                "description": "a domain label before the opening bracket is not valid",
+                "data": "test@a[255.255.255.255]",
+                "valid": false
+            },
+            {
+                "description": "a lowercase IPv6 tag in an address literal is valid",
+                "data": "a@[ipv6:::1]",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The file has one valid IPv4 literal, one valid IPv6 literal and one out-of-range IPv4 literal. It does not test the brackets themselves or the octet count, both of which [RFC 5321 section 4.1.3](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3) pins exactly.

```
address-literal  = "[" ( IPv4-address-literal / IPv6-address-literal /
                   General-address-literal ) "]"
IPv4-address-literal  = Snum 3("."  Snum)
IPv6-address-literal  = "IPv6:" IPv6-addr
```

`Snum 3("." Snum)` is exactly four `Snum`, so three and five both fail. Both brackets are literals in `address-literal`, so an unclosed or empty pair fails. And because `address-literal` is one of the two alternatives for the domain half of `Mailbox`, the bracket has to begin immediately after the `@` - a label in front of it is neither a `Domain` nor an `address-literal`.

The last case is about case. `IPv6-address-literal = "IPv6:" IPv6-addr` writes the tag as an ABNF quoted literal, and [RFC 5234 section 2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) says *"ABNF strings are case insensitive and the character set for these strings is US-ASCII."* So `ipv6:` matches the same production as `IPv6:`. The file's existing valid case is `joe.bloggs@[IPv6:::1]`; this test changes only the case of the tag, so it isolates that one variable.

## Changes

- Added 7 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `test@[1.2.3.4` - unclosed literal, invalid.
- `a@[]` - empty brackets, invalid.
- `a@[1.2.3]` - three `Snum`, invalid.
- `a@[1.2.3.4.5]` - five `Snum`, invalid.
- `test@[RFC-5322-domain-literal]` - no `Snum`, no `IPv6:` tag and no colon, so `General-address-literal` cannot apply either, invalid.
- `test@a[255.255.255.255]` - a label before the opening bracket, invalid.
- `a@[ipv6:::1]` - lowercase tag, valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 (both modes)**: FAILS on `a@[ipv6:::1]` (rejects it). Neither regex has a bracket alternative, so it rejects every address literal including the two already in this file.
2. **ata-validator 1.2.1**: FAILS on five of the six invalid cases (accepts them).
3. **python-jsonschema 4.25.1**: FAILS on all six invalid cases (accepts them) - `is_email` is `return "@" in instance`.
4. **validator.js 13.15.35**, **email-validator 2.0.4**, **python email-validator 2.3.0**, **Go `net/mail.ParseAddress` (1.25.5)**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**: FAIL on `a@[ipv6:::1]` (reject it).
5. **sourcemeta/core `is_email`** (main, 8af4fe01): PASSES all seven. It handles the tag case explicitly.

Eleven of the implementations I ran reject the lowercase tag while accepting the uppercase one, so this is the one case here with a wide blast radius. @jdesrosiers raised the case question on [#893](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/893); RFC 5234 section 2.3 is the answer.

## RFC References

- RFC 5321 section 4.1.3 (`address-literal`, `IPv4-address-literal`, `IPv6-address-literal`, `Snum`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.3
- RFC 5234 section 2.3 (ABNF quoted literals are case insensitive): https://www.rfc-editor.org/rfc/rfc5234#section-2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
