### PR TITLE
test(email): add cases for the @ separating local part and domain

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -215,6 +215,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -250,6 +250,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -212,6 +212,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -212,6 +212,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -212,6 +212,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -250,6 +250,26 @@
                 "description": "an unclosed double quote in the local part is not valid",
                 "data": "\"test@iana.org",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "two unquoted @ signs are not valid",
+                "data": "a@b@c.org",
+                "valid": false
+            },
+            {
+                "description": "a backslash-escaped @ in an unquoted local part is not valid",
+                "data": "test\\@test@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an address literal in the local part position is not valid",
+                "data": "[1.2.3.4]@iana.org",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not valid",
+                "data": "",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`Mailbox = Local-part "@" ( Domain / address-literal )` in [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) has exactly one `@` outside a quoted string. The file tests both halves being empty (`@example.com` and `joe.bloggs@`) but never the separator itself, and it has no test for the empty string.

An unquoted `Local-part` is `Dot-string = Atom *("." Atom)` with `Atom = 1*atext`, and neither `@` nor `\` nor `[` is in `atext`, so none of them can appear there. The backslash only escapes inside a `Quoted-string`; in a `Dot-string` it is just a character outside the alphabet.

## Changes

- Added 4 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `a@b@c.org` - a second `@` the `Local-part` cannot reach, invalid.
- `test\@test@iana.org` - %d92 is not `atext`, invalid.
- `[1.2.3.4]@iana.org` - `address-literal` is an alternative for the domain half only, invalid.
- `""` - `Mailbox` requires a `Local-part`, an `@` and a domain half, invalid.

## Ecosystem Impact

1. **ata-validator 1.2.1**: FAILS on the three non-empty cases (accepts them).
2. **python-jsonschema 4.25.1**: FAILS on the three non-empty cases (accepts them) - `is_email` is `return "@" in instance`, and each of them contains one.
3. **ajv-formats 3.0.1**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**, **sourcemeta/core `is_email`**: PASS all four.

The empty string breaks nothing in my matrix. It is here because it is the one input that fails every part of `Mailbox` at once, and a validator that short-circuits on a falsy value before checking the format would pass every other test in this file.

## RFC References

- RFC 5321 section 4.1.2 (`Mailbox`, `Local-part`, `Dot-string`, `Atom`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5322 section 3.2.3 (`atext`): https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
