### PR TITLE
test(email): add cases for characters not permitted in an unquoted local part

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -300,6 +300,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -317,12 +317,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -122,12 +122,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -317,12 +317,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -352,12 +352,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -157,12 +157,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -335,6 +335,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -352,12 +352,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -314,12 +314,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -297,6 +297,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -314,12 +314,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -314,12 +314,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -297,6 +297,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -314,12 +314,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -314,12 +314,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -297,6 +297,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -119,12 +119,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -314,12 +314,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -352,12 +352,14 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
+                "description": "a parenthesis in the domain is not valid",
+                "comment": "a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -157,12 +157,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -335,6 +335,31 @@
                 "description": "a lowercase IPv6 tag in an address literal is valid",
                 "data": "a@[ipv6:::1]",
                 "valid": true
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a comma in an unquoted local part is not valid",
+                "data": "a,b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a semicolon in an unquoted local part is not valid",
+                "data": "a;b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a colon in an unquoted local part is not valid",
+                "data": "a:b@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in an unquoted local part is not valid",
+                "data": "test(comment)@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a parenthesis in the domain is not valid",
+                "data": "a@b(c).org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -352,12 +352,12 @@
                 "valid": false
             },
             {
-                "description": "a parenthesis in an unquoted local part is not valid",
+                "description": "a parenthesis in an unquoted local part is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "test(comment)@iana.org",
                 "valid": false
             },
             {
-                "description": "a parenthesis in the domain is not valid",
+                "description": "a parenthesis in the domain is not valid (a comment is RFC 5322 syntax, which the RFC 5321 Mailbox grammar does not have)",
                 "data": "a@b(c).org",
                 "valid": false
             }


### PR DESCRIPTION
An unquoted `Local-part` is `Dot-string = Atom *("." Atom)` with `Atom = 1*atext`. `atext` is not defined in RFC 5321 - the [section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) preamble says terminals it does not define come from the RFC 5234 core syntax or from RFC 5322, where [section 3.2.3](https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3) gives `atext` as ALPHA, DIGIT and seventeen listed punctuation characters.

The file tests exactly one character outside that set - the space, in `joe bloggs@example.com`. These add one test per remaining punctuation class rather than one per character, and one for the domain side, where `sub-domain` is limited to `ALPHA / DIGIT / "-"`.

I kept this deliberately small. An earlier draft of this work had eleven parenthesis tests; @jdesrosiers pointed out on [#893](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/893) that they were all testing one thing, and he was right, so there is one here.

## Changes

- Added 5 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `a,b@iana.org` - `,` is not in `atext`, invalid.
- `a;b@iana.org` - `;` is not in `atext`, invalid.
- `a:b@iana.org` - `:` is not in `atext`, invalid.
- `test(comment)@iana.org` - `(` and `)` are not in `atext`, invalid.
- `a@b(c).org` - and they are not in `sub-domain` either, invalid.

## Ecosystem Impact

1. **ata-validator 1.2.1**: FAILS on four of the five (accepts them).
2. **python-jsonschema 4.25.1**: FAILS on four of the five (accepts them) - `is_email` is `return "@" in instance`.
3. **python-fastjsonschema 2.21.2**: FAILS on `a,b@iana.org` (accepts it).
4. **ajv-formats 3.0.1**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**, **sourcemeta/core `is_email`**: PASS all five.

`test(comment)@iana.org` breaks nothing in my matrix. It is here because a parenthesised comment is the one RFC 5322 construct people most often expect `format: email` to accept, and RFC 5321's `Mailbox` has no production for it anywhere.

## RFC References

- RFC 5321 section 4.1.2 (`Dot-string`, `Atom`, `sub-domain`, and the terminal-import sentence): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5322 section 3.2.3 (`atext`): https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
