### PR TITLE
test(email): add trailing and control character cases

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -150,6 +150,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -185,6 +185,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -147,6 +147,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -147,6 +147,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -147,6 +147,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -185,6 +185,36 @@
                 "description": "a non-ASCII character in a quoted pair is not valid",
                 "data": "\"test\\\u00a9\"@iana.org",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,36 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a trailing line feed is not valid",
+                "data": "test@iana.org\n",
+                "valid": false
+            },
+            {
+                "description": "a trailing carriage return is not valid",
+                "data": "test@iana.org\r",
+                "valid": false
+            },
+            {
+                "description": "a trailing space is not valid",
+                "data": "a@iana.org ",
+                "valid": false
+            },
+            {
+                "description": "a leading space is not valid",
+                "data": " a@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a tab in the local part is not valid",
+                "data": "a\tb@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a delete character in the local part is not valid",
+                "data": "\u007f@iana.org",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
No production reachable from `Mailbox` admits whitespace or a control character anywhere. [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) also says it in prose:

> Systems MUST NOT define mailboxes in such a way as to require the use in SMTP of non-ASCII characters (octets with the high order bit set to one) or ASCII "control characters" (decimal value 0-31 and 127).

The file has one unquoted space in the middle of a local part and nothing on either end of the string. A trailing newline in particular is the case a regex anchored with `$` rather than `\A...\z` will let through, which is the same class as the `ipv4` test in #840, the `duration` one in #982 and the `hostname` one in #1023.

## Changes

- Added 6 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `test@iana.org\n` - trailing line feed, invalid.
- `test@iana.org\r` - trailing carriage return, invalid.
- `a@iana.org ` - trailing space, invalid.
- ` a@iana.org` - leading space, invalid.
- `a\tb@iana.org` - tab in the local part, invalid.
- a DEL character (U+007F) as the local part, invalid - named directly by the prose above.

## Ecosystem Impact

1. **ata-validator 1.2.1**: FAILS on all six (accepts them).
2. **python-jsonschema 4.25.1**: FAILS on all six (accepts them) - `is_email` is `return "@" in instance`.
3. **python-fastjsonschema 2.21.2**, **api7/jsonschema 0.9.13 (Lua)**, **dotnet-corvus 4.5.8**: FAIL on the trailing line feed (accept it).
4. **Python `email.utils.parseaddr` (3.9.6)**: FAILS on the tab and the DEL case (accepts them).
5. **ajv-formats 3.0.1**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**, **sourcemeta/core `is_email`**: PASS all six.

## RFC References

- RFC 5321 section 4.1.2 (`Mailbox` and the control-character prose): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5322 section 3.2.3 (`atext`): https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
