### PR TITLE
test(email): add non-ASCII cases

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -130,6 +130,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -165,6 +165,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -127,6 +127,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -127,6 +127,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -127,6 +127,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,26 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -165,6 +165,26 @@
                 "description": "a domain label starting with a digit is valid",
                 "data": "test@123.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII character in the local part is not valid",
+                "data": "a\u00e9@iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in the domain is not valid",
+                "data": "a@\u00e9.org",
+                "valid": false
+            },
+            {
+                "description": "a fullwidth commercial at is not a valid separator",
+                "data": "a\uff20iana.org",
+                "valid": false
+            },
+            {
+                "description": "a non-ASCII character in a quoted pair is not valid",
+                "data": "\"test\\\u00a9\"@iana.org",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Every terminal reachable from `Mailbox` is an ASCII range - `atext` is ASCII, `qtextSMTP` is %d32-126, `quoted-pairSMTP` is %d92 followed by %d32-126, and `sub-domain` is `ALPHA / DIGIT / "-"`. [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) states it in prose as well:

> Systems MUST NOT define mailboxes in such a way as to require the use in SMTP of non-ASCII characters (octets with the high order bit set to one)

Non-ASCII is what `idn-email` is for. The file has no test that keeps the two formats apart, so an implementation that wires one checker to both format keywords passes `email` today.

## Changes

- Added 4 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `aé@iana.org` - U+00E9 in the local part, invalid.
- `a@é.org` - U+00E9 in the domain, invalid.
- `a＠iana.org` - U+FF20 fullwidth commercial at, which is not the `@` of `Mailbox` (%d64), invalid.
- `"test\©"@iana.org` - `quoted-pairSMTP` is %d92 followed by %d32-126, so U+00A9 cannot follow the backslash, invalid.

## Ecosystem Impact

1. **python-fastjsonschema 2.21.2**, **java-networknt 3.0.1**, **java-jsonschemafriend 0.12.5**, **go-gojsonschema v1.2.0**, **dotnet-newtonsoft 4.0.2-beta**: FAIL on both U+00E9 cases (accept them).
2. **ts-vscode-json-languageservice 5.7.2** and **php-justinrainbow-json-schema 6.7.2**: FAIL on the local-part case (accept it).
3. **validator.js 13.15.35**, **isemail 3.2.0**, **ata-validator 1.2.1**, **Go `net/mail.ParseAddress`**, **Python `email.utils.parseaddr`**: FAIL on both U+00E9 cases (accept them).
4. **python-jsonschema 4.25.1**: FAILS on all four (accepts them). The same `"@" in instance` function is registered for both `email` and `idn-email`, which is exactly the conflation these tests are meant to catch.
5. **ajv-formats 3.0.1**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**, **sourcemeta/core `is_email`**: PASS all four.

The fullwidth `@` breaks nothing in my matrix - every implementation rejects it, because with no ASCII `@` present there is no separator to find. It is here so that the "non-ASCII lookalike" case is pinned alongside the two real ones rather than assumed.

## RFC References

- RFC 5321 section 4.1.2 (`Mailbox`, `qtextSMTP`, `quoted-pairSMTP`, `sub-domain`, and the ASCII prose): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5322 section 3.2.3 (`atext`): https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
