### PR TITLE
test(email): cover grammar branches the suite does not reach

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -105,6 +105,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/email.json
+++ b/tests/draft2020-12/optional/format/email.json
@@ -140,6 +140,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -102,6 +102,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/email.json
+++ b/tests/v1/format/email.json
@@ -140,6 +140,31 @@
                 "description": "unquoted space in local part is invalid",
                 "data": "joe bloggs@example.com",
                 "valid": false
+            },
+            {
+                "description": "a domain that looks like an IPv4 address without brackets is valid",
+                "data": "test@255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "an empty quoted string in the local part is valid",
+                "data": "\"\"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "a quoted string containing only a space in the local part is valid",
+                "data": "\" \"@iana.org",
+                "valid": true
+            },
+            {
+                "description": "consecutive hyphens inside a domain label are valid",
+                "data": "test@c--n.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label starting with a digit is valid",
+                "data": "test@123.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
These do not correct anything. They fill in branches of the [RFC 5321 section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2) grammar that no existing test in the file reaches, one test per branch.

`Let-dig` admits `DIGIT`, so a label may start with a digit, and a `Domain` of four all-digit labels is an ordinary `Domain` - what selects `address-literal` is the brackets, not the shape of the content. `Ldh-str` permits a run of hyphens in the interior as long as the label still ends in a `Let-dig`. `*QcontentSMTP` permits zero repetitions, so an empty quoted string is a `Local-part`. And %d32 is inside `qtextSMTP`'s %d32-33 range, so a quoted string of one space is content rather than an empty string.

One flag on the empty quoted string: [erratum 5414](https://www.rfc-editor.org/errata/eid5414) proposes changing that production to `1*QcontentSMTP` for exactly this reason. It was filed in 2018 and is still Held for Document Update, so the test follows the published text - but I am happy to drop that one case if the suite would rather not pin a point that has an open erratum against it.

## Changes

- Added 5 test cases across draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `test@255.255.255.255` - a `Domain` of four `sub-domain`s, no brackets so no `address-literal`, valid.
- `""@iana.org` - `*QcontentSMTP` with zero repetitions, valid.
- `" "@iana.org` - %d32 is inside `qtextSMTP`, valid.
- `test@c--n.com` - `Ldh-str` permits interior hyphens, valid.
- `test@123.com` - `Let-dig` admits `DIGIT`, valid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 (both modes)**, **@exodus/schemasafe 1.3.0**, **@cfworker/json-schema 4.1.1**, **jsonschema 1.5.0**: FAIL on both quoted-string cases (reject them) - neither ajv regex has a quoted-string alternative.
2. **api7/jsonschema 0.9.13 (Lua)**, **js-json-schema 4.1.1**, **js-jsonschema 1.5.0**, **js-schemasafe 1.3.0**, **go-gojsonschema v1.2.0**, **ts-vscode-json-languageservice 5.7.2**: FAIL on `""@iana.org` (reject it).
3. **php-opis-json-schema 2.6.0**, **php-justinrainbow-json-schema 6.7.2**, **java-networknt 3.0.1**, **java-jsonschemafriend 0.12.5**, **validator.js 13.15.35**, **PHP `filter_var` (8.1.34)**: FAIL on `test@255.255.255.255` (reject it, treating a dotted quad as an address rather than a domain).
4. **sourcemeta/core `is_email`** (main, 8af4fe01): PASSES all five.

`test@c--n.com` and `test@123.com` break nothing in my matrix. They are the two branches of `Ldh-str` and `Let-dig` with no existing test, and an implementation that borrowed a hostname regex forbidding consecutive hyphens or a leading digit would pass every other test in this file.

## RFC References

- RFC 5321 section 4.1.2 (`Domain`, `sub-domain`, `Let-dig`, `Ldh-str`, `Quoted-string`, `qtextSMTP`): https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
- RFC 5321 erratum 5414 (Held for Document Update - empty `Quoted-string`): https://www.rfc-editor.org/errata/eid5414

Reproduction commands and the wider email cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/email.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
