### PR TITLE
test(time): leap seconds are not valid times in v1

### DIFF
--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -57,9 +57,9 @@
                 "valid": false
             },
             {
-                "description": "a valid time string with leap second, Zulu",
+                "description": "a leap second is not a valid time",
                 "data": "23:59:60Z",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid leap second, Zulu (wrong hour)",
@@ -72,9 +72,9 @@
                 "valid": false
             },
             {
-                "description": "valid leap second, zero time-offset",
+                "description": "a leap second with a zero time-offset is not a valid time",
                 "data": "23:59:60+00:00",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid leap second, zero time-offset (wrong hour)",
@@ -87,14 +87,14 @@
                 "valid": false
             },
             {
-                "description": "valid leap second, positive time-offset",
+                "description": "a leap second with a positive time-offset is not a valid time",
                 "data": "01:29:60+01:30",
-                "valid": true
+                "valid": false
             },
             {
-                "description": "valid leap second, large positive time-offset",
+                "description": "a leap second with a large positive time-offset is not a valid time",
                 "data": "23:29:60+23:30",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid leap second, positive time-offset (wrong hour)",
@@ -107,14 +107,14 @@
                 "valid": false
             },
             {
-                "description": "valid leap second, negative time-offset",
+                "description": "a leap second with a negative time-offset is not a valid time",
                 "data": "15:59:60-08:00",
-                "valid": true
+                "valid": false
             },
             {
-                "description": "valid leap second, large negative time-offset",
+                "description": "a leap second with a large negative time-offset is not a valid time",
                 "data": "00:29:60-23:30",
-                "valid": true
+                "valid": false
             },
             {
                 "description": "invalid leap second, negative time-offset (wrong hour)",


### PR DESCRIPTION
`tests/v1/format/time.json` still asserts six leap-second values as valid, and the v1 validation spec now says they must not be.

[json-schema-spec#1644](https://github.com/json-schema-org/json-schema-spec/pull/1644) merged on 2025-12-16 and resolved [#1637](https://github.com/json-schema-org/json-schema-spec/issues/1637). The current text in `specs/jsonschema-validation.md` reads:

> - *time*: A string instance is valid against this attribute if it is a valid representation according to the "full-time" ABNF rule in RFC 3339. This MUST NOT include leap seconds.

with a footnote giving the reasoning:

> The `time` format represents a time value that is independent of any specific date [...] Because `time` isn't for capturing a moment in time, leap seconds don't make sense because leap seconds only apply to specific dates. See RFC 3339, section 5.7.

The same PR's description says what is still owed:

> Note: This will require a follow up to the test suite to remove the leap second tests from v1 only. They can stay in the other releases because I think the spec was ambiguous and those tests are optional anyway.

I could not find an issue or PR tracking that follow-up, so this is it. It touches `tests/v1/format/time.json` and nothing else - the `draft7`, `draft2019-09` and `draft2020-12` copies are left exactly as they are, per the note above.

The six rows that currently say `valid: true`:

| data | current | description |
|---|---|---|
| `23:59:60Z` | true | a valid time string with leap second, Zulu |
| `23:59:60+00:00` | true | valid leap second, zero time-offset |
| `01:29:60+01:30` | true | valid leap second, positive time-offset |
| `23:29:60+23:30` | true | valid leap second, large positive time-offset |
| `15:59:60-08:00` | true | valid leap second, negative time-offset |
| `00:29:60-23:30` | true | valid leap second, large negative time-offset |

I flipped them to `valid: false` and reworded the descriptions, rather than deleting the rows. My reasoning: under the new text these are not "leap second tests" that no longer apply - they are values that a v1 implementation must now reject, so they still carry weight, and eight of the ten implementations I checked currently get them wrong. If you would rather they were deleted outright I will send that instead - your note said "remove" and I want to match what you actually want here.

Measured blast radius, `format: time` at 2020-12 (the closest dialect these implementations support), on the six values:

| implementation | accepts (out of 6) |
|---|---|
| ajv-formats 3.0.1 `full` | 6 |
| sourcemeta/core | 6 |
| fastjsonschema 2.21.2 | 6 |
| jsonschema-rs 0.49.2 | 6 |
| @exodus/schemasafe 1.3.0 | 6 |
| json-schema-library 11.6.2 | 6 |
| ajv-formats 3.0.1 `fast` | 2 |
| @cfworker/json-schema 4.1.1 | 2 |
| ata-validator 1.2.2 | 0 |
| python-jsonschema 4.25.1 | 0 |

The two that are already correct are correct by accident rather than by design. python-jsonschema delegates to `rfc3339-validator`, whose seconds class is `[0-5]\d` and whose docstring says "Leap seconds are no supported" - so it has never accepted a leap second in any dialect. That behaviour has been recorded as a limitation of the reference validator; under v1 it is the required behaviour.

The ten remaining `ss=60` rows in the file already say `valid: false` and stay untouched, so the file keeps coverage on the shape. Their descriptions still talk about the wrong hour and the wrong minute, which is no longer the reason they are invalid - I left them alone to keep this diff to one concern, and can send a wording pass separately.

Not touching the other three draft files also keeps this clear of [json-schema-spec#1690](https://github.com/json-schema-org/json-schema-spec/issues/1690), the still-open question about whether the section 5.7 restrictions apply when only section 5.6 is cited. Nothing here rests on how that one is answered.

## Changes

`tests/v1/format/time.json` only, 6 rows, `+12/-12`. No other file is touched. Each row keeps its `data` and flips `valid` from `true` to `false`, with the description reworded:

```json
            {
                "description": "a leap second is not a valid time",
                "data": "23:59:60Z",
                "valid": false
            }
```

and the same shape for `23:59:60+00:00`, `01:29:60+01:30`, `23:29:60+23:30`, `15:59:60-08:00` and `00:29:60-23:30`.
