### PR TITLE
test(time): add numeric offsets missing the colon and the minutes as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,18 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the colon separator",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+0130",
+                "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the minutes component",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,18 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the colon separator",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+0130",
+                "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the minutes component",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,18 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the colon separator",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+0130",
+                "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the minutes component",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,18 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the colon separator",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+0130",
+                "valid": false
+            },
+            {
+                "description": "a numeric time-offset requires the minutes component",
+                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+                "data": "08:30:06+01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`08:30:06+0130` and `08:30:06+01` are both accepted by ajv-formats 3.0.1, and neither shape is in `time.json` today.

[RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) gives the offset as:

```
time-numoffset  = ("+" / "-") time-hour ":" time-minute
time-offset     = "Z" / time-numoffset
```

The `":"` is a required literal and `time-minute` is not optional, so a colonless `+0130` and a minutes-less `+01` are both invalid. The lax `[[":"] time-minute]` form people expect only appears in the informative [Appendix A](https://www.rfc-editor.org/rfc/rfc3339#appendix-A) ISO grammar, not in the normative section 5.6 productions.

The existing offset tests only cover digit counts inside a well-formed offset (`08:30:06-8:000`) and the range bounds (`01:02:03+24:00`, `01:02:03+00:60`). Nothing pins the colon or the presence of the minutes field.

Five validators accept at least one of the two:

| implementation | `+0130` | `+01` |
|---|---|---|
| ajv-formats 3.0.1 (`full` and `fast`) | accepts | accepts |
| @cfworker/json-schema 4.1.1 | accepts | accepts |
| @exodus/schemasafe 1.3.0 | accepts | accepts |
| json-schema-library 11.6.2 | accepts | accepts |
| python-jsonschema 4.25.1, sourcemeta/core, jsonschema-rs 0.49.2 | rejects | rejects |

In ajv-formats the cause is one regex, `src/formats.ts:158`:

```js
const TIME = /^(\d\d):(\d\d):(\d\d(?:\.\d+)?)(z|([+-])(\d\d)(?::?(\d\d))?)?$/i
```

`(?::?(\d\d))?` makes the colon optional and the whole minutes group optional, which is why both shapes get through.

I kept them as two cases rather than one because they are separable: a regex written `(:\d\d)?` accepts `+01` but rejects `+0130`, and one written `\d\d:?\d\d` does the reverse. I checked that against the published file by building both wrong implementations and running them over all 41 existing string cases - each passes the whole file, and each is caught by exactly one of these two new cases.

This behaviour is deliberate on ajv's side rather than an oversight: [ajv#1061](https://github.com/ajv-validator/ajv/issues/1061) asked for `+0130` and `+05` to be accepted and [ajv#1062](https://github.com/ajv-validator/ajv/pull/1062) shipped it in 6.11.0, and `tests/extras/issues/1061_alternative_time_offsets.json` in ajv-formats still asserts both as valid. When it was challenged in [ajv#1193](https://github.com/ajv-validator/ajv/issues/1193) the maintainer's answer was that the cases should be added to the JSON Schema Test Suite, and Julian agreed - that never happened, so this is that. [ajv-formats#104](https://github.com/ajv-validator/ajv-formats/issues/104) is an independent report of the minutes-less form and is still open with no reply.

## Changes

The same cases are added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "a numeric time-offset requires the colon separator",
                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                "data": "08:30:06+0130",
                "valid": false
            },
            {
                "description": "a numeric time-offset requires the minutes component",
                "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                "data": "08:30:06+01",
                "valid": false
            }
```
