### PR TITLE
test(time): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -253,6 +253,12 @@
                 "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                 "data": "08:30:06+01",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -253,6 +253,12 @@
                 "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                 "data": "08:30:06+01",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -250,6 +250,12 @@
                 "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                 "data": "08:30:06+01",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -253,6 +253,12 @@
                 "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
                 "data": "08:30:06+01",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+                "data": "08:30:06Z\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`08:30:06Z\n` is accepted by python-jsonschema 4.25.1, the validator the suite's own tooling uses.

No production in [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) emits a line feed, and `full-time = partial-time time-offset` has to account for the whole string, so a terminal LF makes the value invalid. Hex of the case: `30383a33303a30365a0a`.

The cause is Python's `$`. `is_time` prepends a date and calls the shared `is_datetime`, which calls `rfc3339_validator.validate_rfc3339`; that builds a pattern ending in `$` and uses `re.match`. In Python `$` matches at the end of the string *or just before a single trailing newline*, so exactly one terminal LF slips through.

The leak is that narrow, which is why the case is the bare single LF - I checked the neighbours and they all reject: `\n\n`, `\r`, `\r\n`, a mid-string LF, and LF followed by more content.

ajv-formats 3.0.1 (both modes), sourcemeta/core and jsonschema-rs 0.49.2 all reject it. The existing `01:02:03Z+00:30` test catches a validator that ignores trailing content in general, but not this one - python-jsonschema rejects `Z+00:30` and accepts `Z\n`, so the two are different mechanisms. I confirmed that by building an implementation whose only defect is the `$`-anchor and running it over the 41 published string cases: it passes all of them.

This is the same anchor class already merged for other formats - [#982](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/982) (duration), [#1003](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/1003) (uuid), [#1030](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/1030) (relative-json-pointer) - so the shape of the test should look familiar.

## Changes

The same case is added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "a trailing newline after a valid time",
                "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
                "data": "08:30:06Z\n",
                "valid": false
            }
```
