### PR TITLE
test(time): add hour 24 with a numeric offset as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -259,6 +259,12 @@
                 "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
                 "data": "08:30:06Z\n",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -259,6 +259,12 @@
                 "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
                 "data": "08:30:06Z\n",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -256,6 +256,12 @@
                 "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
                 "data": "08:30:06Z\n",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -259,6 +259,12 @@
                 "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
                 "data": "08:30:06Z\n",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "hour 24 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+                "data": "24:59:00+01:00",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`24:59:00+01:00` is accepted by ajv-formats 3.0.1 `full` and by fastjsonschema 2.21.2, while the existing `24:00:00Z` test is rejected by both. The difference is the offset.

[RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) gives `time-hour = 2DIGIT ; 00-23`, and [section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) is explicit about why:

> Although ISO 8601 permits the hour to be "24", this profile of ISO 8601 only allows values between "00" and "23" for the hour in order to reduce confusion.

The bound does not depend on the offset, so hour 24 is invalid whatever follows it.

In ajv-formats the hour bound sits on one branch only. From the live `fullFormats.time.validate`:

```js
if (tzH > 23 || tzM > 59 || (strictTimeZone && !tz)) return false
if (hr <= 23 && min <= 59 && sec < 60) return true
// leap second
const utcMin = min - tzM * tzSign
const utcHr = hr - tzH * tzSign - (utcMin < 0 ? 1 : 0)
return (utcHr === 23 || utcHr === -1) && (utcMin === 59 || utcMin === -1) && sec < 61
```

`hr <= 23` is only tested on the early-return path. Anything that falls past it reaches the last line, which re-derives the hour through the offset and never re-checks the raw value. With `Z` the offset is zero so `utcHr` stays 24 and the value is rejected - which is why `24:00:00Z` passes today and this shape does not.

Worth noting that the last line tests `sec < 61`, not `sec === 60`, so it is not really a leap-second path: an ordinary `:00` reaches it too. That is why I used `24:59:00+01:00` rather than the leap-second form `24:59:60+01:00` - it violates exactly one rule (the hour bound) instead of touching the leap-second rules as well, and ajv-formats `fast` accepts it too via its `[0-2]\d` hour class.

The two forms are not interchangeable across the wider ecosystem, and I would rather say so than imply one dominates. Measured on a 40-image sweep:

| input | ajv `full` | ajv `fast` | fastjsonschema | networknt |
|---|---|---|---|---|
| `24:59:00+01:00` (this test) | accept | accept | accept | rejects, correctly |
| `24:59:60+01:00` (leap form) | accept | rejects | accept | **accept** |

networknt's `TimeFormat` normalises by the offset and then checks the leap second against the normalised values, so it only skips the bound on the genuine `:60` path. So the leap form catches something this test does not. I went with the ordinary-second form because it is the cleaner single-rule case for the suite and it catches both ajv modes; if you would rather have the leap form, or both, I have the evidence for either.

The class is parametric rather than a single value - any hour whose offset-shifted hour lands on 23 gets in, so `29:59:00+06:00` and `46:59:00+23:00` are accepted as well. One case is enough for the suite; I have the rest in the evidence set.

I checked this is not already covered by building an implementation with exactly this defect (hour and minute bounded only on the non-leap path) and running it over the 41 published string cases - it passes all of them.

## Changes

The same case is added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "hour 24 is invalid with a numeric time-offset",
                "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
                "data": "24:59:00+01:00",
                "valid": false
            }
```
