### PR TITLE
test(time): add minute 60 with a numeric offset as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -265,6 +265,12 @@
                 "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
                 "data": "24:59:00+01:00",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -265,6 +265,12 @@
                 "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
                 "data": "24:59:00+01:00",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -262,6 +262,12 @@
                 "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
                 "data": "24:59:00+01:00",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -265,6 +265,12 @@
                 "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
                 "data": "24:59:00+01:00",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "minute 60 is invalid with a numeric time-offset",
+                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+                "data": "23:60:00+00:01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
`23:60:00+00:01` is accepted by ajv-formats 3.0.1 `full` and by fastjsonschema 2.21.2. The existing minute test, `00:60:00Z`, is rejected by both - the offset is what makes the difference.

[RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6): `time-minute = 2DIGIT ; 00-59`. The bound does not depend on the offset.

Same code path as the hour case - in ajv-formats the `min <= 59` test is on the early-return branch only, and the branch past it re-derives the minute through the offset (`utcMin = min - tzM * tzSign`) without re-checking the raw value. `60 - 1 = 59` lands on the accepted value, so the minute gets in. With `Z` the offset is zero, `utcMin` stays 60, and the value is rejected, which is why the existing `00:60:00Z` test does not reach this.

I am sending this separately from the hour case because an implementation can fix one and not the other. I built both halves - hour bounded everywhere with the minute only on the fast path, and the reverse - ran each over the 41 published string cases, and both pass the whole file; each is then caught by exactly one of the two new cases. So neither is redundant with the other.

Like the hour case this is parametric: any minute of the form `59 + M` with a `+00:M` offset gets in, so `23:99:00+00:40` is accepted too.

## Changes

The same case is added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "minute 60 is invalid with a numeric time-offset",
                "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
                "data": "23:60:00+00:01",
                "valid": false
            }
```
