### PR TITLE
test(time): add a high-precision second fraction as valid

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -271,6 +271,12 @@
                 "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
                 "data": "23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -271,6 +271,12 @@
                 "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
                 "data": "23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -268,6 +268,12 @@
                 "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
                 "data": "23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,12 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -271,6 +271,12 @@
                 "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
                 "data": "23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid time string with a 15 digit second fraction",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+                "data": "00:59:59.999999999999999Z",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
`00:59:59.999999999999999Z` is valid per the grammar and is rejected by ajv-formats 3.0.1 `full` - which is the default, since `addFormats(ajv)` installs `full` mode.

[RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6): `time-secfrac = "." 1*DIGIT`. There is no upper bound on the digit count. The second is 59, not 60, so the [section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) leap-second rules do not apply.

ajv-formats reads the seconds field with its fraction attached and coerces it to a number:

```js
const TIME = /^(\d\d):(\d\d):(\d\d(?:\.\d+)?)(z|([+-])(\d\d)(?::?(\d\d))?)?$/i
...
const sec = +matches[3]
...
if (hr <= 23 && min <= 59 && sec < 60) return true
```

`Number("59.999999999999999")` is exactly `60` in IEEE-754 - the ulp near 60 is 2^-47, so fifteen nines is the first length that rounds up. `sec < 60` then fails, the value falls into the branch below, that branch requires the offset-shifted hour to be 23, and at hour 00 it is not, so the value is rejected.

Fifteen digits is the mathematical minimum trigger, not an arbitrary choice - I walked the ladder and `00:59:59.99999999999999Z` (fourteen nines) is accepted by everything, including ajv. I put the control in the evidence set rather than the suite since it exercises the same branch on the passing side.

Two other implementations reject it for a different reason - a hard cap on the fraction length rather than float rounding:

| implementation | first rejected fraction length |
|---|---|
| fastjsonschema 2.21.2 | 7 digits (`\d{1,6}` in its `time` pattern) |
| @exodus/schemasafe 1.3.0 | 18 digits |
| ajv-formats 3.0.1 `full` | 15 nines specifically (float rounding, not a length cap) |

python-jsonschema 4.25.1, ajv-formats `fast`, sourcemeta/core and jsonschema-rs 0.49.2 all accept it.

The suite's longest existing fraction is `08:30:06.283185Z` at six digits, so nothing currently exercises the unbounded part of `1*DIGIT`. Flagging the digit count explicitly in case fifteen nines reads as contrived - high-precision sub-second timestamps are ordinary, and the failure is in the default configuration of the most-used JavaScript validator.

## Changes

The same case is added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "a valid time string with a 15 digit second fraction",
                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
                "data": "00:59:59.999999999999999Z",
                "valid": true
            }
```
