### PR TITLE
test(time): add second-fraction, component and boundary coverage

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -277,6 +277,30 @@
                 "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
                 "data": "00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -241,6 +241,30 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -277,6 +277,30 @@
                 "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
                 "data": "00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -241,6 +241,30 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -238,6 +238,30 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -274,6 +274,30 @@
                 "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
                 "data": "00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -277,6 +277,30 @@
                 "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
                 "data": "00:59:59.999999999999999Z",
                 "valid": true
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -241,6 +241,30 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
+            },
+            {
+                "description": "a second fraction with no digits",
+                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+                "data": "08:30:06.Z",
+                "valid": false
+            },
+            {
+                "description": "partial-time requires the seconds component",
+                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+                "data": "12:00Z",
+                "valid": false
+            },
+            {
+                "description": "a comma decimal separator with a time-offset",
+                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+                "data": "08:30:06,5Z",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace before a valid time",
+                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+                "data": " 08:30:06Z",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Four cases, each one justified by an implementation the current 41 string tests cannot distinguish from a correct one.

I checked distinctness mechanically rather than by eye: I built 32 wrong implementations of `full-time` - each one either a single dropped grammar branch, a single loosened bound, or a real shipping validator - and ran all of them over the 41 published string cases. Eighteen are caught by a test that already exists. Fourteen pass the entire file. Each case below kills at least one of those fourteen, and none of them kills only mutants that another case already covers.

**`08:30:06.Z` invalid** - [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) gives `time-secfrac = "." 1*DIGIT`, so the dot needs at least one digit after it. No existing test has a dot followed by a non-digit; the smallest fraction in the file is the two-digit `.52`. An implementation whose only defect is treating the fraction as `\d*` passes all 41.

**`12:00Z` invalid** - `partial-time = time-hour ":" time-minute ":" time-second [time-secfrac]`, so the seconds component is not optional. The three existing "too short" tests (`8:3:6Z`, `008:030:006Z`, `8:0030:6Z`) all keep three components and only vary digit counts; none of them drops a whole component. An implementation that makes the seconds group optional passes all 41. `java.time.OffsetTime.parse` accepts this shape, so any validator delegating to it would fail here.

**`08:30:06,5Z` invalid** - the decimal separator in `time-secfrac` is `"."`; ISO 8601's comma is not part of this profile. There is already a comma test, `01:01:01,1111`, but it cannot do this job: it has no time-offset, so an implementation that happily accepts the comma still rejects it for the missing offset and passes the file. Adding the offset is what makes the case actually test the separator.

**` 08:30:06Z` invalid** - no production of `full-time` emits whitespace. The existing whitespace-adjacent test is `08:30:06 PST`, where the space sits before a bogus offset rather than at the start, so an implementation that skips leading whitespace before parsing passes all 41.

None of the four breaks any of the ten JSON Schema validators I have wired, which is why they are here rather than in a breaker PR. Two of them do get corroboration from outside that set: `08:30:06.Z` is accepted by networknt's `TimeFormat` (its `DateTimeFormatterBuilder` is built with `parseLenient`), and `12:00Z` is accepted by luxon and by `java.time`.

Three candidates I dropped after measuring them, so the volume question does not come up:

- `08:30:06.5Z` (one-digit fraction) - kills nothing. The two-digit `.52` already exercises the same branch; there is no implementation that accepts two digits and rejects one.
- `23:59:59Z` (maximum non-leap second) - kills nothing. Every implementation I have either uses a `[0-5]\d` seconds class, which accepts 59, or a numeric bound, which also accepts 59.
- `08:30:06.123456789012Z` (long fraction) - dominated. It kills the two fraction-length caps, but so does the fifteen-digit case in the separate fraction-precision PR, which additionally breaks ajv-formats `full`. Keeping both would be the redundancy this check exists to avoid.

## Changes

The same cases are added to each of the four files the merged `-00:00` test ([#878](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/878)) touched - `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. `tests/latest` is a symlink to `draft2020-12`; draft4 and draft6 have no `time.json`, and draft3's `time` is a different format (`hh:mm:ss`, no offset), so none of those are touched.

```json
            {
                "description": "a second fraction with no digits",
                "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
                "data": "08:30:06.Z",
                "valid": false
            },
            {
                "description": "partial-time requires the seconds component",
                "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
                "data": "12:00Z",
                "valid": false
            },
            {
                "description": "a comma decimal separator with a time-offset",
                "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
                "data": "08:30:06,5Z",
                "valid": false
            },
            {
                "description": "leading whitespace before a valid time",
                "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
                "data": " 08:30:06Z",
                "valid": false
            }
```
