### PR TITLE
test(time): remove two duplicate leap-second test cases

### DIFF
--- a/tests/draft2019-09/optional/format/time.json
+++ b/tests/draft2019-09/optional/format/time.json
@@ -178,16 +178,6 @@
                 "valid": false
             },
             {
-                "description": "an invalid time string with invalid leap second (wrong hour)",
-                "data": "22:59:60Z",
-                "valid": false
-            },
-            {
-                "description": "an invalid time string with invalid leap second (wrong minute)",
-                "data": "23:58:60Z",
-                "valid": false
-            },
-            {
                 "description": "an invalid time string with invalid time numoffset hour",
                 "data": "01:02:03+24:00",
                 "valid": false

--- a/tests/draft2020-12/optional/format/time.json
+++ b/tests/draft2020-12/optional/format/time.json
@@ -178,16 +178,6 @@
                 "valid": false
             },
             {
-                "description": "an invalid time string with invalid leap second (wrong hour)",
-                "data": "22:59:60Z",
-                "valid": false
-            },
-            {
-                "description": "an invalid time string with invalid leap second (wrong minute)",
-                "data": "23:58:60Z",
-                "valid": false
-            },
-            {
                 "description": "an invalid time string with invalid time numoffset hour",
                 "data": "01:02:03+24:00",
                 "valid": false

--- a/tests/draft7/optional/format/time.json
+++ b/tests/draft7/optional/format/time.json
@@ -175,16 +175,6 @@
                 "valid": false
             },
             {
-                "description": "an invalid time string with invalid leap second (wrong hour)",
-                "data": "22:59:60Z",
-                "valid": false
-            },
-            {
-                "description": "an invalid time string with invalid leap second (wrong minute)",
-                "data": "23:58:60Z",
-                "valid": false
-            },
-            {
                 "description": "an invalid time string with invalid time numoffset hour",
                 "data": "01:02:03+24:00",
                 "valid": false

--- a/tests/v1/format/time.json
+++ b/tests/v1/format/time.json
@@ -178,16 +178,6 @@
                 "valid": false
             },
             {
-                "description": "an invalid time string with invalid leap second (wrong hour)",
-                "data": "22:59:60Z",
-                "valid": false
-            },
-            {
-                "description": "an invalid time string with invalid leap second (wrong minute)",
-                "data": "23:58:60Z",
-                "valid": false
-            },
-            {
                 "description": "an invalid time string with invalid time numoffset hour",
                 "data": "01:02:03+24:00",
                 "valid": false


### PR DESCRIPTION
`22:59:60Z` and `23:58:60Z` each appear twice in every copy of `time.json`, with different descriptions.

| data | description | added by |
|---|---|---|
| `22:59:60Z` | invalid leap second, Zulu (wrong hour) | [#482](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/482), 2021-04-23 |
| `22:59:60Z` | an invalid time string with invalid leap second (wrong hour) | [#481](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/481), 2021-04-22 |
| `23:58:60Z` | invalid leap second, Zulu (wrong minute) | #482 |
| `23:58:60Z` | an invalid time string with invalid leap second (wrong minute) | #481 |

The two PRs landed a day apart and neither noticed the other. Same data, same expected verdict, so the second copy of each cannot fail anything the first does not.

I removed the #481 pair rather than the #482 pair. The #482 cases sit inside the leap-second grid, which walks the offset kinds systematically - Zulu, zero offset, positive, negative - each with a valid case plus a wrong-hour and a wrong-minute case. Dropping two entries out of that grid would leave it asymmetric. The #481 pair sits in the later "an invalid time string with invalid ..." block next to `24:00:00Z`, `00:60:00Z` and `00:00:61Z`, where they are the only two entries that duplicate anything, so removing them leaves both structures intact.

This is removals only - no new cases - per the split you asked for on [#899](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/899).

## Changes

`47 -> 45` tests in each of `draft7`, `draft2019-09` and `draft2020-12` under `optional/format`, plus `tests/v1/format`. The removed entries:

```json
            {
                "description": "an invalid time string with invalid leap second (wrong hour)",
                "data": "22:59:60Z",
                "valid": false
            },
            {
                "description": "an invalid time string with invalid leap second (wrong minute)",
                "data": "23:58:60Z",
                "valid": false
            }
```
