### PR TITLE
test(iri-reference): add a leading zero in an embedded IPv4 as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an embedded IPv4 with a leading zero is invalid",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an embedded IPv4 with a leading zero is invalid",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -67,6 +67,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an embedded IPv4 with a leading zero is invalid",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an embedded IPv4 with a leading zero is invalid",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found the suite has no IPv6 host with an embedded IPv4 address in `iri-reference.json` - the one position where the leading-zero rule actually bites.

`irelative-part` reaches an authority through its `"//" iauthority ipath-abempty` branch, and `iauthority` takes its host from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), where the last 32 bits of an IPv6 literal may be written as an IPv4 address. `ls32 = ( h16 ":" h16 ) / IPv4address`, and none of `dec-octet`'s five alternatives (`DIGIT`, `%x31-39 DIGIT`, `"1" 2DIGIT`, `"2" %x30-34 DIGIT`, `"25" %x30-35`) matches `01` - a two-digit octet must start `%x31-39`. What makes this position different from a bare host is that there is no fallback: `ihost = IP-literal / IPv4address / ireg-name`, so a bare `//192.168.0.01/p` is perfectly valid because it matches `ireg-name`, but inside the brackets `ireg-name` is not an alternative and the leading zero has nowhere to go.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `//[::ffff:192.168.0.01]/p` - a network-path reference whose IPv6 host has an embedded IPv4 with a leading zero - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1 with the `[format]` extra**: FAILS (accepts it). `rfc3987 1.3.8` builds `dec_octet` as a single alternation whose `DIGIT` branch is not anchored within the octet, so a leading zero is absorbed. I swept this exhaustively - every octet string of one to three digits in each of the four positions, 4440 probes - and it diverges on exactly 440, every one a leading-zero octet.
2. **python-jsonschema 4.25.1 with the `[format-nongpl]` extra**: rejects it, but for an unrelated reason. That path uses `rfc3987-syntax 1.1.0`, whose grammar rejects every compressed IPv6 form, so it is right here by accident and wrong on valid addresses.
3. **sourcemeta/core `is_iri_reference`**: PASSES (rejects it). **Rust `iri-string` 0.7.12**: PASSES.
4. **ajv-formats 3.0.1**: not applicable. Its format table has no `iri-reference` key, so ajv treats the format as unknown.

This is the same mechanism as #1064, already merged for `iri`. Implementations route the two formats through separate entry points - `rfc3987` compiles a distinct pattern per rule, and sourcemeta/core has separate `is_iri` and `is_iri_reference` functions - so the merged test does not exercise this path.

## RFC References

- RFC 3987 section 2.2 (`irelative-part` and its iauthority branch): https://www.rfc-editor.org/rfc/rfc3987#section-2.2
- RFC 3986 section 3.2.2 (`ls32`, `IPv4address`, the five `dec-octet` alternatives): https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2

Reproduction commands and the iri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/iri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
