### PR TITLE
test(iri-reference): add a compressed IPv6 host as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -75,6 +75,11 @@
                 "description": "an embedded IPv4 with a leading zero is invalid",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -75,6 +75,11 @@
                 "description": "an embedded IPv4 with a leading zero is invalid",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -72,6 +72,11 @@
                 "description": "an embedded IPv4 with a leading zero is invalid",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -67,6 +67,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -75,6 +75,11 @@
                 "description": "an embedded IPv4 with a leading zero is invalid",
                 "data": "//[::ffff:192.168.0.01]/p",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
+                "data": "//[2001:db8::1]/p",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found `iri-reference.json` has no IPv6 host in any form, so the compressed alternatives of the address grammar are completely unexercised.

`irelative-part` includes `"//" iauthority ipath-abempty`, and `iauthority` takes `IP-literal` from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), whose `IPv6address` rule has nine alternatives. Seven of them begin with an optional group - `[ *4( h16 ":" ) h16 ] "::" ls32` and its neighbours - so the number of `h16` groups before the `::` may be anything from zero up to the stated maximum. `2001:db8::1` uses two of them. A checker that special-cases a leading `::` while still requiring a full-length prefix otherwise would pass `//[::1]/p` and fail this one, so the two-group form catches strictly more than the loopback form.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `//[2001:db8::1]/p` - a protocol-relative reference with a compressed IPv6 host - valid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1 with the `[format-nongpl]` extra**: FAILS (rejects it). That extra routes `is_iri_reference` to `rfc3987-syntax 1.1.0` instead of `rfc3987`, and its `syntax_rfc3987.lark` transcribes `IPv6address` with the optional prefix groups dropped and the repetition counts frozen - where RFC 3986 writes `[ *4( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32`, the grammar writes a fixed `h16 "::" h16 ":" ...`. An address then parses only when the group count on each side of the `::` matches one fixed shape exactly. Enumerating the shape space exhaustively - every `::` position crossed with every group count, 225 distinct shapes, 67 valid - it rejects 51 of the 67, including `::1`, `::`, `fe80::1` and `::ffff:192.168.0.1`.
2. **python-jsonschema 4.25.1 with the `[format]` extra**: PASSES (accepts it). `rfc3987 1.3.8` generates its pattern from the ABNF and keeps the optional groups.
3. **sourcemeta/core `is_iri_reference`**: PASSES. **Rust `iri-string` 0.7.12**: PASSES. **rfc3987-syntax2 1.3.2**: PASSES - the maintained fork of the same library has already restored the rule.
4. **ajv-formats 3.0.1**: not applicable. Its format table has no `iri-reference` key.

## RFC References

- RFC 3987 section 2.2 (`irelative-part` and its iauthority branch): https://www.rfc-editor.org/rfc/rfc3987#section-2.2
- RFC 3986 section 3.2.2 (the nine `IPv6address` alternatives and their optional prefix groups): https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2

Reproduction commands and the iri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/iri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
