### PR TITLE
test(iri-reference): add supplementary-plane ucschar and iprivate as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -80,6 +80,16 @@
                 "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
                 "data": "//[2001:db8::1]/p",
                 "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -70,6 +70,16 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -80,6 +80,16 @@
                 "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
                 "data": "//[2001:db8::1]/p",
                 "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -70,6 +70,16 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -67,6 +67,16 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -77,6 +77,16 @@
                 "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
                 "data": "//[2001:db8::1]/p",
                 "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -80,6 +80,16 @@
                 "description": "a valid protocol-relative IRI Reference with a compressed IPv6 host",
                 "data": "//[2001:db8::1]/p",
                 "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -70,6 +70,16 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a valid relative IRI Reference with a supplementary-plane character",
+                "data": "/âππ/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a query-only IRI Reference with a supplementary private-use char",
+                "data": "?q=󰀀",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found no test in `iri-reference.json` uses a character above the Basic Multilingual Plane, even though most of the `ucschar` rule lives up there.

`ucschar` has seventeen ranges and fourteen of them are supplementary (`%x10000-1FFFD` through `%xE1000-EFFFD`); `iprivate` has three and two are supplementary (`%xF0000-FFFFD`, `%x100000-10FFFD`). Every non-ASCII character in the current file is in the BMP. The two are separate productions on separate lines and a transcription can complete one and miss the other, so a checker with the supplementary `ucschar` ranges restored but `iprivate` still capped at U+F8FF passes the first test below and fails only the second. `iprivate` appears only in the `iquery` production, so a query-only reference is the smallest form that reaches it.

## Changes

- Added 2 test cases across draft7, draft2019-09, draft2020-12, and v1.
- `/âππ/𐌀` - a relative-path reference with U+10300 OLD ITALIC LETTER A, in `ucschar`'s `%x10000-1FFFD` - valid.
- `?q=<U+F0000>` - a query-only reference with a supplementary private-use character, in `iprivate`'s `%xF0000-FFFFD` - valid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1 with the `[format-nongpl]` extra**: FAILS (rejects both). That extra routes `is_iri_reference` to `rfc3987-syntax 1.1.0`, whose Lark grammar stops both rules at the end of the BMP - `ucschar` is written as `/[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]/` and `iprivate` as `/[\uE000-\uF8FF]/`. All fourteen supplementary `ucschar` ranges and both supplementary `iprivate` ranges are missing, so any character above U+FFFF is rejected wherever it appears.
2. **python-jsonschema 4.25.1 with the `[format]` extra**: PASSES (accepts both). `rfc3987 1.3.8` builds its character classes from the full ABNF.
3. **sourcemeta/core `is_iri_reference`**: PASSES. **Rust `iri-string` 0.7.12**: PASSES. **rfc3987-syntax2 1.3.2**: PASSES - the maintained fork has the complete ranges.
4. **ajv-formats 3.0.1**: not applicable. Its format table has no `iri-reference` key.

If the `iprivate` case seems too fine a distinction from the `ucschar` one I am happy to drop it and keep the first alone.

## RFC References

- RFC 3987 section 2.2 (the `ucschar` and `iprivate` ranges, and `iprivate` appearing only in `iquery`): https://www.rfc-editor.org/rfc/rfc3987#section-2.2

Reproduction commands and the iri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/iri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
