### PR TITLE
test(iri-reference): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -90,6 +90,11 @@
                 "description": "a query-only IRI Reference with a supplementary private-use char",
                 "data": "?q=󰀀",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -90,6 +90,11 @@
                 "description": "a query-only IRI Reference with a supplementary private-use char",
                 "data": "?q=󰀀",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -87,6 +87,11 @@
                 "description": "a query-only IRI Reference with a supplementary private-use char",
                 "data": "?q=󰀀",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -67,6 +67,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -90,6 +90,11 @@
                 "description": "a query-only IRI Reference with a supplementary private-use char",
                 "data": "?q=󰀀",
                 "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI Reference is invalid",
+                "data": "/âππ\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found no test in `iri-reference.json` covers a trailing control character, so a valid relative reference followed by a single line feed goes unchecked.

A line feed appears in no production of the section 2.2 grammar. `ucschar` starts at `%xA0`, `iunreserved` is ALPHA, DIGIT, `-`, `.`, `_`, `~` and `ucschar`, and neither `sub-delims` nor `pct-encoded` reaches it, so U+000A cannot appear anywhere in an IRI reference. The test below reuses `/âππ`, the existing valid relative reference in this file, so the terminator is the only difference.

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `/âππ\n` - the existing valid relative reference followed by a single line feed - invalid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1 with the `[format]` extra**: FAILS (accepts it). Its `is_iri_reference` calls `rfc3987.parse(instance, rule="IRI_reference")`; `parse` delegates to `match` at `rfc3987.py` line 460, and `match` at line 424 is `get_compiled_pattern('^%%(%s)s$' % rule).match(string)`. The anchor is `$`, not `\Z`, and with default flags Python's `$` matches at the end of the string or immediately before a single trailing newline. The leak is narrow - a doubled LF, an LF in the middle, a CR, a CRLF, and a trailing space, tab, vertical tab or form feed are all correctly rejected. Because the same construction backs all four of that library's rules, the same input is accepted for `iri`, `uri` and `uri-reference` too.
2. **python-jsonschema 4.25.1 with the `[format-nongpl]` extra**: PASSES (rejects it). That path uses a Lark parser, which requires a full-input match.
3. **sourcemeta/core `is_iri_reference`**: PASSES. **Rust `iri-string` 0.7.12**: PASSES.
4. **ajv-formats 3.0.1**: not applicable. Its format table has no `iri-reference` key.

This is the same anchor class as the merged `iri` test #1067, the `ipv4` one in #840, `duration` #982 and `hostname` #1023.

## RFC References

- RFC 3987 section 2.2 (the IRI reference grammar; no production admits U+000A): https://www.rfc-editor.org/rfc/rfc3987#section-2.2

Reproduction commands and the iri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/iri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
