### PR TITLE
test(iri-reference): add an uppercase IPvFuture version letter as valid

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -67,6 +67,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -70,6 +70,11 @@
                 "description": "an invalid IRI fragment",
                 "data": "#ƒräg\\mênt",
                 "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "//[V1.fe]/p",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3987 section 2.2](https://www.rfc-editor.org/rfc/rfc3987#section-2.2) and found `iri-reference.json` has no IPvFuture host test at all, in either letter case.

`irelative-part` reaches an authority through its `//` branch, and `iauthority` takes `IP-literal` from [RFC 3986 section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2): `IP-literal = "[" ( IPv6address / IPvFuture ) "]"` and `IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )`. [RFC 5234 section 2.3](https://www.rfc-editor.org/rfc/rfc5234#section-2.3) says ABNF "terminal values are case-insensitive" and gives the worked example that `%d97` and `%d65` both satisfy the literal `"a"`, so the `"v"` matches `V`. RFC 3986 section 3.2.2 says the same thing in prose for this exact rule - it describes "an IP literal that starts with `v` (case-insensitive)" - and adds that "the host subcomponent is case-insensitive".

## Changes

- Added 1 test case across draft7, draft2019-09, draft2020-12, and v1.
- `//[V1.fe]/p` - a network-path reference whose IPvFuture host uses an uppercase version letter - valid.

## Ecosystem Impact

1. **python-jsonschema 4.25.1 with the `[format]` extra**: FAILS (rejects it). `rfc3987 1.3.8` hardcodes a lowercase letter in a generated pattern with no case-insensitive flag - `('IPvFuture', r"v{hexdig}+\.(?:{unreserved}|{sub_delims}|:)+")`. `//[v1.fe]/p` is accepted, so the version letter's case is the only difference.
2. **python-jsonschema 4.25.1 with the `[format-nongpl]` extra**: FAILS (rejects it). Different library, same mistake written a different way: `rfc3987-syntax`'s grammar has `ipvfuture: "v" hexdig+ "." (unreserved | sub_delims | ":")+`, and Lark string literals are case-sensitive by default.
3. **rfc3987-syntax2 1.3.2**: FAILS (rejects it). The maintained fork carries the rule across unchanged, so all three Python libraries behind this format get it wrong.
4. **sourcemeta/core `is_iri_reference`**: PASSES (accepts it). Its parser tests the letter explicitly as `'v' || 'V'`. **Rust `iri-string` 0.7.12**: PASSES.
5. **ajv-formats 3.0.1**: not applicable. Its format table has no `iri-reference` key.

## RFC References

- RFC 3987 section 2.2 (`irelative-part` and its iauthority branch): https://www.rfc-editor.org/rfc/rfc3987#section-2.2
- RFC 3986 section 3.2.2 (`IPvFuture`, and the host subcomponent being case-insensitive): https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
- RFC 5234 section 2.3 (ABNF terminal values are case-insensitive): https://www.rfc-editor.org/rfc/rfc5234#section-2.3

Reproduction commands and the iri-reference cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/iri-reference.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
