### PR TITLE
test(regex): reindent the ecmascript-regex files to four spaces

### DIFF
--- a/tests/draft2020-12/optional/format/ecmascript-regex.json
+++ b/tests/draft2020-12/optional/format/ecmascript-regex.json
@@ -1,116 +1,116 @@
 [
-  {
-    "description": "\\a is not an ECMA 262 control escape",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "when used as a pattern",
-        "data": "\\a",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "Python-specific regular expression syntax is not valid ECMA 262",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "Python named group (?P<name>...) is not ECMA 262",
-        "data": "(?P<name>x)",
-        "valid": false
-      },
-      {
-        "description": "Python named backreference (?P=name) is not ECMA 262",
-        "data": "(?P<n>a)(?P=n)",
-        "valid": false
-      },
-      {
-        "description": "inline comment group (?#...) is not ECMA 262",
-        "data": "(?#comment)a",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "global inline flag groups are not valid ECMA 262",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "a single global inline flag (?i)",
-        "data": "(?i)abc",
-        "valid": false
-      },
-      {
-        "description": "multiple global inline flags (?ims)",
-        "data": "(?ims)abc",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 named groups and backreferences are valid",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "an ECMA 262 named group (?<name>...)",
-        "data": "(?<name>x)",
-        "valid": true
-      },
-      {
-        "description": "an ECMA 262 named backreference \\k<name>",
-        "data": "(?<n>a)\\k<n>",
-        "valid": true
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 lookbehind is valid, including variable width",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "a variable-width lookbehind (ES2018)",
-        "data": "(?<=a+)b",
-        "valid": true
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 character classes and escapes",
-    "schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "format": "regex"
-    },
-    "tests": [
-      {
-        "description": "an empty character class is valid ECMA 262",
-        "data": "[]",
-        "valid": true
-      },
-      {
-        "description": "a negated empty character class is valid ECMA 262",
-        "data": "[^]",
-        "valid": true
-      },
-      {
-        "description": "a control escape \\cA is valid ECMA 262",
-        "data": "\\cA",
-        "valid": true
-      }
-    ]
-  }
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
 ]

--- a/tests/v1/format/ecmascript-regex.json
+++ b/tests/v1/format/ecmascript-regex.json
@@ -1,116 +1,116 @@
 [
-  {
-    "description": "\\a is not an ECMA 262 control escape",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "when used as a pattern",
-        "data": "\\a",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "Python-specific regular expression syntax is not valid ECMA 262",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "Python named group (?P<name>...) is not ECMA 262",
-        "data": "(?P<name>x)",
-        "valid": false
-      },
-      {
-        "description": "Python named backreference (?P=name) is not ECMA 262",
-        "data": "(?P<n>a)(?P=n)",
-        "valid": false
-      },
-      {
-        "description": "inline comment group (?#...) is not ECMA 262",
-        "data": "(?#comment)a",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "global inline flag groups are not valid ECMA 262",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "a single global inline flag (?i)",
-        "data": "(?i)abc",
-        "valid": false
-      },
-      {
-        "description": "multiple global inline flags (?ims)",
-        "data": "(?ims)abc",
-        "valid": false
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 named groups and backreferences are valid",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "an ECMA 262 named group (?<name>...)",
-        "data": "(?<name>x)",
-        "valid": true
-      },
-      {
-        "description": "an ECMA 262 named backreference \\k<name>",
-        "data": "(?<n>a)\\k<n>",
-        "valid": true
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 lookbehind is valid, including variable width",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
     },
-    "tests": [
-      {
-        "description": "a variable-width lookbehind (ES2018)",
-        "data": "(?<=a+)b",
-        "valid": true
-      }
-    ]
-  },
-  {
-    "description": "ECMA 262 character classes and escapes",
-    "schema": {
-      "$schema": "https://json-schema.org/v1",
-      "format": "regex"
-    },
-    "tests": [
-      {
-        "description": "an empty character class is valid ECMA 262",
-        "data": "[]",
-        "valid": true
-      },
-      {
-        "description": "a negated empty character class is valid ECMA 262",
-        "data": "[^]",
-        "valid": true
-      },
-      {
-        "description": "a control escape \\cA is valid ECMA 262",
-        "data": "\\cA",
-        "valid": true
-      }
-    ]
-  }
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
 ]


### PR DESCRIPTION
Closes #1130 for the format tests.

I went through every file under `tests/*/optional/format/` and `tests/v1/format/` (130 files) checking the two things named in the issue - four-space indentation, and objects/arrays not collapsed onto one line.

## What I found

Only two files use two-space indentation instead of four:

- `tests/draft2020-12/optional/format/ecmascript-regex.json`
- `tests/v1/format/ecmascript-regex.json`

(`tests/latest/optional/format/ecmascript-regex.json` is the same file - `tests/latest` is a symlink to `draft2020-12`.)

Everything else in the format tree is already four-space, including the draft7 and draft2019-09 copies of `ecmascript-regex.json`.

## What I did not change

The collapsed `"schema": { "format": "..." }` line is the existing convention in these files rather than an inconsistency - all 19 format files in `draft7/optional/format` use it, and the same holds across the other draft directories. The 2020-12 and v1 files expand that block only because they carry a `$schema` key as well. I left all of that alone; changing it would be a much larger and separate discussion.

## How I checked

The reindent is a pure whitespace transformation - each line's leading spaces doubled, nothing else touched. I parsed both files before and after and asserted the resulting objects are identical, so no content, ordering or escaping changed. `bin/jsonschema_suite check` passes (2287 test cases, 11098 tests).

The two-space style predates the recent format work - both files were created that way (2024 and 2025), and my earlier additions in #998 followed the style already in the file rather than the repo convention. This brings them in line.
