### PR TITLE
test(format/date-time): add leap year cases from the date file

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -185,6 +185,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -170,6 +170,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -185,6 +185,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -170,6 +170,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -72,6 +72,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -57,6 +57,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -167,6 +167,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -182,6 +182,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -167,6 +167,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -182,6 +182,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -167,6 +167,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -182,6 +182,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -185,6 +185,41 @@
                 "description": "an invalid minute in date-time string, with a numeric offset",
                 "data": "1985-04-12T23:60:00+00:01",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -170,6 +170,41 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "a valid date-time string with 28 days in February (normal)",
+                "data": "2021-02-28T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string with 30 days in February (leap)",
+                "data": "2020-02-30T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 0100 is not a leap year",
+                "data": "0100-02-29T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "century year 0400 is a leap year",
+                "data": "0400-02-29T00:00:00Z",
+                "valid": true
+            },
+            {
+                "description": "century year 2100 is not a leap year",
+                "data": "2100-02-29T00:00:00Z",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) and found that `date-time.json` has no February or leap-year case at all, while `date.json` has seven. This is what @karenetheridge reported in #1100.

Section 5.7's table gives `date-mday` a maximum of 28 for "February, normal" and 29 for "February, leap year", and Appendix C gives the leap-year algorithm, so the rule applies to the `full-date` half of `date-time` exactly as it applies to `date`. Nothing in the current `date-time.json` exercises it: the only February case in the file is `1990-02-31T15:59:59.123-08:00`, and 31 is out of range in February of every year, so an implementation with no leap-year logic at all still passes it. That is the gap - a separate `date-time` code path can be missing the century rule and the file will not notice.

## Changes

- Added 7 test cases across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `2021-02-28T00:00:00Z` - 28 days in a normal February, valid.
- `2020-02-30T00:00:00Z` - 30 days in February of a leap year, invalid.
- `2021-02-29T00:00:00Z` - 2021 is not a leap year, invalid.
- `2020-02-29T00:00:00Z` - 2020 is a leap year, valid.
- `0100-02-29T00:00:00Z` - century year 0100 is not a leap year, invalid.
- `0400-02-29T00:00:00Z` - century year 0400 is a leap year, valid.
- `2100-02-29T00:00:00Z` - century year 2100 is not a leap year, invalid.

These are the seven February cases already in `date.json`, with `T00:00:00Z` appended so the only thing under test is the date half. Keeping the same dates and the same descriptions means the two files can be diffed against each other.

Three of the seven carry the discriminating power: `2020-02-29` catches an implementation with no leap-year rule, `2100-02-29` and `0100-02-29` catch one that tests only `year % 4`, and `0400-02-29` catches one that has the century rule but forgot the 400-year exception. `2021-02-28` and `2020-02-30` are the controls that make the set readable next to `date.json`.

## Ecosystem Impact

1. **sourcemeta/core 1d3331018**: PASSES (correct on all seven). `is_rfc3339_fulldate` calls `max_day_in_month(month, year)`, which consults `is_leap_year` with the full Gregorian rule.
2. **ajv-formats 3.0.1 full**: PASSES (correct on all seven). `dist/formats.js` `date()` computes `month === 2 && isLeapYear(year) ? 29 : DAYS[month]`.
3. **python-jsonschema 4.25.1 with `[format]`**: PASSES (correct on all seven). It delegates to `rfc3339-validator`, which calls `calendar.monthrange(year, month)`.
4. **JSON::Schema::Modern 0.641**: FAILS (accepts all four invalid cases). This is the implementation #1100 was filed from and the behaviour the issue describes - the `date` path has the leap-year logic and the `date-time` path does not. I measured it at draft-07, 2019-09 and 2020-12, with `$schema` supplied both by the dialect command and in the schema body; the result is the same in all six combinations.
5. **ajv-formats 3.0.1 fast**: FAILS (accepts all four invalid cases). Its fast `date-time` pattern is a pure character-class regex with no day-maximum table.
6. **ata-validator 1.2.2**: FAILS (accepts all four invalid cases). Its `date-time` check validates field shape and ranges but never bounds the day by month and year.
7. **tdegrunt/jsonschema 1.5.0**: FAILS (accepts all four invalid cases). Same cause - a regex with a fixed `0[1-9]|[12]\d|3[01]` day class and no calendar context.
8. **z-schema 6.0.2**: FAILS (accepts all four invalid cases). `FormatValidators.js` splits the string and range-checks the time half only.
9. **api7/jsonschema 0.9.13-0 (Lua)**: FAILS (accepts all four invalid cases). Its format table is regex-only, so the day class has no month or year context.
10. **fastjsonschema 2.21.2**: FAILS (accepts all four invalid cases). Same regex-only day class.
11. **vscode-json-languageservice 5.7.2**: FAILS (accepts all four invalid cases). Same cause.

I checked the seven against 32 distinct asserting implementations - 12 wired directly and 20 reached through the Bowtie images over the raw JSON-line protocol. Every implementation that gets them right handles the day maximum with month and year context; every one that gets them wrong uses a fixed day character class.

## RFC References

- RFC 3339 section 5.7 (the `date-mday` maximum table, including February normal and leap): https://www.rfc-editor.org/rfc/rfc3339#section-5.7
- RFC 3339 Appendix C (the leap-year algorithm): https://www.rfc-editor.org/rfc/rfc3339#appendix-C
- RFC 3339 section 5.6 (`date-time = full-date "T" full-time`): https://www.rfc-editor.org/rfc/rfc3339#section-5.6

Reproduction commands and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Closes #1100

Related: [#965](https://github.com/json-schema-org/community/issues/965)
