### PR TITLE
test(format/date-time): add an invalid minute with a numeric offset

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -170,6 +170,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -180,6 +180,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -170,6 +170,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -180,6 +180,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -57,6 +57,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -67,6 +67,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -167,6 +167,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -177,6 +177,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -167,6 +167,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -177,6 +177,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -167,6 +167,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -177,6 +177,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -170,6 +170,11 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -180,6 +180,11 @@
                 "description": "an invalid date-time string with trailing content after the offset",
                 "data": "1985-04-12T23:20:50Ztail",
                 "valid": false
+            },
+            {
+                "description": "an invalid minute in date-time string, with a numeric offset",
+                "data": "1985-04-12T23:60:00+00:01",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) and found that the file's only invalid-minute case uses `Z`, which is the one form the ajv-formats defect cannot reach.

Section 5.6 gives `time-minute = 2DIGIT ; 00-59`, so `60` is out of range whatever offset follows. The existing case is `1990-12-31T15:60:00Z`, and every validator I ran rejects that one, including ajv-formats. The difference is the offset: with `Z` there is no offset arithmetic, and with `+00:01` there is, and ajv-formats' leap-second fallback runs the arithmetic without re-checking the minute it already skipped.

## Changes

- Added 1 test case across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `1985-04-12T23:60:00+00:01` - minute 60 with a one-minute positive offset, invalid.

## Ecosystem Impact

1. **ajv-formats 3.0.1 full**: FAILS (accepts it). `dist/formats.js` `getTime()` range-checks the fields in one place - `if (hr <= 23 && min <= 59 && sec < 60) return true;` - and that line fails when `min > 59`, so control falls into the leap-second branch below it. That branch computes `utcMin = min - tzM * tzSign` and `utcHr = hr - tzH * tzSign - (utcMin < 0 ? 1 : 0)`, then returns `(utcHr === 23 || utcHr === -1) && (utcMin === 59 || utcMin === -1) && sec < 61`. It never looks at `min` again, so `min = 60` with `tzM = 1` gives a shifted minute of 59 and the string is accepted. The seconds value is `00` here, so no leap second is involved despite the branch being labelled for one.
2. **ajv-formats 3.0.1 fast**: PASSES (rejects it). Its fast pattern has a fixed `[0-5]\d` minute class.
3. **sourcemeta/core 1d3331018**: PASSES (rejects it). `is_rfc3339_fulltime` bounds the minute before any offset arithmetic runs.
4. **python-jsonschema 4.25.1 with `[format]`**: PASSES (rejects it). Its delegate `rfc3339-validator` uses `(?:[0-5]\d)` for the minute.
5. **@cfworker/json-schema 4.1.1**: PASSES (rejects it). It carries its own date-time regex rather than ajv's.
6. **@exodus/schemasafe 1.3.0**: PASSES (rejects it).
7. **santhosh-tekuri/jsonschema v6.0.2**: PASSES (rejects it).
8. **boon 0.6.1**: PASSES (rejects it).
9. **jsonschema-rs 0.47.0**: PASSES (rejects it).
10. **is-my-json-valid 2.20.6**: FAILS (accepts it), but it has no minute range check at all, so it already fails the existing `1990-12-31T15:60:00Z` case and this adds nothing for it.

I found the boundary by enumerating the whole time-of-day and offset space rather than sampling it - every `hh` and `mm` from `00` to `99`, seconds in `{00, 60, 61}`, against `Z` and every `+/-HH:MM` from `00:00` to `23:59`, which is 86,430,000 decisions. ajv-formats full accepts 6,638 strings that RFC 3339 forbids and wrongly rejects none; they fall into eight shapes and every one needs a **positive** offset, which is why `Z` and every negative offset are handled correctly. `format: time` behaves identically, since `getDateTime` delegates to `getTime`.

I also ran the 40 Bowtie images over the raw JSON-line protocol, probing every dialect; 20 assert `format` for date-time and none of them accepts this input. Counting those plus the directly-wired columns, ajv-formats full is the only one of 32 distinct asserting implementations that takes it.

## RFC References

- RFC 3339 section 5.6 (`time-minute = 2DIGIT ; 00-59`): https://www.rfc-editor.org/rfc/rfc3339#section-5.6
- RFC 3339 section 5.7 (the leap-second rule the accepting branch exists for): https://www.rfc-editor.org/rfc/rfc3339#section-5.7

Reproduction commands and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
