### PR TITLE
test(format/date-time): add a missing seconds field and trailing content after the offset

### DIFF
--- a/tests/draft2019-09/optional/format/date-time.json
+++ b/tests/draft2019-09/optional/format/date-time.json
@@ -170,6 +170,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/date-time.json
+++ b/tests/draft2020-12/optional/format/date-time.json
@@ -170,6 +170,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/draft3/optional/format/date-time.json
+++ b/tests/draft3/optional/format/date-time.json
@@ -57,6 +57,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/date-time.json
+++ b/tests/draft4/optional/format/date-time.json
@@ -167,6 +167,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/date-time.json
+++ b/tests/draft6/optional/format/date-time.json
@@ -167,6 +167,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/date-time.json
+++ b/tests/draft7/optional/format/date-time.json
@@ -167,6 +167,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/date-time.json
+++ b/tests/v1/format/date-time.json
@@ -170,6 +170,16 @@
                 "description": "a trailing newline is invalid",
                 "data": "1985-04-12T23:20:50Z\n",
                 "valid": false
+            },
+            {
+                "description": "an invalid date-time string without seconds",
+                "data": "1985-04-12T23:20Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string with trailing content after the offset",
+                "data": "1985-04-12T23:20:50Ztail",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Following the methodology I used for ipv4 and uuid, I read [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) and found two productions with no case in the file: a missing `time-second`, and content after the `time-offset`.

The grammar is `partial-time = time-hour ":" time-minute ":" time-second [time-secfrac]`, `full-time = partial-time time-offset` and `date-time = full-date "T" full-time`. `time-second` sits outside the optional group and `time-offset` is not optional, so a seconds-less string and a string with anything after the offset are both invalid. The nearest existing cases do not reach either: `1963-06-1T08:30:06.283185Z` is a short day field, not a missing seconds field, and the file has no trailing-content case whose first character is a `t`.

## Changes

- Added 2 test cases across draft3, draft4, draft6, draft7, draft2019-09, draft2020-12, and v1.
- `1985-04-12T23:20Z` - the seconds field omitted, invalid.
- `1985-04-12T23:20:50Ztail` - trailing text after the offset beginning with a `t`, invalid.

I checked each one against a wrong implementation rather than assuming it catches something. For every candidate I wrote a validator that is correct except for a single rule, confirmed it passes all 27 string cases now in the file, and kept the candidate only if it fails that validator. Nine candidates survived that filter; the other seven are already asserted in open PRs, so these two are what is left.

## Ecosystem Impact

1. **jsonschemafriend 0.12.5**: FAILS on `1985-04-12T23:20Z` (accepts it). It treats the seconds field as optional, which is the ISO 8601 reduced-precision form rather than the RFC 3339 grammar.
2. **io.openapiprocessor.json-schema-validator 2026.1**: FAILS on `1985-04-12T23:20Z` (accepts it). Same cause.
3. **com.networknt:json-schema-validator 3.0.1**: FAILS on `1985-04-12T23:20:50Ztail` (accepts it). It routes date-time through `com.ethlo.time:itu`, whose `ITU.parseDateTime(String)` parses a fixed-width prefix and never requires end-of-input, so anything after a complete date-time is ignored. A leading space is still rejected, which is why the existing trailing-whitespace cases do not catch it.
4. **z-schema 6.0.2**: FAILS on `1985-04-12T23:20:50Ztail` (accepts it), by a different route to the same defect. `src/FormatValidators.js` does `var s = dateTime.toLowerCase().split("t");` and then reads only `s[0]` and `s[1]`, so a third part is discarded. Trailing content without a `t` is caught, which is why `...Zjunk` is rejected and `...Ztail` is not.
5. **sourcemeta/core 1d3331018**: PASSES on both (rejects both). `is_rfc3339_fulltime` requires the seconds field and ends with `if (position != size) return false;`.
6. **ajv-formats 3.0.1 full and fast**: PASSES on both (rejects both).
7. **python-jsonschema 4.25.1 with `[format]`**: PASSES on both (rejects both). Its delegate anchors the whole string.
8. **santhosh-tekuri/jsonschema v6.0.2, boon 0.6.1, jsonschema-rs 0.47.0**: PASS on both (reject both). These three are the only implementations that are 0-divergence across all 72 probes I sent through the Bowtie images.

I ran the 40 Bowtie images over the raw JSON-line protocol, probing every dialect, to establish which implementations assert `format` at all; 20 of them do, and the four failures above are among them.

## RFC References

- RFC 3339 section 5.6 (`partial-time`, `full-time` and `date-time`): https://www.rfc-editor.org/rfc/rfc3339#section-5.6

Reproduction commands and the date-time cross-implementation matrix are in my evidence repo: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/date-time.md

Related: [#965](https://github.com/json-schema-org/community/issues/965)
