### PR TITLE
fix(dump_remotes): refuse to operate on the repository's remotes/ dir…

### DIFF
--- a/bin/jsonschema_suite
+++ b/bin/jsonschema_suite
@@ -638,6 +638,13 @@ def main(arguments):
         }
         json.dump(remotes, sys.stdout, indent=4, sort_keys=True)
     elif arguments.command == "dump_remotes":
+        if os.path.abspath(arguments.out_dir) == os.path.abspath(REMOTES_DIR):
+            print(
+                "Refusing to operate on the repository's remotes/ directory. "
+                "Pass a different --out-dir.",
+            )
+            sys.exit(1)
+
         if arguments.update:
             shutil.rmtree(arguments.out_dir, ignore_errors=True)
 


### PR DESCRIPTION
Fixes #1152

`dump_remotes` defaults `--out-dir` to the in-repo `remotes/` directory,
so running:

    bin/jsonschema_suite dump_remotes --update

would `shutil.rmtree()` that directory and then crash with
`FileNotFoundError` when `copytree()` was handed its own deleted source —
destroying the working tree's remotes in the process.

This adds a guard so any invocation targeting `REMOTES_DIR` exits with a
clear message instead. Explicit `--out-dir` invocations (both fresh dumps
and `--update`) behave exactly as before.

Verified:
- `bin/jsonschema_suite dump_remotes --update` now exits 1 and leaves `remotes/` intact
- `dump_remotes --out-dir <dir>` and `--update --out-dir <dir>` still work
- `python3 bin/jsonschema_suite check` passes