### PR TITLE
test(email): add the RFC 5321 Mailbox cases to the remaining drafts

### DIFF
--- a/tests/draft2019-09/optional/format/email.json
+++ b/tests/draft2019-09/optional/format/email.json
@@ -62,6 +62,31 @@
                 "valid": true
             },
             {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
                 "description": "dot before local part is not valid",
                 "data": ".test@example.com",
                 "valid": false
@@ -79,6 +104,16 @@
             {
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
             },
             {

--- a/tests/draft4/optional/format/email.json
+++ b/tests/draft4/optional/format/email.json
@@ -59,6 +59,31 @@
                 "valid": true
             },
             {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
                 "description": "dot before local part is not valid",
                 "data": ".test@example.com",
                 "valid": false
@@ -76,6 +101,16 @@
             {
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
             },
             {

--- a/tests/draft6/optional/format/email.json
+++ b/tests/draft6/optional/format/email.json
@@ -59,6 +59,31 @@
                 "valid": true
             },
             {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
                 "description": "dot before local part is not valid",
                 "data": ".test@example.com",
                 "valid": false
@@ -76,6 +101,16 @@
             {
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
             },
             {

--- a/tests/draft7/optional/format/email.json
+++ b/tests/draft7/optional/format/email.json
@@ -59,6 +59,31 @@
                 "valid": true
             },
             {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
                 "description": "dot before local part is not valid",
                 "data": ".test@example.com",
                 "valid": false
@@ -76,6 +101,16 @@
             {
                 "description": "two subsequent dots inside local part are not valid",
                 "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
                 "valid": false
             },
             {


### PR DESCRIPTION
Closes #1162.

The seven cases added in 995932c (#467) only landed in `draft2020-12`. `draft2019-09`, `draft7`, `draft6` and `draft4` have been missing them ever since:

| instance | expected |
| --- | --- |
| `"joe bloggs"@example.com` | valid |
| `"joe..bloggs"@example.com` | valid |
| `"joe@bloggs"@example.com` | valid |
| `joe.bloggs@[127.0.0.1]` | valid |
| `joe.bloggs@[IPv6:::1]` | valid |
| `joe.bloggs@invalid=domain.com` | invalid |
| `joe.bloggs@[127.0.0.300]` | invalid |

None of them depend on anything specific to `draft2020-12`. `format: "email"` has denoted an [RFC 5321 `Mailbox`](https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.2) since draft4, and each case follows directly from that grammar:

- `qtextSMTP` is `%d32-33 / %d35-91 / %d93-126`, so a `Quoted-string` local part may contain SP, consecutive `.`, and `@` — covering the three quoted cases.
- `Mailbox = Local-part "@" ( Domain / address-literal )`, and `address-literal` admits both `IPv4-address-literal` and `IPv6-address-literal`.
- `Domain = sub-domain *("." sub-domain)` with `sub-domain = Let-dig [Ldh-str]`, so `=` cannot occur in a domain.
- `Snum = 1*3DIGIT ; representing a decimal integer value in the range 0 through 255`, so `300` is not a valid final octet.

Per CONTRIBUTING — *"When adding test cases, they should be added to all past (and future) versions of the specification which they apply to"* — they belong in every draft that has the file.

The cases are inserted at their `draft2020-12` positions, so after this change `optional/format/email.json` is identical across draft4 → draft2020-12 and `v1` apart from the `schema` object. `v1` already had all seven.

`draft3` is deliberately untouched: its `email.json` is a much older 11-test file that has diverged from draft4+ in far more than these seven cases, and reconciling it is a separate change.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).
