### PR TITLE
test(hostname): cover the RFC 1034 overall name length in draft4 and draft6

### DIFF
--- a/tests/draft4/optional/format/hostname.json
+++ b/tests/draft4/optional/format/hostname.json
@@ -89,6 +89,11 @@
                 "valid": false
             },
             {
+                "description": "exceeds maximum overall length (256)",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": false
+            },
+            {
                 "description": "maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
                 "valid": true

--- a/tests/draft6/optional/format/hostname.json
+++ b/tests/draft6/optional/format/hostname.json
@@ -89,6 +89,11 @@
                 "valid": false
             },
             {
+                "description": "exceeds maximum overall length (256)",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": false
+            },
+            {
                 "description": "maximum label length",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
                 "valid": true


### PR DESCRIPTION
Closes #1166.

`tests/draft4/optional/format/hostname.json` and `tests/draft6/optional/format/hostname.json` test the 63-octet **label** limit but never the 255-octet **total name** limit. The longest instance in either file is 91 octets, so nothing exercises the rule. draft7, draft2019-09, draft2020-12 and `v1` all cover it.

### Why it applies

[RFC 1034 §3.1](https://www.rfc-editor.org/rfc/rfc1034.html#section-3.1) states both limits:

> Each node has a label, which is zero to 63 octets in length.

> To simplify implementations, the total number of octets that represent a domain name (i.e., the sum of all label octets and label lengths) is limited to 255.

draft4 and draft6 define `hostname` as *"a valid representation for an Internet host name, as defined by RFC 1034, section 3.1"* — the same base draft7 builds on. They inherit the 255-octet rule exactly as they inherit the 63-octet one they already test.

The instance is copied verbatim from draft7 and inserted at the position it occupies there, immediately before the label-length pair. Its four labels are 63 octets each, so every label is legal and the 259-octet total is the only thing out of range — it isolates the rule cleanly.

### Deliberately not changed

The remaining divergence between draft4/draft6 and draft7's `hostname.json` is correct as it stands:

- The `validation of A-label (punycode) host names` case belongs only to draft7+. The Punycode clause — *"including host names produced using the Punycode algorithm specified in RFC 5891, section 4.4"* — was introduced in draft7; draft4 and draft6 cite RFC 1034 alone.
- `1host` (*single label starting with digit*) stays absent from draft4/draft6, per the reasoning in 9265a4f.
- draft7's `a--b.com` (*consecutive hyphens inside a label*) is already covered in draft4/draft6 by `ab--cd.example`.

`draft3` is out of scope: its format is spelled `host-name` and draft-03 defines it only as *"This SHOULD be a host-name"*, with no RFC citation.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).