### PR TITLE
test(uri): add a trailing newline as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uri.json
+++ b/tests/draft2019-09/optional/format/uri.json
@@ -237,6 +237,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri.json
+++ b/tests/draft2020-12/optional/format/uri.json
@@ -237,6 +237,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft4/optional/format/uri.json
+++ b/tests/draft4/optional/format/uri.json
@@ -234,6 +234,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft6/optional/format/uri.json
+++ b/tests/draft6/optional/format/uri.json
@@ -234,6 +234,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri.json
+++ b/tests/draft7/optional/format/uri.json
@@ -234,6 +234,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri.json
+++ b/tests/v1/format/uri.json
@@ -237,6 +237,11 @@
                 "description": "square brackets are not allowed in a path segment",
                 "data": "http:/[::1]",
                 "valid": false
+            },
+            {
+                "description": "a trailing newline after a valid URI is invalid",
+                "data": "http://foo.bar/\n",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Closes #1168.

`optional/format/uri.json` never asserted that a trailing line feed is invalid, in any of the drafts that have the file, while the three sibling reference formats assert it in every draft that has them:

| format | draft4 | draft6 | draft7 | 2019-09 | 2020-12 | v1 |
| --- | --- | --- | --- | --- | --- | --- |
| `uri-reference` | – | ✅ | ✅ | ✅ | ✅ | ✅ |
| `iri` | – | – | ✅ | ✅ | ✅ | ✅ |
| `iri-reference` | – | – | ✅ | ✅ | ✅ | ✅ |
| **`uri`** (before this) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

### Why it applies

[RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2) builds every URI production from `unreserved`, `pct-encoded`, `gen-delims` and `sub-delims`:

```
unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
```

LF (`%x0A`) appears in none of them, so `"http://foo.bar/\n"` is not a URI.

It is also squarely the kind of case this file already covers: `uri.json` has a run of ten tests rejecting individual characters excluded on the same grounds — `\`, `"`, `<>`, `{}`, `^`, `` ` ``, `|` and SPACE. LF was the conspicuous omission, and it is the one most likely to slip past a real implementation, since reading a URI from a file or stream without stripping the terminator is a common way to get one wrong, and a regex anchored with `$` rather than `\z` will accept it.

The description mirrors `iri.json`'s existing counterpart (*a trailing newline after a valid IRI is invalid*) so the two read as a pair.

### Scope

draft4, draft6, draft7, draft2019-09, draft2020-12 and v1 — six files, appended at the end of the tests array in each. Those files are byte-identical apart from the `schema` object, so the change is the same in all six.

`draft3` is left alone: its `uri.json` has only four tests and has diverged from draft4+ far more broadly, the same situation as its `email.json` and `host-name.json`.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).