### PR TITLE
test(uuid): add a brace-wrapped UUID as invalid

### DIFF
--- a/tests/draft2019-09/optional/format/uuid.json
+++ b/tests/draft2019-09/optional/format/uuid.json
@@ -122,6 +122,11 @@
                 "valid": false
             },
             {
+                "description": "a UUID wrapped in curly braces is invalid",
+                "data": "{2eb8aa08-aa98-11ea-b4aa-73b441d16380}",
+                "valid": false
+            },
+            {
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false

--- a/tests/draft2020-12/optional/format/uuid.json
+++ b/tests/draft2020-12/optional/format/uuid.json
@@ -122,6 +122,11 @@
                 "valid": false
             },
             {
+                "description": "a UUID wrapped in curly braces is invalid",
+                "data": "{2eb8aa08-aa98-11ea-b4aa-73b441d16380}",
+                "valid": false
+            },
+            {
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false

--- a/tests/v1/format/uuid.json
+++ b/tests/v1/format/uuid.json
@@ -122,6 +122,11 @@
                 "valid": false
             },
             {
+                "description": "a UUID wrapped in curly braces is invalid",
+                "data": "{2eb8aa08-aa98-11ea-b4aa-73b441d16380}",
+                "valid": false
+            },
+            {
                 "description": "trailing hyphen after a complete UUID is invalid",
                 "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
                 "valid": false


### PR DESCRIPTION
Closes #1170.

`optional/format/uuid.json` rejects two of the three wrapper forms that permissive UUID parsers accept, but not the third:

| instance | before this |
| --- | --- |
| `urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380` | ✅ *URN prefixed UUID is invalid* |
| `2eb8aa08aa9811eab4aa73b441d16380` | ✅ *no dashes* |
| `{2eb8aa08-aa98-11ea-b4aa-73b441d16380}` | ❌ missing |

### Why it applies

[RFC 4122 §3](https://www.rfc-editor.org/rfc/rfc4122.html#section-3) gives the string representation as:

```
UUID                   = time-low "-" time-mid "-"
                         time-high-and-version "-"
                         clock-seq-and-reserved
                         clock-seq-low "-" node
```

There is no brace production, and the RFC does not mention braces anywhere in connection with the string form. The brace-wrapped spelling is the Microsoft registry/GUID convention, not an RFC 4122 UUID.

### Why it is worth testing

The two cases already in the file look chosen because lenient parsers accept them — and the braced form is accepted by the very same parsers. Python's standard library accepts all three:

```python
>>> import uuid
>>> uuid.UUID('{2eb8aa08-aa98-11ea-b4aa-73b441d16380}')          # accepted
>>> uuid.UUID('urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380')   # accepted
>>> uuid.UUID('2eb8aa08aa9811eab4aa73b441d16380')                # accepted
```

.NET's `Guid.Parse` accepts it too. An implementation that validates `format: "uuid"` by handing the string to one of these parsers passes the two existing cases only because they are spelled differently, while still wrongly accepting a braced UUID — so this is the variant most likely to hide a real bug.

### Scope

draft2019-09, draft2020-12 and v1 — the three drafts that have the file, whose `uuid.json` files are identical apart from the `schema` object. draft7 and earlier have no `uuid` format.

Kept to the balanced `{...}` form, in line with the file's one-case-per-variant style. Worth noting for reviewers that Python also accepts the *unbalanced* `{2eb8aa08-...` and `2eb8aa08-...}`; happy to add those two as well if you'd like them covered.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).