### PR TITLE
test(iri): reject malformed percent-encoding

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -52,6 +52,21 @@
                 "valid": true
             },
             {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://ƒøø.ßår/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://ƒøø.ßår/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://ƒøø.ßår/%",
+                "valid": false
+            },
+            {
                 "description": "a valid IRI with many special characters",
                 "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
                 "valid": true

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -52,6 +52,21 @@
                 "valid": true
             },
             {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://ƒøø.ßår/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://ƒøø.ßår/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://ƒøø.ßår/%",
+                "valid": false
+            },
+            {
                 "description": "a valid IRI with many special characters",
                 "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
                 "valid": true

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -49,6 +49,21 @@
                 "valid": true
             },
             {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://ƒøø.ßår/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://ƒøø.ßår/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://ƒøø.ßår/%",
+                "valid": false
+            },
+            {
                 "description": "a valid IRI with many special characters",
                 "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
                 "valid": true

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -52,6 +52,21 @@
                 "valid": true
             },
             {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "http://ƒøø.ßår/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "http://ƒøø.ßår/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "http://ƒøø.ßår/%",
+                "valid": false
+            },
+            {
                 "description": "a valid IRI with many special characters",
                 "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
                 "valid": true


### PR DESCRIPTION
Closes #1173.

`optional/format/iri.json` had two instances containing *valid* percent-encoded triplets but nothing checking that a malformed one is rejected. `uri.json` already covers all three shapes:

| instance | `uri.json` | `iri.json` before |
| --- | --- | --- |
| `…/%6G` — non-hex digit | ✅ invalid | ❌ untested |
| `…/%A` — incomplete triplet | ✅ invalid | ❌ untested |
| `…/%` — lone percent sign | ✅ invalid | ❌ untested |

An implementation could therefore ignore percent-encoding entirely when validating `format: "iri"` and still pass every case in the file — the two existing instances (`http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff` and `http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com`) are both valid, so nothing distinguishes a validator that parses `pct-encoded` from one that treats `%` as an ordinary character.

### Why it applies

[RFC 3987 §2.2](https://www.rfc-editor.org/rfc/rfc3987.html#section-2.2) uses `pct-encoded` directly in `ipchar` and takes it unchanged from RFC 3986:

```
ipchar      = iunreserved / pct-encoded / sub-delims / ":" / "@"
iunreserved = ALPHA / DIGIT / "-" / "." / "_" / "~" / ucschar
pct-encoded = "%" HEXDIG HEXDIG
```

RFC 3987 notes this "is identical to the percent-encoding mechanism in section 2.1 of [RFC3986]". An IRI widens the *unreserved* set with `ucschar`; it does not relax `pct-encoded`. Every shape `uri.json` rejects is malformed in an IRI for exactly the same reason.

It is also the place the IRI/URI distinction most invites a bug: an implementation that handles IRIs by letting non-ASCII through a relaxed character class can easily stop validating `%` sequences at the same time.

### Scope

draft7, draft2019-09, draft2020-12 and v1 — the four drafts with the file. The three cases mirror `uri.json`'s existing trio rather than inventing new shapes, so the two files line up, and each uses the `http://ƒøø.ßår/` stem already used elsewhere in `iri.json`.

`iri-reference.json` has the same hole and no percent-encoding case of its own. I've kept this change to `iri`; happy to follow up there separately if you'd like.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).