### PR TITLE
Remove IPvFuture tests

### DIFF
--- a/tests/draft2019-09/optional/format/iri.json
+++ b/tests/draft2019-09/optional/format/iri.json
@@ -97,11 +97,6 @@
                 "valid": false
             },
             {
-                "description": "an IPvFuture host with an uppercase version letter is valid",
-                "data": "http://[V1.fe]",
-                "valid": true
-            },
-            {
                 "description": "a valid IRI with an IPv4 host",
                 "data": "http://192.168.0.1/p",
                 "valid": true

--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -164,12 +164,6 @@
                 "comment": "RFC 3986, Appendix A: no production admits %x0A.",
                 "data": "/p\n",
                 "valid": false
-            },
-            {
-                "description": "an uppercase version character in an IPvFuture literal",
-                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
-                "data": "//[V1.fe]/p",
-                "valid": true
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/iri.json
+++ b/tests/draft2020-12/optional/format/iri.json
@@ -97,11 +97,6 @@
                 "valid": false
             },
             {
-                "description": "an IPvFuture host with an uppercase version letter is valid",
-                "data": "http://[V1.fe]",
-                "valid": true
-            },
-            {
                 "description": "a valid IRI with an IPv4 host",
                 "data": "http://192.168.0.1/p",
                 "valid": true

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -164,12 +164,6 @@
                 "comment": "RFC 3986, Appendix A: no production admits %x0A.",
                 "data": "/p\n",
                 "valid": false
-            },
-            {
-                "description": "an uppercase version character in an IPvFuture literal",
-                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
-                "data": "//[V1.fe]/p",
-                "valid": true
             }
         ]
     }

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -161,12 +161,6 @@
                 "comment": "RFC 3986, Appendix A: no production admits %x0A.",
                 "data": "/p\n",
                 "valid": false
-            },
-            {
-                "description": "an uppercase version character in an IPvFuture literal",
-                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
-                "data": "//[V1.fe]/p",
-                "valid": true
             }
         ]
     }

--- a/tests/draft7/optional/format/iri.json
+++ b/tests/draft7/optional/format/iri.json
@@ -94,11 +94,6 @@
                 "valid": false
             },
             {
-                "description": "an IPvFuture host with an uppercase version letter is valid",
-                "data": "http://[V1.fe]",
-                "valid": true
-            },
-            {
                 "description": "a valid IRI with an IPv4 host",
                 "data": "http://192.168.0.1/p",
                 "valid": true

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -161,12 +161,6 @@
                 "comment": "RFC 3986, Appendix A: no production admits %x0A.",
                 "data": "/p\n",
                 "valid": false
-            },
-            {
-                "description": "an uppercase version character in an IPvFuture literal",
-                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
-                "data": "//[V1.fe]/p",
-                "valid": true
             }
         ]
     }

--- a/tests/v1/format/iri.json
+++ b/tests/v1/format/iri.json
@@ -97,11 +97,6 @@
                 "valid": false
             },
             {
-                "description": "an IPvFuture host with an uppercase version letter is valid",
-                "data": "http://[V1.fe]",
-                "valid": true
-            },
-            {
                 "description": "a valid IRI with an IPv4 host",
                 "data": "http://192.168.0.1/p",
                 "valid": true

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -164,12 +164,6 @@
                 "comment": "RFC 3986, Appendix A: no production admits %x0A.",
                 "data": "/p\n",
                 "valid": false
-            },
-            {
-                "description": "an uppercase version character in an IPvFuture literal",
-                "comment": "RFC 3986, Section 3.2.2 gives IPvFuture = \"v\" 1*HEXDIG \".\" 1*( unreserved / sub-delims / \":\" ), and RFC 5234, Section 2.3 makes ABNF literals case-insensitive.",
-                "data": "//[V1.fe]/p",
-                "valid": true
             }
         ]
     }


### PR DESCRIPTION
The IPvFuture production in RFC 3986 is an extension mechanism: the version flag indicates a future IP-literal format that has never been defined. Because no such version exists, the spec is vague on how to validate an unknown IP-literal format, and there's no unambiguous answer for whether something like `//[V1.fe]/p` is valid or invalid.

Different URI/IRI libraries implement this gray area in conflicting ways (some accept it, some reject it), and since validators are expected to rely on whatever standard libraries they have available rather than implementing URI validation themselves, we need to allow for some variation when the spec isn't clear. Requiring a specific result here would effectively reject reasonable implementations that behave differently.

By removing these tests (including the earlier merged uri-reference case), the suite leaves this unclarified area untested, so each implementation can handle the unknown extension as it sees fit without the suite forcing one interpretation

(This explanation is AI generated, see https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/1145 for the full discussion.)