### PR TITLE
docs: document metaschema URIs for v1 and published drafts (fixes #554)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,11 @@ Comments can and should be used to explain tests which are unclear or complex.
 The `comment` field is present both for test cases and individual tests for this purpose.
 Links to the relevant specification sections are also encouraged, though they can be tedious to maintain from one version to the next.
 
-When adding test cases, they should be added to all past (and future) versions of the specification which they apply to, potentially with minor modifications (e.g. changing `$id` to `id` or accounting for `$ref` not allowing siblings on older drafts).
+When adding test cases, they should be added to all past (and future) versions of the specification which they apply to, potentially with minor modifications (e.g. changing `$id` to `id` or accounting for `$ref` not allowing siblings on older drafts). Ensure that each test schema uses the correct `$schema` metaschema URI for that version:
+- For `v1` (the unreleased version, formerly referred to as `draft-next`), schemas MUST use `"https://json-schema.org/v1"`.
+- For `draft2020-12`, schemas MUST use `"https://json-schema.org/draft/2020-12/schema"`.
+- For `draft2019-09`, schemas MUST use `"https://json-schema.org/draft/2019-09/schema"`.
+- For `draft-07` and earlier drafts, `$schema` is typically omitted unless the test specifically exercises `$schema` behavior.
 
 Changing the schema used in a particular test case should be done with extra caution, though it is not formally discouraged if the change simplifies the schema.
 Contributors should not generally append *additional* behavior to existing test case schemas, unless doing so has specific justification.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,27 @@ The precise steps described do not need to be followed exactly, but the results 
 
 To test a specific version:
 
-* For 2019-09 and later published versions, implementations that are able to detect the version of each schema via `$schema` SHOULD be configured to do so
-* For draft-07 and earlier, v1 (not yet released), and implementations unable to detect via `$schema`, implementations MUST be configured to expect the version matching the test directory name
+* For 2019-09 and later published versions, as well as `v1`, implementations that are able to detect the version of each schema via `$schema` SHOULD be configured to do so
+* For draft-07 and earlier, `v1` (if not detecting via `$schema`), and implementations unable to detect via `$schema`, implementations MUST be configured to expect the version matching the test directory name
 * Load any remote references [described below](#additional-assumptions) and configure your implementation to retrieve them via their URIs
 * Walk the filesystem tree for that version's subdirectory and for each `.json` file found:
+
+### Metaschema URIs
+
+Each specification directory in `tests/` corresponds to a specific version of JSON Schema and uses a standard metaschema URI in test `$schema` declarations (when present):
+
+| Specification Directory | Metaschema URI | Notes |
+|-------------------------|----------------|-------|
+| `v1` | `https://json-schema.org/v1` | Unreleased version (formerly referred to as `draft-next`, which used `https://json-schema.org/draft/next/schema`) |
+| `draft2020-12` | `https://json-schema.org/draft/2020-12/schema` | Published draft |
+| `draft2019-09` | `https://json-schema.org/draft/2019-09/schema` | Published draft |
+| `draft7` | `http://json-schema.org/draft-07/schema#` | Standard draft |
+| `draft6` | `http://json-schema.org/draft-06/schema#` | Standard draft |
+| `draft4` | `http://json-schema.org/draft-04/schema#` | Standard draft (frozen) |
+| `draft3` | `http://json-schema.org/draft-03/schema#` | Standard draft (frozen) |
+
+For `v1`, `draft2020-12`, and `draft2019-09`, test schemas explicitly include the `$schema` keyword referencing these URIs. For `draft7` and earlier versions, `$schema` is generally omitted from individual test schemas, so test runners should configure the validator for the target draft based on the directory name.
+
 
     * if the file is located in the root of the version directory:
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The precise steps described do not need to be followed exactly, but the results 
 To test a specific version:
 
 * For 2019-09 and later published versions, as well as `v1`, implementations that are able to detect the version of each schema via `$schema` SHOULD be configured to do so
-* For draft-07 and earlier, `v1` (if not detecting via `$schema`), and implementations unable to detect via `$schema`, implementations MUST be configured to expect the version matching the test directory name
+* For draft-07 and earlier, and for `v1` when not detecting via `$schema`, the test runner MUST be configured to expect the version matching the test directory name
 * Load any remote references [described below](#additional-assumptions) and configure your implementation to retrieve them via their URIs
 * Walk the filesystem tree for that version's subdirectory and for each `.json` file found:
 


### PR DESCRIPTION
This PR documents the canonical `$schema` metaschema URIs used across all specification versions in the test suite, specifically clarifying the URI used for `v1` (formerly referred to as `draft-next`).
- **`README.md`**:
  - Added a **Metaschema URIs** reference table detailing URIs for `v1` (`https://json-schema.org/v1`), `draft2020-12`, `draft2019-09`, `draft7`, `draft6`, `draft4`, and `draft3`.
  - Noted that `v1` represents the unreleased draft (formerly `draft-next`, which used `https://json-schema.org/draft/next/schema`).
  - Clarified version detection via `$schema` for test runner implementers.
- **`CONTRIBUTING.md`**:
  - Added explicit instructions under **Writing Good Tests** for test authors specifying which `$schema` URI to include when adding new test cases for `v1` and published drafts.
### Verification
Ran `bin/jsonschema_suite check` - all sanity checks pass cleanly without issues.