### PR TITLE
test(uri-template): reject malformed percent-encoding

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -92,6 +92,21 @@
                 "valid": true
             },
             {
+                "description": "a literal with a lone percent sign is invalid",
+                "data": "a%",
+                "valid": false
+            },
+            {
+                "description": "a literal with an incomplete percent-encoded triplet is invalid",
+                "data": "a%4",
+                "valid": false
+            },
+            {
+                "description": "a literal with non-hex percent encoding is invalid",
+                "data": "a%GG",
+                "valid": false
+            },
+            {
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
@@ -155,6 +170,21 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a variable name with a lone percent sign is invalid",
+                "data": "{%}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with an incomplete percent-encoded triplet is invalid",
+                "data": "{%4}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with non-hex percent encoding is invalid",
+                "data": "{%GG}",
+                "valid": false
             },
             {
                 "description": "a four-digit prefix max-length is valid",

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -92,6 +92,21 @@
                 "valid": true
             },
             {
+                "description": "a literal with a lone percent sign is invalid",
+                "data": "a%",
+                "valid": false
+            },
+            {
+                "description": "a literal with an incomplete percent-encoded triplet is invalid",
+                "data": "a%4",
+                "valid": false
+            },
+            {
+                "description": "a literal with non-hex percent encoding is invalid",
+                "data": "a%GG",
+                "valid": false
+            },
+            {
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
@@ -155,6 +170,21 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a variable name with a lone percent sign is invalid",
+                "data": "{%}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with an incomplete percent-encoded triplet is invalid",
+                "data": "{%4}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with non-hex percent encoding is invalid",
+                "data": "{%GG}",
+                "valid": false
             },
             {
                 "description": "a four-digit prefix max-length is valid",

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -89,6 +89,21 @@
                 "valid": true
             },
             {
+                "description": "a literal with a lone percent sign is invalid",
+                "data": "a%",
+                "valid": false
+            },
+            {
+                "description": "a literal with an incomplete percent-encoded triplet is invalid",
+                "data": "a%4",
+                "valid": false
+            },
+            {
+                "description": "a literal with non-hex percent encoding is invalid",
+                "data": "a%GG",
+                "valid": false
+            },
+            {
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
@@ -152,6 +167,21 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a variable name with a lone percent sign is invalid",
+                "data": "{%}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with an incomplete percent-encoded triplet is invalid",
+                "data": "{%4}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with non-hex percent encoding is invalid",
+                "data": "{%GG}",
+                "valid": false
             },
             {
                 "description": "a four-digit prefix max-length is valid",

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -89,6 +89,21 @@
                 "valid": true
             },
             {
+                "description": "a literal with a lone percent sign is invalid",
+                "data": "a%",
+                "valid": false
+            },
+            {
+                "description": "a literal with an incomplete percent-encoded triplet is invalid",
+                "data": "a%4",
+                "valid": false
+            },
+            {
+                "description": "a literal with non-hex percent encoding is invalid",
+                "data": "a%GG",
+                "valid": false
+            },
+            {
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
@@ -152,6 +167,21 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a variable name with a lone percent sign is invalid",
+                "data": "{%}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with an incomplete percent-encoded triplet is invalid",
+                "data": "{%4}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with non-hex percent encoding is invalid",
+                "data": "{%GG}",
+                "valid": false
             },
             {
                 "description": "a four-digit prefix max-length is valid",

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -92,6 +92,21 @@
                 "valid": true
             },
             {
+                "description": "a literal with a lone percent sign is invalid",
+                "data": "a%",
+                "valid": false
+            },
+            {
+                "description": "a literal with an incomplete percent-encoded triplet is invalid",
+                "data": "a%4",
+                "valid": false
+            },
+            {
+                "description": "a literal with non-hex percent encoding is invalid",
+                "data": "a%GG",
+                "valid": false
+            },
+            {
                 "description": "a supplementary plane character in a literal is valid",
                 "data": "a\ud83d\ude00b",
                 "valid": true
@@ -155,6 +170,21 @@
                 "description": "a variable name may start with a percent-encoded triplet",
                 "data": "{%41}",
                 "valid": true
+            },
+            {
+                "description": "a variable name with a lone percent sign is invalid",
+                "data": "{%}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with an incomplete percent-encoded triplet is invalid",
+                "data": "{%4}",
+                "valid": false
+            },
+            {
+                "description": "a variable name with non-hex percent encoding is invalid",
+                "data": "{%GG}",
+                "valid": false
             },
             {
                 "description": "a four-digit prefix max-length is valid",


### PR DESCRIPTION
## Description:

This PR adds `uri-template` format tests that reject malformed percent encodings in literals and variable names.

RFC 6570 allows percent signs in these grammar productions only as RFC 3986 percent-encoded triplets.

### Checks run, locally:

- [x] `git diff --check`
- [x] `.\.tox\sanity\Scripts\python.exe -X utf8 bin\jsonschema_suite check`