### PR TITLE
test(relative-json-pointer): require the json-pointer part to start with a slash

### DIFF
--- a/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -62,6 +62,11 @@
                 "valid": false
             },
             {
+                "description": "a json-pointer part that does not start with a slash is invalid",
+                "data": "1foo",
+                "valid": false
+            },
+            {
                 "description": "negative prefix",
                 "data": "-1/foo/bar",
                 "valid": false

--- a/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -62,6 +62,11 @@
                 "valid": false
             },
             {
+                "description": "a json-pointer part that does not start with a slash is invalid",
+                "data": "1foo",
+                "valid": false
+            },
+            {
                 "description": "negative prefix",
                 "data": "-1/foo/bar",
                 "valid": false

--- a/tests/draft7/optional/format/relative-json-pointer.json
+++ b/tests/draft7/optional/format/relative-json-pointer.json
@@ -59,6 +59,11 @@
                 "valid": false
             },
             {
+                "description": "a json-pointer part that does not start with a slash is invalid",
+                "data": "1foo",
+                "valid": false
+            },
+            {
                 "description": "negative prefix",
                 "data": "-1/foo/bar",
                 "valid": false

--- a/tests/v1/format/relative-json-pointer.json
+++ b/tests/v1/format/relative-json-pointer.json
@@ -62,6 +62,11 @@
                 "valid": false
             },
             {
+                "description": "a json-pointer part that does not start with a slash is invalid",
+                "data": "1foo",
+                "valid": false
+            },
+            {
                 "description": "negative prefix",
                 "data": "-1/foo/bar",
                 "valid": false


### PR DESCRIPTION
Closes #1180.

Nothing in `relative-json-pointer.json` exercised the boundary between the integer prefix and the json-pointer part, so `"1foo"` was accepted by the file.

### Why the existing tests leave the hole

All 19 cases fall into a bucket that misses the rule:

| bucket | cases |
| --- | --- |
| pointer part already starts with `/` | `0/foo/bar`, `2/0/baz/1/zip`, `0//`, `120/foo/bar` |
| pointer part is empty | `1`, `100` |
| uses the `#` form | `0#`, `0##`, `01#`, `1#/foo/bar` |
| fails on the **integer prefix** | `/foo/bar`, `-1/foo/bar`, `+1/foo/bar`, `١/foo`, `01/a`, `01#`, `""`, `1\n` |
| fails on **escaping inside** the pointer | `0/~2`, `0/foo/bar~` |

An implementation that parses off the leading digits and then validates the remainder *without* requiring the leading `/` — or one matching `^(0|[1-9][0-9]*)` with an unconstrained tail — passed the entire file while accepting `1foo`.

### Why it applies

The rule is stated explicitly, and identically, in both published versions of the spec.

[draft-handrews-relative-json-pointer-01](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01):

```
relative-json-pointer =  non-negative-integer <json-pointer>
relative-json-pointer =/ non-negative-integer "#"
non-negative-integer  =  %x30 / %x31-39 *( %x30-39 )
```

[draft-bhutton-relative-json-pointer-00](https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00) adds index manipulation but keeps the same tail:

```
relative-json-pointer =  non-negative-integer [index-manipulation] <json-pointer>
relative-json-pointer =/ non-negative-integer "#"
index-manipulation    =  ("+" / "-") non-negative-integer
```

Both spell out the reasoning:

> The separation between the integer prefix and the JSON Pointer will always be unambiguous, because a JSON Pointer must be either zero-length or start with a '/' (%x2F).

`foo` is neither zero-length nor slash-initial, so `1foo` is invalid under either grammar and the case carries no dependency on which version a draft cites.

Deliberately nothing involving `+` or `-` *after* the integer, since `0+1/foo` is invalid under handrews-01 but valid under bhutton-00. The file's existing `+1/foo/bar` is a *leading* sign, invalid under both, so it is unaffected.

### Scope

draft7, draft2019-09, draft2020-12 and v1 — the four drafts with the file, whose copies are identical apart from the `schema` object.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).