### PR TITLE
test(uri-template): accept private-use characters in literals

### DIFF
--- a/tests/draft2019-09/optional/format/uri-template.json
+++ b/tests/draft2019-09/optional/format/uri-template.json
@@ -112,6 +112,11 @@
                 "valid": true
             },
             {
+                "description": "a private-use character in a literal is valid",
+                "data": "a\ue000b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true

--- a/tests/draft2020-12/optional/format/uri-template.json
+++ b/tests/draft2020-12/optional/format/uri-template.json
@@ -112,6 +112,11 @@
                 "valid": true
             },
             {
+                "description": "a private-use character in a literal is valid",
+                "data": "a\ue000b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true

--- a/tests/draft6/optional/format/uri-template.json
+++ b/tests/draft6/optional/format/uri-template.json
@@ -109,6 +109,11 @@
                 "valid": true
             },
             {
+                "description": "a private-use character in a literal is valid",
+                "data": "a\ue000b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true

--- a/tests/draft7/optional/format/uri-template.json
+++ b/tests/draft7/optional/format/uri-template.json
@@ -109,6 +109,11 @@
                 "valid": true
             },
             {
+                "description": "a private-use character in a literal is valid",
+                "data": "a\ue000b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true

--- a/tests/v1/format/uri-template.json
+++ b/tests/v1/format/uri-template.json
@@ -112,6 +112,11 @@
                 "valid": true
             },
             {
+                "description": "a private-use character in a literal is valid",
+                "data": "a\ue000b",
+                "valid": true
+            },
+            {
                 "description": "reserved expansion operator",
                 "data": "{+var}",
                 "valid": true


### PR DESCRIPTION
## Description:

This PR adds `uri-template` format tests accepting private use characters in literals.

RFC 6570 Section 2.1 permits `iprivate` code points in URI template literals.

### Checks run, locally:

- [x] `git diff --check`
- [x] `.\.tox\sanity\Scripts\python.exe -X utf8 bin\jsonschema_suite check`