### PR TITLE
test(multipleOf): move the bignum dependent case to optional/bignum.json

### DIFF
--- a/tests/draft2019-09/multipleOf.json
+++ b/tests/draft2019-09/multipleOf.json
@@ -84,19 +84,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "type": "integer", "multipleOf": 1e-8
-        },
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/draft2019-09/optional/bignum.json
+++ b/tests/draft2019-09/optional/bignum.json
@@ -106,5 +106,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer",
+            "multipleOf": 1e-8
+        },
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft2020-12/multipleOf.json
+++ b/tests/draft2020-12/multipleOf.json
@@ -84,19 +84,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "integer", "multipleOf": 1e-8
-        },
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/draft2020-12/optional/bignum.json
+++ b/tests/draft2020-12/optional/bignum.json
@@ -106,5 +106,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer",
+            "multipleOf": 1e-8
+        },
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft4/multipleOf.json
+++ b/tests/draft4/multipleOf.json
@@ -72,16 +72,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {"type": "integer", "multipleOf": 1e-8},
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/draft4/optional/bignum.json
+++ b/tests/draft4/optional/bignum.json
@@ -91,5 +91,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {"type": "integer", "multipleOf": 1e-8},
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft6/multipleOf.json
+++ b/tests/draft6/multipleOf.json
@@ -72,16 +72,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {"type": "integer", "multipleOf": 1e-8},
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/draft6/optional/bignum.json
+++ b/tests/draft6/optional/bignum.json
@@ -89,5 +89,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {"type": "integer", "multipleOf": 1e-8},
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/draft7/multipleOf.json
+++ b/tests/draft7/multipleOf.json
@@ -72,16 +72,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {"type": "integer", "multipleOf": 1e-8},
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/draft7/optional/bignum.json
+++ b/tests/draft7/optional/bignum.json
@@ -89,5 +89,16 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {"type": "integer", "multipleOf": 1e-8},
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]

--- a/tests/v1/multipleOf.json
+++ b/tests/v1/multipleOf.json
@@ -85,19 +85,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "small multiple of large integer",
-        "schema": {
-            "$schema": "https://json-schema.org/v1",
-            "type": "integer", "multipleOf": 1e-8
-        },
-        "tests": [
-            {
-                "description": "any integer is a multiple of 1e-8",
-                "data": 12391239123,
-                "valid": true
-            }
-        ]
     }
 ]

--- a/tests/v1/optional/bignum.json
+++ b/tests/v1/optional/bignum.json
@@ -106,5 +106,20 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with high precision on large integers",
+        "schema": {
+            "$schema": "https://json-schema.org/v1",
+            "type": "integer",
+            "multipleOf": 1e-8
+        },
+        "tests": [
+            {
+                "description": "any integer is a multiple of 1e-8",
+                "data": 12391239123,
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## Why

The "small multiple of large integer" case in multipleOf.json (schema `{"type": "integer", "multipleOf": 1e-8}`, instance `12391239123`) requires arbitrary precision arithmetic to evaluate correctly. An implementation using IEEE doubles for the division check can get a result that is not a clean integer multiple purely from the imprecise binary representation of 1e-8, even though the value is mathematically a valid multiple. This is the same "arbitrary precision is optional" situation already established for the other bignum tests in optional/bignum.json, but this particular case was left in the required suite.

This was raised in #536 and a first attempt to fix it (#538) got stuck because it also tried to merge in unrelated integer-overflow tests into the same case, which mixes two different implementation capabilities (bignum integer support vs arbitrary precision float support) that an implementation can have independently. This PR only moves the existing, unmodified multipleOf case, with no scope beyond that.

## What changed

Removed the "small multiple of large integer" test case from multipleOf.json and added the equivalent case to optional/bignum.json, in each of draft4, draft6, draft7, draft2019-09, draft2020-12, and v1. The schema and test data are unchanged, only the file and location moved, matching each draft's existing formatting conventions.

## Verification

python3 bin/jsonschema_suite check passes. All twelve edited files parse as valid JSON.
