### PR TITLE
Reject malformed percent-encoding in uri-reference and iri-reference

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -95,6 +95,21 @@
                 "description": "a trailing newline after a valid IRI Reference is invalid",
                 "data": "/âππ\n",
                 "valid": false
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/%",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2019-09/optional/format/uri-reference.json
+++ b/tests/draft2019-09/optional/format/uri-reference.json
@@ -118,6 +118,18 @@
                 "valid": false
             },
             {
+                "description": "incomplete percent-encoding triplet",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%",
+                "valid": false
+            },
+            {
                 "description": "a double quote in a path",
                 "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
                 "data": "/a\"b",

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -95,6 +95,21 @@
                 "description": "a trailing newline after a valid IRI Reference is invalid",
                 "data": "/âππ\n",
                 "valid": false
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/%",
+                "valid": false
             }
         ]
     }

--- a/tests/draft2020-12/optional/format/uri-reference.json
+++ b/tests/draft2020-12/optional/format/uri-reference.json
@@ -118,6 +118,18 @@
                 "valid": false
             },
             {
+                "description": "incomplete percent-encoding triplet",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%",
+                "valid": false
+            },
+            {
                 "description": "a double quote in a path",
                 "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
                 "data": "/a\"b",

--- a/tests/draft6/optional/format/uri-reference.json
+++ b/tests/draft6/optional/format/uri-reference.json
@@ -115,6 +115,18 @@
                 "valid": false
             },
             {
+                "description": "incomplete percent-encoding triplet",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%",
+                "valid": false
+            },
+            {
                 "description": "a double quote in a path",
                 "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
                 "data": "/a\"b",

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -92,6 +92,21 @@
                 "description": "a trailing newline after a valid IRI Reference is invalid",
                 "data": "/âππ\n",
                 "valid": false
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/%",
+                "valid": false
             }
         ]
     }

--- a/tests/draft7/optional/format/uri-reference.json
+++ b/tests/draft7/optional/format/uri-reference.json
@@ -115,6 +115,18 @@
                 "valid": false
             },
             {
+                "description": "incomplete percent-encoding triplet",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%",
+                "valid": false
+            },
+            {
                 "description": "a double quote in a path",
                 "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
                 "data": "/a\"b",

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -95,6 +95,21 @@
                 "description": "a trailing newline after a valid IRI Reference is invalid",
                 "data": "/âππ\n",
                 "valid": false
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/%",
+                "valid": false
             }
         ]
     }

--- a/tests/v1/format/uri-reference.json
+++ b/tests/v1/format/uri-reference.json
@@ -118,6 +118,18 @@
                 "valid": false
             },
             {
+                "description": "incomplete percent-encoding triplet",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%",
+                "valid": false
+            },
+            {
                 "description": "a double quote in a path",
                 "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
                 "data": "/a\"b",


### PR DESCRIPTION
`uri.json` and `iri.json` both cover the three malformed percent-encoding shapes (non-hex digit, incomplete triplet, lone percent), but their reference-form siblings do not:

- `uri-reference.json` only has the non-hex-digit shape, under a different description ("an incomplete percent-encoding").
- `iri-reference.json` has none of the three shapes at all.

So an implementation could ignore percent-encoding entirely in a relative reference and still pass every case in these files.

RFC 3986 Section 2.1 defines `pct-encoded` the same way regardless of whether the URI is absolute or a reference, and RFC 3987 Section 2.2 carries that production into IRIs unchanged, so the same three shapes apply here too. This mirrors the trio already merged into `uri.json` and `iri.json` (#1174, #1179), completing the same sweep for their reference-form counterparts across every applicable draft: `uri-reference.json` (draft6, draft7, draft2019-09, draft2020-12, v1) and `iri-reference.json` (draft2019-09, draft2020-12, draft7, v1).

Verified all 9 edited files parse as valid JSON and pass `bin/jsonschema_suite check` with no new failures beyond the 7 pre-existing ones already present on `main`.