### PR TITLE
test(iri-reference): exercise percent-encoding

### DIFF
--- a/tests/draft2019-09/optional/format/iri-reference.json
+++ b/tests/draft2019-09/optional/format/iri-reference.json
@@ -52,6 +52,26 @@
                 "valid": true
             },
             {
+                "description": "a relative IRI Reference with a percent-encoded triplet",
+                "data": "/âππ/%20",
+                "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/âππ/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/âππ/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/âππ/%",
+                "valid": false
+            },
+            {
                 "description": "an invalid IRI Reference",
                 "data": "\\\\WINDOWS\\filëßåré",
                 "valid": false

--- a/tests/draft2020-12/optional/format/iri-reference.json
+++ b/tests/draft2020-12/optional/format/iri-reference.json
@@ -52,6 +52,26 @@
                 "valid": true
             },
             {
+                "description": "a relative IRI Reference with a percent-encoded triplet",
+                "data": "/âππ/%20",
+                "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/âππ/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/âππ/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/âππ/%",
+                "valid": false
+            },
+            {
                 "description": "an invalid IRI Reference",
                 "data": "\\\\WINDOWS\\filëßåré",
                 "valid": false

--- a/tests/draft7/optional/format/iri-reference.json
+++ b/tests/draft7/optional/format/iri-reference.json
@@ -49,6 +49,26 @@
                 "valid": true
             },
             {
+                "description": "a relative IRI Reference with a percent-encoded triplet",
+                "data": "/âππ/%20",
+                "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/âππ/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/âππ/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/âππ/%",
+                "valid": false
+            },
+            {
                 "description": "an invalid IRI Reference",
                 "data": "\\\\WINDOWS\\filëßåré",
                 "valid": false

--- a/tests/v1/format/iri-reference.json
+++ b/tests/v1/format/iri-reference.json
@@ -52,6 +52,26 @@
                 "valid": true
             },
             {
+                "description": "a relative IRI Reference with a percent-encoded triplet",
+                "data": "/âππ/%20",
+                "valid": true
+            },
+            {
+                "description": "invalid percent-encoding with non-hex digits",
+                "data": "/âππ/%6G",
+                "valid": false
+            },
+            {
+                "description": "incomplete percent-encoding triplet",
+                "data": "/âππ/%A",
+                "valid": false
+            },
+            {
+                "description": "lone percent sign is invalid",
+                "data": "/âππ/%",
+                "valid": false
+            },
+            {
                 "description": "an invalid IRI Reference",
                 "data": "\\\\WINDOWS\\filëßåré",
                 "valid": false


### PR DESCRIPTION
Closes #1185.

`iri-reference.json` contained no instance with a `%` in it at all — no valid percent-encoded triplet and no malformed one — so an implementation could treat `%` as an ordinary literal character and still pass every case in the file.

It was the last of the four URI/IRI formats with the hole, after #1174 and #1179:

| format | valid pct case | malformed pct case |
| --- | --- | --- |
| `uri` | ✅ | ✅ ×3 |
| `iri` | ✅ | ✅ ×3 (#1174) |
| `uri-template` | ✅ | ✅ (#1179) |
| `uri-reference` | – | ✅ `/%zz` |
| **`iri-reference`** (before this) | ❌ | ❌ |

### Why it applies

[RFC 3987 §2.2](https://www.rfc-editor.org/rfc/rfc3987.html#section-2.2):

```
IRI-reference  = IRI / irelative-ref
irelative-ref  = irelative-part [ "?" iquery ] [ "#" ifragment ]
irelative-part = "//" iauthority ipath-abempty
              / ipath-absolute
              / ipath-noscheme
              / ipath-empty
isegment       = *ipchar
isegment-nz-nc = 1*( iunreserved / pct-encoded / sub-delims / "@" )
ipchar         = iunreserved / pct-encoded / sub-delims / ":" / "@"
pct-encoded    = "%" HEXDIG HEXDIG
```

An IRI-reference is either an IRI or a relative reference, and every path, query and fragment production in both bottoms out at `ipchar`, which includes `pct-encoded`; `isegment-nz-nc` references it directly. Each malformed form is malformed here for the same reason it is in `iri`.

### The change

| instance | expected |
| --- | --- |
| `/âππ/%20` | valid |
| `/âππ/%6G` | invalid — non-hex digit |
| `/âππ/%A` | invalid — incomplete triplet |
| `/âππ/%` | invalid — lone percent sign |

The three invalid descriptions match `iri.json`'s verbatim so the two files line up and diff cleanly. The valid instance is added alongside because the file had no positive percent case either, and CONTRIBUTING asks that "test cases should include both valid and invalid instances which exercise the test case schema whenever possible". All four reuse the `/âππ` stem already used elsewhere in the file.

### Scope

draft7, draft2019-09, draft2020-12 and v1 — the four drafts with the file, whose copies are identical apart from the `schema` object.

### Verification

`bin/jsonschema_suite check` passes 11/11 with no skips (`jsonschema==4.19.0`).