### PR TITLE
Adding @jetio/validator to the list of javascript validators that uses the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ This suite is being used by:
 * [tv4](https://github.com/geraintluff/tv4)
 * [z-schema](https://github.com/zaggino/z-schema)
 * [jsen](https://github.com/bugventure/jsen)
+* [@jetio/validator](https://github.com/official-jetio/validator)
 * [ajv](https://github.com/epoberezkin/ajv)
 * [djv](https://github.com/korzio/djv)
 * [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Kotlin, and Scala)


### PR DESCRIPTION
@jetio/validator uses the JSON Schema Test Suite. It achieves over 99% compliance on draft 6, draft 7, and draft 2020-12, and 98% on draft 2019-09.

This can be verified by cloning the [validator repo](https://github.com/official-jetio/validator) and running:
```bash
npm run test:2020-12
```
```bash
npm run test:2019-09
```
```bash
npm run test:7
```
```bash
npm run test:6
```

The README also documents the compliance rates.