### PR TITLE
List Sury under JavaScript implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ This suite is being used by:
 * [djv](https://github.com/korzio/djv)
 * [M3](https://github.com/JulesGosnell/m3) (all drafts, pure Clojure — also usable from Java, Kotlin, and Scala)
 * [TypeBox](https://github.com/sinclairzx81/typebox)
+* [Sury](https://github.com/DZakh/sury)
 
 ### Kotlin
 


### PR DESCRIPTION
Adds [Sury](https://github.com/DZakh/sury) to Who Uses, under JavaScript, below TypeBox.

Sury consumes this suite in CI through `S.fromJSONSchemaOrThrow` + `S.parseOrThrow`. Current required-test scores: 93.4% draft-07, 75.0% draft-2020-12. Runner: https://github.com/DZakh/sury/tree/main/packages/json-schema-test-suite.

Thank you for the test suite. It pushes the ecosystem further in terms of quality 🙏