### PR TITLE
Fix annotate-specification-links crash, CI trigger path, and UTF-8 file loading

### DIFF
--- a/.github/workflows/show_specification_annotations.yml
+++ b/.github/workflows/show_specification_annotations.yml
@@ -3,7 +3,7 @@ name: Show Specification Annotations
 on:
   pull_request:
     paths:
-      - 'tests/**'
+      - 'validation/tests/**'
 
 jobs:
   annotate:

--- a/validation/annotate-specification-links
+++ b/validation/annotate-specification-links
@@ -18,7 +18,9 @@ from uritemplate import URITemplate
 BASE_DIR = Path(__file__).parent
 VALIDATION_DIR = BASE_DIR.parent / "validation"
 TESTS = VALIDATION_DIR / "tests"
-URLS = json.loads(BASE_DIR.joinpath("specification_urls.json").read_text())
+URLS = json.loads(
+    BASE_DIR.joinpath("specification_urls.json").read_text(encoding="utf-8"),
+)
 
 sys.path.insert(0, str(VALIDATION_DIR))
 import check_validation_suite as checker  # type: ignore  # noqa: E402
@@ -62,7 +64,7 @@ def annotation(
     else:
         additional = ""
 
-    relative = path.relative_to(VALIDATION_DIR.parent)
+    relative = path.relative_to(VALIDATION_DIR.parent).as_posix()
     return f"::{level} file={relative},line={line}{additional}::{message}\n"
 
 
@@ -70,7 +72,7 @@ def line_number_of(path: Path, case: dict[str, Any]) -> int:
     """
     Crudely find the line number of a test case.
     """
-    with path.open() as file:
+    with path.open(encoding="utf-8") as file:
         description = case["description"]
         return next(
             (i + 1 for i, line in enumerate(file, 1) if description in line),
@@ -96,7 +98,7 @@ def applicable_dialects(compatibility: str) -> list[str]:
     return [
         dialect
         for dialect in checker.DIALECT_ORDER
-        if checker.dialect_applies(compatibility, dialect)
+        if checker.dialect_applies(compatibility, int(dialect))
     ]
 
 
@@ -106,7 +108,7 @@ def main():
 
     for path in sorted(TESTS.rglob("*.json")):
         try:
-            contents = json.loads(path.read_text())
+            contents = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as error:
             error = annotation(
                 level="error",
@@ -129,16 +131,20 @@ def main():
             dialects = applicable_dialects(test_case.get("compatibility", ""))
 
             for each in specifications:
+                each = dict(each)
                 quote = each.pop("quote", "")
                 (key, section), = each.items()
 
                 (kind, spec) = extract_kind_and_spec(key)
 
-                templates = [
-                    template
-                    for dialect in dialects
-                    if (template := urls(dialect).get(kind)) is not None
-                ]
+                if kind in URLS["external"]:
+                    templates = [URITemplate(URLS["external"][kind])]
+                else:
+                    templates = [
+                        template
+                        for dialect in dialects
+                        if (template := urls(dialect).get(kind)) is not None
+                    ]
 
                 if not templates:
                     error = annotation(

--- a/validation/check_validation_suite.py
+++ b/validation/check_validation_suite.py
@@ -86,7 +86,7 @@ def collect(directory: Path, filename_filter: str | None = None):
 
 
 def load(path: Path):
-    return json.loads(path.read_text())
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def load_cases(path: Path) -> list:


### PR DESCRIPTION
Resolves #1190

### Summary of Changes

This PR addresses three related tooling, cross-platform, and CI issues identified on the `unify` branch:

1. **Fix `TypeError` and external template lookups in `validation/annotate-specification-links`:**
   - Cast `dialect` to `int(dialect)` in `applicable_dialects` so `checker.dialect_applies` compares numeric versions against integers rather than strings.
   - Resolve external templates (`rfc`, `iso`, `ecma262`, `perl5`) directly from `URLS["external"]`, which avoids false-positive missing template errors on future dialect placeholders (`"compatibility": "9999"`).
   - Prevent in-place mutation of specification dictionaries (`each = dict(each)`).
   - Use `.as_posix()` for emitted annotation file paths to guarantee forward slashes across all operating systems.

2. **Fix disconnected CI path filter in `.github/workflows/show_specification_annotations.yml`:**
   - Update `paths` from `'tests/**'` to `'validation/tests/**'` so pull requests modifying the unified test suite properly trigger specification link checks.

3. **Cross-platform UTF-8 file loading:**
   - Add explicit `encoding="utf-8"` to `path.read_text()` and `path.open()` in `check_validation_suite.py` and `annotate-specification-links` to prevent `UnicodeDecodeError` on Windows environments defaulting to `cp1252`.

---

### Verification

- `python validation/annotate-specification-links` runs end-to-end and exits cleanly with code 0, emitting all notices with POSIX paths.
- `python validation/check_validation_suite.py` passes all 11 test suites across all 114 test files on Windows and POSIX systems.
- `python -m py_compile validation/annotate-specification-links validation/check_validation_suite.py` confirms no syntax errors.